### PR TITLE
Configure kind cluster for Scion runtime testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Two implementer agents (Claude + Codex) draft the same prompt in isolated worktr
 ```bash
 task install      # bootstrap host: scion CLI, runtime checks, PATH
 task init         # scion init --machine + scion init for this grove
+task kind:up      # create/reuse local kind cluster for Scion K8s runtime tests
 task hub:up       # start local Scion Hub on :8090
 eval "$(task hub:auth-export)"
 task hub:link     # link grove, register auth files/configs, sync templates
@@ -28,12 +29,18 @@ the Claude, Codex, and Gemini harness configs.
 Set `FINAL_REVIEWER=codex` when starting a round if you want to skip Gemini for
 that run.
 
+For local Kubernetes runtime testing, use `task kind:up`, then
+`task kind:configure-scion` and `task kind:doctor`. See
+`docs/kind-scion-runtime.md`.
+
 ## Layout
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
+- `deploy/kind/` — native Kubernetes resources for the local kind runtime
 - `orchestrator/round.sh` — thin launcher for the consensus runner
 - `mcp_servers/scion_ops.py` — stdio MCP server for Zed external agents
 - `rubric/` — reviewer prompt + verdict JSON schema
+- `scripts/kind-scion-runtime.sh` — local kind orchestration helper
 - `scripts/bootstrap-host.sh` — one-shot host preflight
 
 ## Zed MCP

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,12 @@ vars:
   # workstation-mode web port if you pass --web-port=8090 below.
   HUB_ENDPOINT: http://127.0.0.1:8090
   HUB_WEB_PORT: 8090
+  KIND_CLUSTER_NAME:
+    sh: printf '%s' "${KIND_CLUSTER_NAME:-scion-ops}"
+  KIND_CONTEXT:
+    sh: printf 'kind-%s' "${KIND_CLUSTER_NAME:-scion-ops}"
+  SCION_K8S_NAMESPACE:
+    sh: printf '%s' "${SCION_K8S_NAMESPACE:-scion-agents}"
   HOME:
     sh: echo "$HOME"
   GOPATH:
@@ -30,6 +36,46 @@ tasks:
     cmds:
       - '{{.SCION_BIN}} init --machine'
       - '{{.SCION_BIN}} init'
+
+  images:build:
+    desc: 'Build Scion container images with podman. Usage: task images:build -- [scripts/build-images.sh options]'
+    cmds:
+      - bash scripts/build-images.sh {{.CLI_ARGS}}
+
+  kind:up:
+    desc: Create/reuse the local kind cluster and apply deploy/kind resources.
+    cmds:
+      - bash scripts/kind-scion-runtime.sh up
+
+  kind:down:
+    desc: Delete the local kind cluster.
+    cmds:
+      - bash scripts/kind-scion-runtime.sh down
+
+  kind:status:
+    desc: Show kind cluster, deployed runtime resources, and node status.
+    cmds:
+      - bash scripts/kind-scion-runtime.sh status
+
+  kind:load-images:
+    desc: 'Load local images into kind. Usage: task kind:load-images -- localhost/scion-claude:latest'
+    cmds:
+      - bash scripts/kind-scion-runtime.sh load-images {{.CLI_ARGS}}
+
+  kind:load-archive:
+    desc: 'Load image archives into kind. Usage: task kind:load-archive -- /tmp/scion-claude.tar'
+    cmds:
+      - bash scripts/kind-scion-runtime.sh load-archive {{.CLI_ARGS}}
+
+  kind:configure-scion:
+    desc: Configure global Scion profile "kind" for the local kind cluster.
+    cmds:
+      - bash scripts/kind-scion-runtime.sh configure-scion
+
+  kind:doctor:
+    desc: Run Scion diagnostics against the local kind runtime profile.
+    cmds:
+      - '{{.SCION_BIN}} doctor --profile kind'
 
   hub:up:
     desc: Start local Scion Hub (workstation mode). Run hub:link after exporting SCION_DEV_TOKEN.

--- a/deploy/kind/kustomization.yaml
+++ b/deploy/kind/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: scion-agents
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/deploy/kind/namespace.yaml
+++ b/deploy/kind/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scion-agents

--- a/deploy/kind/rbac.yaml
+++ b/deploy/kind/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scion-agent-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scion-agent-manager
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scion-agent-manager
+subjects:
+  - kind: ServiceAccount
+    name: scion-agent-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scion-agent-manager

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -1,0 +1,134 @@
+# Local kind Runtime
+
+This project uses `kind` as the local Kubernetes target for Scion runtime
+testing. This is the substrate for later Hub/Broker work: issue #1 only creates
+the cluster, namespace, RBAC, and image-loading path.
+
+## Responsibility Split
+
+Scion does not bootstrap the local Kubernetes substrate for us. Once configured
+with a Kubernetes runtime, Scion creates and manages agent runtime objects such
+as pods and secrets in the configured namespace. This project is responsible for
+the local setup around that runtime: the kind cluster, namespace, and minimum
+RBAC needed by Scion.
+
+Those Kubernetes resources live in `deploy/kind` and are directly deployable:
+
+```bash
+kubectl --context kind-scion-ops apply -k deploy/kind
+```
+
+`task kind:up` creates or reuses the kind cluster, then applies that
+kustomization. The helper script should not contain embedded Kubernetes YAML.
+
+## Defaults
+
+| Setting | Value |
+|---|---|
+| kind cluster | `scion-ops` |
+| kubectl context | `kind-scion-ops` |
+| agent namespace | `scion-agents` |
+| RBAC service account | `scion-agent-manager` |
+| Scion profile | `kind` |
+
+Override the cluster name with an environment variable:
+
+```bash
+KIND_CLUSTER_NAME=scion-dev task kind:up
+```
+
+For a different namespace or service account, create a kustomize overlay and
+run with matching `SCION_K8S_MANIFEST_DIR`, `SCION_K8S_NAMESPACE`, and
+`SCION_K8S_SERVICE_ACCOUNT` values.
+
+## Create the Cluster
+
+Prerequisites:
+
+- `kind`
+- `kubectl`
+- `yq` for `task kind:configure-scion`
+
+```bash
+task kind:up
+```
+
+The task is idempotent. It creates the cluster if missing, reuses it if present,
+applies the `deploy/kind` Kubernetes resources, and sets the kind context
+namespace.
+
+Check the result:
+
+```bash
+task kind:status
+kubectl --context kind-scion-ops get pods -n scion-agents
+```
+
+## Configure Scion Diagnostics
+
+Configure a global Scion profile named `kind`. This step uses `yq` because the
+current `scion config set` command does not support nested runtime/profile
+keys:
+
+```bash
+task kind:configure-scion
+```
+
+This writes:
+
+```yaml
+runtimes:
+  kind:
+    type: kubernetes
+    context: kind-scion-ops
+    namespace: scion-agents
+profiles:
+  kind:
+    runtime: kind
+```
+
+Run Scion's Kubernetes diagnostics:
+
+```bash
+task kind:doctor
+```
+
+This validates cluster connectivity, namespace access, pod permissions,
+`pods/exec`, pod logs, and secret permissions.
+
+## Load Agent Images
+
+Build the Scion images locally:
+
+```bash
+task images:build
+```
+
+Load the images into kind:
+
+```bash
+task kind:load-images -- \
+  localhost/scion-base:latest \
+  localhost/scion-claude:latest \
+  localhost/scion-codex:latest \
+  localhost/scion-gemini:latest
+```
+
+If the images were built with Podman but your kind provider cannot see them as
+Docker images, export archives and load those instead:
+
+```bash
+podman save localhost/scion-claude:latest -o /tmp/scion-claude.tar
+task kind:load-archive -- /tmp/scion-claude.tar
+```
+
+For repeated local development, a local registry can replace `kind load`, but
+that should be introduced with the broker/runtime issue if we need it.
+
+## Cleanup
+
+```bash
+task kind:down
+```
+
+This deletes the kind cluster named by `KIND_CLUSTER_NAME`.

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -55,8 +55,12 @@ require "tmux"        command -v tmux
 require "git"         command -v git
 require "claude CLI"  command -v claude
 require "codex CLI"   command -v codex
+# shellcheck disable=SC2016 # Intentionally expand $HOME in the bash -lc child.
 require "gemini CLI"  bash -lc 'command -v gemini >/dev/null 2>&1 || test -x "$HOME/.npm-global/bin/gemini"'
 require "task"        command -v task
+require "kind"        command -v kind
+require "kubectl"     command -v kubectl
+require "yq"          command -v yq
 
 # GOPATH/bin must be on PATH so `scion` is findable after install
 gobin="$(go env GOPATH 2>/dev/null)/bin"

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Manage the local kind cluster used for Scion Kubernetes runtime testing.
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-scion-ops}"
+NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
+SERVICE_ACCOUNT="${SCION_K8S_SERVICE_ACCOUNT:-scion-agent-manager}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST_DIR="${SCION_K8S_MANIFEST_DIR:-${REPO_ROOT}/deploy/kind}"
+CONTEXT="kind-${CLUSTER_NAME}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command> [args]
+
+Commands:
+  up                  Create/reuse the kind cluster and apply deploy/kind.
+  down                Delete the kind cluster.
+  status              Show cluster, namespace, RBAC, and node status.
+  load-images IMAGE   Load one or more local images into the kind nodes.
+  load-archive FILE   Load one or more image archives into the kind nodes.
+  configure-scion     Configure global Scion profile "kind" for this cluster.
+
+Environment:
+  KIND_CLUSTER_NAME          Cluster name (default: scion-ops)
+  SCION_K8S_MANIFEST_DIR     Kustomize manifest directory (default: deploy/kind)
+  SCION_K8S_NAMESPACE        Agent namespace (default: scion-agents)
+  SCION_K8S_SERVICE_ACCOUNT  Runtime service account (default: scion-agent-manager)
+EOF
+}
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '\033[36m==> %s\033[0m\n' "$*"
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required on PATH"
+}
+
+cluster_exists() {
+  kind get clusters 2>/dev/null | grep -Fxq "$CLUSTER_NAME"
+}
+
+kubectl_ctx() {
+  kubectl --context "$CONTEXT" "$@"
+}
+
+ensure_cluster() {
+  require kind
+  if cluster_exists; then
+    log "reuse kind cluster $CLUSTER_NAME"
+    return
+  fi
+
+  log "create kind cluster $CLUSTER_NAME"
+  kind create cluster --name "$CLUSTER_NAME"
+}
+
+apply_manifests() {
+  require kubectl
+  [[ -d "$MANIFEST_DIR" ]] || die "manifest directory not found: $MANIFEST_DIR"
+  log "apply Kubernetes resources from $MANIFEST_DIR"
+  kubectl_ctx apply -k "$MANIFEST_DIR"
+  if ! kubectl_ctx get namespace "$NAMESPACE" >/dev/null 2>&1; then
+    die "namespace $NAMESPACE was not created by $MANIFEST_DIR; set SCION_K8S_NAMESPACE to match the applied manifests"
+  fi
+  # Make ad-hoc kubectl commands predictable after setup.
+  kubectl config set-context "$CONTEXT" --namespace "$NAMESPACE" >/dev/null
+}
+
+cmd_up() {
+  ensure_cluster
+  apply_manifests
+
+  cat <<EOF
+
+kind cluster ready
+  cluster:   ${CLUSTER_NAME}
+  context:   ${CONTEXT}
+  namespace: ${NAMESPACE}
+  manifests: ${MANIFEST_DIR}
+
+Next:
+  task kind:configure-scion
+  task kind:doctor
+EOF
+}
+
+cmd_down() {
+  require kind
+  if cluster_exists; then
+    log "delete kind cluster $CLUSTER_NAME"
+    kind delete cluster --name "$CLUSTER_NAME"
+  else
+    log "cluster $CLUSTER_NAME does not exist"
+  fi
+}
+
+cmd_status() {
+  require kind
+  require kubectl
+
+  printf 'cluster:   %s\n' "$CLUSTER_NAME"
+  printf 'context:   %s\n' "$CONTEXT"
+  printf 'namespace: %s\n\n' "$NAMESPACE"
+
+  if ! cluster_exists; then
+    die "kind cluster $CLUSTER_NAME does not exist"
+  fi
+
+  kubectl_ctx get nodes -o wide
+  printf '\n'
+  kubectl_ctx get namespace "$NAMESPACE"
+  printf '\n'
+  kubectl_ctx get serviceaccount,role,rolebinding -n "$NAMESPACE" | grep -E "NAME|${SERVICE_ACCOUNT}|scion-agent-manager"
+}
+
+cmd_load_images() {
+  require kind
+  [[ "$#" -gt 0 ]] || die "provide at least one image tag, e.g. localhost/scion-claude:latest"
+  cluster_exists || die "kind cluster $CLUSTER_NAME does not exist; run: task kind:up"
+
+  for image in "$@"; do
+    log "load image $image into $CLUSTER_NAME"
+    kind load docker-image --name "$CLUSTER_NAME" "$image"
+  done
+}
+
+cmd_load_archive() {
+  require kind
+  [[ "$#" -gt 0 ]] || die "provide at least one image archive"
+  cluster_exists || die "kind cluster $CLUSTER_NAME does not exist; run: task kind:up"
+
+  for archive in "$@"; do
+    [[ -f "$archive" ]] || die "image archive not found: $archive"
+    log "load image archive $archive into $CLUSTER_NAME"
+    kind load image-archive --name "$CLUSTER_NAME" "$archive"
+  done
+}
+
+cmd_configure_scion() {
+  require yq
+
+  local settings_file="${SCION_SETTINGS_FILE:-${HOME}/.scion/settings.yaml}"
+  local settings_dir
+  settings_dir="$(dirname "$settings_file")"
+  mkdir -p "$settings_dir"
+  if [[ ! -f "$settings_file" ]]; then
+    printf 'schema_version: "1"\n' > "$settings_file"
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  KIND_CONTEXT="$CONTEXT" SCION_K8S_NAMESPACE="$NAMESPACE" yq eval '
+    .schema_version = (.schema_version // "1") |
+    .runtimes.kind.type = "kubernetes" |
+    .runtimes.kind.context = strenv(KIND_CONTEXT) |
+    .runtimes.kind.namespace = strenv(SCION_K8S_NAMESPACE) |
+    .profiles.kind.runtime = "kind"
+  ' "$settings_file" > "$tmp"
+  mv "$tmp" "$settings_file"
+
+  cat <<EOF
+Configured Scion profile:
+  file:      ${settings_file}
+  profile:   kind
+  context:   ${CONTEXT}
+  namespace: ${NAMESPACE}
+EOF
+}
+
+case "${1:-}" in
+  up)
+    shift
+    cmd_up "$@"
+    ;;
+  down)
+    shift
+    cmd_down "$@"
+    ;;
+  status)
+    shift
+    cmd_status "$@"
+    ;;
+  load-images)
+    shift
+    cmd_load_images "$@"
+    ;;
+  load-archive)
+    shift
+    cmd_load_archive "$@"
+    ;;
+  configure-scion)
+    shift
+    cmd_configure_scion "$@"
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    die "unknown command: $1"
+    ;;
+esac


### PR DESCRIPTION
Closes #1

## Summary
- add kind lifecycle tasks for create/reuse, status, cleanup, and image loading
- move the Kubernetes namespace/RBAC resources into native deployable manifests under `deploy/kind`
- have the helper apply those resources with `kubectl apply -k` instead of embedding Kubernetes YAML
- document the Scion/Kubernetes responsibility split, diagnostic profile, and image-loading options
- extend host preflight for kind, kubectl, and yq

## Verification
- `kubectl kustomize deploy/kind`
- `bash -n scripts/kind-scion-runtime.sh scripts/bootstrap-host.sh scripts/build-images.sh`
- `shellcheck scripts/kind-scion-runtime.sh scripts/bootstrap-host.sh scripts/build-images.sh`
- `KIND_CLUSTER_NAME=scion-ops-pr1b task kind:up`
- `KIND_CLUSTER_NAME=scion-ops-pr1b task kind:status`
- temporary `HOME` + `KUBECONFIG=/home/david/.kube/config` with `task kind:configure-scion` and `task kind:doctor`
- `KIND_CLUSTER_NAME=scion-ops-pr1b task kind:down`
- `task verify`
- `task --list`
- `git diff --check`

## Notes
This PR deliberately stops at the local Kubernetes substrate. Scion creates runtime agent objects such as pods and secrets once it is configured for Kubernetes, but this repo owns the local bootstrap resources: kind cluster creation, namespace, and RBAC. Hub operation, broker registration, and Hub dispatch to the kind runtime are left for the follow-up issues.