### PR TITLE
Add local Scion Hub mode workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,20 @@ For local Kubernetes runtime testing, use `task kind:up`, then
 `task kind:configure-scion` and `task kind:doctor`. See
 `docs/kind-scion-runtime.md`.
 
+For local Hub mode, use `task hub:up`, authenticate with
+`eval "$(task hub:auth-export)"`, then run `task hub:link`. See
+`docs/local-hub-mode.md`.
+
 ## Layout
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `deploy/kind/` — native Kubernetes resources for the local kind runtime
+- `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow
 - `orchestrator/round.sh` — thin launcher for the consensus runner
 - `mcp_servers/scion_ops.py` — stdio MCP server for Zed external agents
 - `rubric/` — reviewer prompt + verdict JSON schema
 - `scripts/kind-scion-runtime.sh` — local kind orchestration helper
+- `scripts/hub-mode.sh` — local Scion Hub workstation helper
 - `scripts/bootstrap-host.sh` — one-shot host preflight
 
 ## Zed MCP

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,8 +9,12 @@ env:
 vars:
   # 8080 is commonly taken by other dev servers (e.g. uvicorn). 8090 is Scion's
   # workstation-mode web port if you pass --web-port=8090 below.
-  HUB_ENDPOINT: http://127.0.0.1:8090
-  HUB_WEB_PORT: 8090
+  HUB_BIND_HOST:
+    sh: printf '%s' "${HUB_BIND_HOST:-127.0.0.1}"
+  HUB_WEB_PORT:
+    sh: printf '%s' "${HUB_WEB_PORT:-8090}"
+  HUB_ENDPOINT:
+    sh: printf '%s' "${HUB_ENDPOINT:-${SCION_HUB_ENDPOINT:-http://127.0.0.1:${HUB_WEB_PORT:-8090}}}"
   KIND_CLUSTER_NAME:
     sh: printf '%s' "${KIND_CLUSTER_NAME:-scion-ops}"
   KIND_CONTEXT:
@@ -78,19 +82,14 @@ tasks:
       - '{{.SCION_BIN}} doctor --profile kind'
 
   hub:up:
-    desc: Start local Scion Hub (workstation mode). Run hub:link after exporting SCION_DEV_TOKEN.
+    desc: Start/reuse local Scion Hub workstation server and wait for Hub/Broker/Web readiness.
     cmds:
-      - '{{.SCION_BIN}} server start --host 0.0.0.0 --web-port {{.HUB_WEB_PORT}}'
-      - sleep 2
-      - 'echo ""'
-      - 'echo "Web UI:  {{.HUB_ENDPOINT}}"'
-      - 'echo "Authenticate this shell:  eval $(task hub:auth-export)"'
-      - 'echo "Then complete setup:      task hub:link"'
+      - SCION_BIN='{{.SCION_BIN}}' HUB_BIND_HOST='{{.HUB_BIND_HOST}}' HUB_WEB_PORT='{{.HUB_WEB_PORT}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/hub-mode.sh up
 
   hub:auth-export:
     desc: Print the SCION_DEV_TOKEN export line from server.log (use with `eval $(task hub:auth-export)`).
     cmds:
-      - 'grep -oE "export SCION_DEV_TOKEN=scion_dev_[[:alnum:]]+" ~/.scion/server.log | tail -1'
+      - SCION_BIN='{{.SCION_BIN}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/hub-mode.sh auth-export
     silent: true
 
   hub:link:
@@ -99,9 +98,7 @@ tasks:
       - sh: '[ -n "$SCION_DEV_TOKEN" ]'
         msg: 'SCION_DEV_TOKEN not set. Run:  eval $(task hub:auth-export)'
     cmds:
-      - '{{.SCION_BIN}} config set hub.endpoint {{.HUB_ENDPOINT}}'
-      - '{{.SCION_BIN}} hub enable'
-      - '{{.SCION_BIN}} hub link --non-interactive --yes'
+      - SCION_BIN='{{.SCION_BIN}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/hub-mode.sh link
       - task: hub:register-claude-auth
       - task: hub:register-codex-auth
       - task: hub:register-gemini-auth
@@ -194,15 +191,24 @@ tasks:
       - '{{.SCION_BIN}} harness-config sync gemini --non-interactive --yes'
 
   hub:down:
-    desc: Stop the local Scion Hub
+    desc: Stop the local Scion workstation server.
     cmds:
-      - '{{.SCION_BIN}} server stop || true'
+      - SCION_BIN='{{.SCION_BIN}}' bash scripts/hub-mode.sh down
 
   hub:status:
-    desc: Show Hub status + registered agents
+    desc: Show server, Hub, and registered agent status.
     cmds:
-      - '{{.SCION_BIN}} hub status'
-      - '{{.SCION_BIN}} list'
+      - SCION_BIN='{{.SCION_BIN}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/hub-mode.sh status
+
+  hub:disable:
+    desc: Disable Hub integration for this grove.
+    cmds:
+      - SCION_BIN='{{.SCION_BIN}}' bash scripts/hub-mode.sh disable
+
+  hub:logs:
+    desc: Tail the local Scion server log.
+    cmds:
+      - bash scripts/hub-mode.sh logs
 
   round:
     desc: 'Detached round + watchdog. Usage: task round -- "<prompt>".  Env: MAX_MINUTES (default 30).'
@@ -246,6 +252,13 @@ tasks:
       - sleep 2
       - '{{.SCION_BIN}} list'
       - '{{.SCION_BIN}} delete scratch || true'
+
+  smoke:local:
+    desc: Local-only smoke test using Scion with Hub integration disabled for each command.
+    cmds:
+      - '{{.SCION_BIN}} start scratch-local "echo local round trip" --detach --no-hub'
+      - '{{.SCION_BIN}} list --no-hub'
+      - '{{.SCION_BIN}} delete scratch-local --no-hub || true'
 
   mcp:stdio:
     desc: Run the scion-ops MCP server over stdio for Zed/Claude/Codex.

--- a/docs/local-hub-mode.md
+++ b/docs/local-hub-mode.md
@@ -1,0 +1,114 @@
+# Local Hub Mode
+
+This project uses Scion workstation mode as the local control plane. In that
+mode a single local Scion server runs:
+
+- Hub API: control plane for groves, templates, secrets, messages, and agent
+  state.
+- Runtime Broker: execution plane for creating and managing agents.
+- Web Frontend: browser dashboard for the same Hub state.
+
+For issue #2, the broker remains the co-located workstation broker. Moving the
+execution plane onto the kind Kubernetes runtime is a follow-up task.
+
+## Defaults
+
+| Setting | Value |
+|---|---|
+| bind host | `127.0.0.1` |
+| web and Hub endpoint | `http://127.0.0.1:8090` |
+| server log | `~/.scion/server.log` |
+| authentication | development token from local server log |
+
+Override the bind host, port, or client endpoint when needed:
+
+```bash
+HUB_BIND_HOST=0.0.0.0 HUB_ENDPOINT=http://192.168.122.103:8090 task hub:up
+```
+
+Keep `HUB_ENDPOINT` or Scion's `SCION_HUB_ENDPOINT` set to the address clients
+should use. Binding to `0.0.0.0` only controls where the server listens.
+
+## Start And Link
+
+Start or reuse the local workstation server:
+
+```bash
+task hub:up
+```
+
+The task waits until Hub, Broker, and Web are all reported as running by
+`scion server status`. It prints the dashboard URL and the next commands.
+
+Authenticate the shell with the development token printed by the server:
+
+```bash
+eval "$(task hub:auth-export)"
+```
+
+Link this grove and sync the runtime assets:
+
+```bash
+task hub:link
+```
+
+That task:
+
+- sets `hub.endpoint`
+- enables Hub integration
+- links the current grove
+- uploads Claude, Codex, and Gemini subscription credential files as Hub file
+  secrets
+- prepares and syncs harness configs
+- syncs local templates to Hub
+
+## Operate
+
+Check the local server, Hub connection, grove link, broker, and current agents:
+
+```bash
+task hub:status
+```
+
+Open the dashboard at:
+
+```text
+http://127.0.0.1:8090
+```
+
+Tail the server log:
+
+```bash
+task hub:logs
+```
+
+Stop the local Scion server:
+
+```bash
+task hub:down
+```
+
+Stopping the workstation server also stops the co-located Runtime Broker. Agents
+managed by that broker are no longer reachable until the server is restarted.
+
+## Local-Only Escape Hatch
+
+Use Scion's global `--no-hub` flag for one-off local-only commands:
+
+```bash
+scion start scratch "echo local" --detach --no-hub
+scion list --no-hub
+scion delete scratch --no-hub
+```
+
+There is also a smoke task for the same path:
+
+```bash
+task smoke:local
+```
+
+To disable Hub integration for this grove until re-enabled:
+
+```bash
+task hub:disable
+```

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -58,6 +58,7 @@ require "codex CLI"   command -v codex
 # shellcheck disable=SC2016 # Intentionally expand $HOME in the bash -lc child.
 require "gemini CLI"  bash -lc 'command -v gemini >/dev/null 2>&1 || test -x "$HOME/.npm-global/bin/gemini"'
 require "task"        command -v task
+require "jq"          command -v jq
 require "kind"        command -v kind
 require "kubectl"     command -v kubectl
 require "yq"          command -v yq

--- a/scripts/hub-mode.sh
+++ b/scripts/hub-mode.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Manage the local Scion workstation server used as Hub + Broker + Web.
+set -euo pipefail
+
+SCION_BIN="${SCION_BIN:-scion}"
+HUB_BIND_HOST="${HUB_BIND_HOST:-127.0.0.1}"
+HUB_WEB_PORT="${HUB_WEB_PORT:-8090}"
+HUB_ENDPOINT="${HUB_ENDPOINT:-${SCION_HUB_ENDPOINT:-http://127.0.0.1:${HUB_WEB_PORT}}}"
+SCION_SERVER_LOG="${SCION_SERVER_LOG:-${HOME}/.scion/server.log}"
+READY_TIMEOUT_SECONDS="${SCION_HUB_READY_TIMEOUT_SECONDS:-30}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command>
+
+Commands:
+  up           Start/reuse the local Scion workstation server.
+  down         Stop the local Scion server daemon.
+  status       Show server, Hub, and current agent status.
+  auth-export  Print the SCION_DEV_TOKEN export line from the server log.
+  link         Configure endpoint, enable Hub mode, and link this grove.
+  disable      Disable Hub integration for this grove.
+  logs         Tail the Scion server log.
+
+Environment:
+  SCION_BIN                         Scion CLI binary (default: scion)
+  HUB_BIND_HOST                     Server bind host (default: 127.0.0.1)
+  HUB_WEB_PORT                      Web/combined Hub port (default: 8090)
+  HUB_ENDPOINT                      Client endpoint (default: http://127.0.0.1:8090)
+  SCION_HUB_READY_TIMEOUT_SECONDS   Startup readiness timeout (default: 30)
+EOF
+}
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '\033[36m==> %s\033[0m\n' "$*"
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required on PATH"
+}
+
+server_status() {
+  "$SCION_BIN" server status 2>&1
+}
+
+server_ready() {
+  local status
+  status="$(server_status || true)"
+  grep -Eq 'Hub API:[[:space:]]+running' <<<"$status" \
+    && grep -Eq 'Runtime Broker:[[:space:]]+running' <<<"$status" \
+    && grep -Eq 'Web Frontend:[[:space:]]+running' <<<"$status"
+}
+
+wait_until_ready() {
+  local deadline
+  deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+
+  while (( SECONDS <= deadline )); do
+    if server_ready; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  server_status >&2 || true
+  if [[ -f "$SCION_SERVER_LOG" ]]; then
+    printf '\nRecent server log:\n' >&2
+    tail -n 40 "$SCION_SERVER_LOG" >&2
+  fi
+  die "Scion server did not become ready within ${READY_TIMEOUT_SECONDS}s"
+}
+
+cmd_up() {
+  require "$SCION_BIN"
+
+  if server_ready; then
+    log "reuse running Scion workstation server"
+  else
+    log "start Scion workstation server on ${HUB_BIND_HOST}:${HUB_WEB_PORT}"
+    "$SCION_BIN" server start --host "$HUB_BIND_HOST" --web-port "$HUB_WEB_PORT"
+    wait_until_ready
+  fi
+
+  cat <<EOF
+
+Scion Hub mode ready
+  Web UI:      ${HUB_ENDPOINT}
+  Bind host:   ${HUB_BIND_HOST}
+  Web port:    ${HUB_WEB_PORT}
+  Server log:  ${SCION_SERVER_LOG}
+
+Next:
+  eval "\$(task hub:auth-export)"
+  task hub:link
+  task hub:status
+EOF
+}
+
+cmd_down() {
+  require "$SCION_BIN"
+  "$SCION_BIN" server stop || true
+}
+
+cmd_auth_export() {
+  [[ -f "$SCION_SERVER_LOG" ]] || die "server log not found: $SCION_SERVER_LOG; run task hub:up first"
+  local token_line
+  token_line="$(grep -oE 'export SCION_DEV_TOKEN=scion_dev_[[:alnum:]]+' "$SCION_SERVER_LOG" | tail -1 || true)"
+  [[ -n "$token_line" ]] || die "SCION_DEV_TOKEN not found in $SCION_SERVER_LOG; restart the server or inspect the log"
+  printf '%s\n' "$token_line"
+}
+
+cmd_link() {
+  require "$SCION_BIN"
+  [[ -n "${SCION_DEV_TOKEN:-}" ]] || die "SCION_DEV_TOKEN not set. Run: eval \"\$(task hub:auth-export)\""
+
+  log "configure Hub endpoint ${HUB_ENDPOINT}"
+  "$SCION_BIN" config set hub.endpoint "$HUB_ENDPOINT"
+  "$SCION_BIN" hub enable --hub "$HUB_ENDPOINT"
+  "$SCION_BIN" hub link --hub "$HUB_ENDPOINT" --non-interactive --yes
+}
+
+cmd_status() {
+  require "$SCION_BIN"
+  "$SCION_BIN" server status
+  printf '\n'
+  "$SCION_BIN" hub status --hub "$HUB_ENDPOINT" --non-interactive
+  printf '\n'
+  "$SCION_BIN" list --hub "$HUB_ENDPOINT" --non-interactive
+}
+
+cmd_disable() {
+  require "$SCION_BIN"
+  "$SCION_BIN" hub disable
+  cat <<EOF
+
+Hub integration disabled for this grove.
+For a one-off local-only command, prefer the global flag:
+  scion start --no-hub scratch "echo local"
+EOF
+}
+
+cmd_logs() {
+  [[ -f "$SCION_SERVER_LOG" ]] || die "server log not found: $SCION_SERVER_LOG"
+  tail -F "$SCION_SERVER_LOG"
+}
+
+case "${1:-}" in
+  up)
+    cmd_up
+    ;;
+  down)
+    cmd_down
+    ;;
+  status)
+    cmd_status
+    ;;
+  auth-export)
+    cmd_auth_export
+    ;;
+  link)
+    cmd_link
+    ;;
+  disable)
+    cmd_disable
+    ;;
+  logs)
+    cmd_logs
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    die "unknown command: $1"
+    ;;
+esac


### PR DESCRIPTION
Closes #2

## Summary
- add `scripts/hub-mode.sh` for local Scion workstation Hub startup, readiness, auth export, link, status, logs, disable, and shutdown operations
- replace the blind `hub:up` sleep with a readiness check against `scion server status`
- add `docs/local-hub-mode.md` covering Hub/Broker/Web responsibilities, dashboard URL, grove linking, auth/harness/template sync, remote bind overrides, and the `--no-hub` escape hatch
- add `hub:disable`, `hub:logs`, and `smoke:local` tasks
- add `jq` to host preflight because Hub harness prep already depends on it

## Verification
- `task hub:up`
- `line=$(task hub:auth-export)` format check without printing the token
- `eval "$(task hub:auth-export)" && task hub:link`
- `task hub:status`
- `scion list --no-hub --non-interactive`
- `bash -n scripts/hub-mode.sh scripts/kind-scion-runtime.sh scripts/bootstrap-host.sh scripts/build-images.sh`
- `shellcheck scripts/hub-mode.sh scripts/kind-scion-runtime.sh scripts/bootstrap-host.sh scripts/build-images.sh`
- `task --list`
- `git diff --check`
- `bash scripts/bootstrap-host.sh`
- `task verify`

## Notes
I did not run `task hub:down` or `task hub:disable` during verification because the local Hub is currently running and linked. Both paths are thin wrappers around `scion server stop` and `scion hub disable` respectively.
