### PR TITLE
Configure kind broker runtime profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,22 @@ For local Hub mode, use `task hub:up`, authenticate with
 `eval "$(task hub:auth-export)"`, then run `task hub:link`. See
 `docs/local-hub-mode.md`.
 
+To advertise the kind Kubernetes runtime through the local broker, run
+`task broker:kind-configure`, then `task broker:kind-provide`. See
+`docs/kind-broker-runtime.md`.
+
 ## Layout
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `deploy/kind/` — native Kubernetes resources for the local kind runtime
+- `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow
 - `orchestrator/round.sh` — thin launcher for the consensus runner
 - `mcp_servers/scion_ops.py` — stdio MCP server for Zed external agents
 - `rubric/` — reviewer prompt + verdict JSON schema
 - `scripts/kind-scion-runtime.sh` — local kind orchestration helper
 - `scripts/hub-mode.sh` — local Scion Hub workstation helper
+- `scripts/kind-broker-runtime.sh` — local broker/kind profile helper
 - `scripts/bootstrap-host.sh` — one-shot host preflight
 
 ## Zed MCP

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,6 +81,26 @@ tasks:
     cmds:
       - '{{.SCION_BIN}} doctor --profile kind'
 
+  broker:kind-configure:
+    desc: Configure the Scion kind profile and verify Kubernetes runtime diagnostics.
+    cmds:
+      - SCION_BIN='{{.SCION_BIN}}' bash scripts/kind-broker-runtime.sh configure
+
+  broker:kind-provide:
+    desc: Refresh broker registration, provide this grove, and make the broker default.
+    cmds:
+      - SCION_BIN='{{.SCION_BIN}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/kind-broker-runtime.sh provide
+
+  broker:kind-status:
+    desc: Show Scion kind profile, local broker, and Hub broker profile status.
+    cmds:
+      - SCION_BIN='{{.SCION_BIN}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/kind-broker-runtime.sh status
+
+  broker:kind-smoke:
+    desc: Dispatch a minimal Hub agent with --profile kind and verify a pod appears in kind.
+    cmds:
+      - SCION_BIN='{{.SCION_BIN}}' HUB_ENDPOINT='{{.HUB_ENDPOINT}}' bash scripts/kind-broker-runtime.sh smoke
+
   hub:up:
     desc: Start/reuse local Scion Hub workstation server and wait for Hub/Broker/Web readiness.
     cmds:
@@ -248,7 +268,7 @@ tasks:
   smoke:
     desc: Phase 1 smoke test — start a stock agent, list, attach to logs, delete
     cmds:
-      - '{{.SCION_BIN}} start scratch "echo round trip" --detach'
+      - '{{.SCION_BIN}} start scratch "echo round trip"'
       - sleep 2
       - '{{.SCION_BIN}} list'
       - '{{.SCION_BIN}} delete scratch || true'
@@ -256,7 +276,7 @@ tasks:
   smoke:local:
     desc: Local-only smoke test using Scion with Hub integration disabled for each command.
     cmds:
-      - '{{.SCION_BIN}} start scratch-local "echo local round trip" --detach --no-hub'
+      - '{{.SCION_BIN}} start scratch-local "echo local round trip" --no-hub'
       - '{{.SCION_BIN}} list --no-hub'
       - '{{.SCION_BIN}} delete scratch-local --no-hub || true'
 

--- a/docs/kind-broker-runtime.md
+++ b/docs/kind-broker-runtime.md
@@ -1,0 +1,111 @@
+# kind Broker Runtime
+
+This wires the local workstation Runtime Broker to the kind-backed Kubernetes
+profile. The shape follows the upstream Scion model:
+
+- Hub is the control plane for groves, agents, templates, and broker routing.
+- Runtime Broker is the compute provider for a grove.
+- Kubernetes is selected by a Scion profile at agent dispatch time.
+
+References:
+
+- Runtime Broker guide: <https://googlecloudplatform.github.io/scion/hub-user/runtime-broker/>
+- Kubernetes runtime guide: <https://googlecloudplatform.github.io/scion/hub-admin/kubernetes/>
+
+## Prerequisites
+
+Start from the issue #1 and #2 workflows:
+
+```bash
+task kind:up
+task hub:up
+eval "$(task hub:auth-export)"
+task hub:link
+```
+
+Build and load the agent images before running real agents on kind. The smoke
+task uses `reviewer-claude`, so `localhost/scion-claude:latest` is the minimum
+image needed for this check:
+
+```bash
+task images:build
+task kind:load-images -- \
+  localhost/scion-base:latest \
+  localhost/scion-claude:latest \
+  localhost/scion-codex:latest \
+  localhost/scion-gemini:latest
+```
+
+## Configure The Profile
+
+Configure Scion's global `kind` profile to target the kind kube context and
+namespace:
+
+```bash
+task broker:kind-configure
+```
+
+This writes the broker-facing profile in `~/.scion/settings.yaml`:
+
+```yaml
+image_registry: localhost
+runtimes:
+  kubernetes:
+    type: kubernetes
+    context: kind-scion-ops
+    namespace: scion-agents
+profiles:
+  kind:
+    runtime: kubernetes
+```
+
+The profile is named `kind`, while the runtime name remains `kubernetes`. That
+keeps the broker metadata and Hub dashboard aligned with Scion's Kubernetes
+runtime type.
+
+## Provide This Grove
+
+Refresh the broker registration so Hub sees the updated profile list, then add
+the broker as a provider for this grove and make it the default:
+
+```bash
+task broker:kind-provide
+```
+
+This runs:
+
+- `scion broker register --force`
+- `scion server stop` followed by `task hub:up`-equivalent startup, so the
+  embedded broker reloads refreshed HMAC credentials
+- `scion broker provide --make-default`
+
+Check the result:
+
+```bash
+task broker:kind-status
+```
+
+The broker profile list should include `kind` with the kind context and
+namespace.
+
+## Smoke Dispatch
+
+Dispatch a minimal Hub agent using the kind profile and verify that a
+Kubernetes pod appears:
+
+```bash
+task broker:kind-smoke
+```
+
+By default, the task deletes the smoke agent after observing the pod. Keep it
+for inspection with:
+
+```bash
+SCION_KIND_SMOKE_KEEP=1 task broker:kind-smoke
+```
+
+The smoke task is intentionally a dispatch check, not a full consensus round.
+It proves Hub routed to the local broker and the broker selected the kind
+Kubernetes runtime for `--profile kind`. It passes `--no-auth` so the check
+does not depend on copying local subscription credentials into the smoke pod.
+Override `SCION_KIND_SMOKE_TEMPLATE` when you want to verify another harness.

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -30,6 +30,8 @@ kustomization. The helper script should not contain embedded Kubernetes YAML.
 | agent namespace | `scion-agents` |
 | RBAC service account | `scion-agent-manager` |
 | Scion profile | `kind` |
+| Scion runtime | `kubernetes` |
+| image registry | `localhost` |
 
 Override the cluster name with an environment variable:
 
@@ -77,14 +79,15 @@ task kind:configure-scion
 This writes:
 
 ```yaml
+image_registry: localhost
 runtimes:
-  kind:
+  kubernetes:
     type: kubernetes
     context: kind-scion-ops
     namespace: scion-agents
 profiles:
   kind:
-    runtime: kind
+    runtime: kubernetes
 ```
 
 Run Scion's Kubernetes diagnostics:

--- a/scripts/hub-mode.sh
+++ b/scripts/hub-mode.sh
@@ -56,6 +56,12 @@ server_ready() {
     && grep -Eq 'Web Frontend:[[:space:]]+running' <<<"$status"
 }
 
+server_running() {
+  local status
+  status="$(server_status || true)"
+  grep -Eq 'Daemon:[[:space:]]+running' <<<"$status"
+}
+
 wait_until_ready() {
   local deadline
   deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
@@ -80,6 +86,9 @@ cmd_up() {
 
   if server_ready; then
     log "reuse running Scion workstation server"
+  elif server_running; then
+    log "wait for running Scion server components"
+    wait_until_ready
   else
     log "start Scion workstation server on ${HUB_BIND_HOST}:${HUB_WEB_PORT}"
     "$SCION_BIN" server start --host "$HUB_BIND_HOST" --web-port "$HUB_WEB_PORT"

--- a/scripts/kind-broker-runtime.sh
+++ b/scripts/kind-broker-runtime.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Wire the local Scion Runtime Broker to the kind-backed Kubernetes profile.
+set -euo pipefail
+
+SCION_BIN="${SCION_BIN:-scion}"
+PROFILE_NAME="${SCION_K8S_PROFILE:-kind}"
+RUNTIME_NAME="${SCION_K8S_RUNTIME:-kubernetes}"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-scion-ops}"
+NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
+HUB_ENDPOINT="${HUB_ENDPOINT:-${SCION_HUB_ENDPOINT:-http://127.0.0.1:8090}}"
+HUB_BIND_HOST="${HUB_BIND_HOST:-127.0.0.1}"
+HUB_WEB_PORT="${HUB_WEB_PORT:-8090}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETTINGS_FILE="${SCION_SETTINGS_FILE:-${HOME}/.scion/settings.yaml}"
+SMOKE_AGENT="${SCION_KIND_SMOKE_AGENT:-kind-smoke-$(date +%Y%m%d%H%M%S)}"
+SMOKE_TEMPLATE="${SCION_KIND_SMOKE_TEMPLATE:-reviewer-claude}"
+SMOKE_PROMPT="${SCION_KIND_SMOKE_PROMPT:-Report the current working directory and then stop.}"
+SMOKE_WAIT_SECONDS="${SCION_KIND_SMOKE_WAIT_SECONDS:-60}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command>
+
+Commands:
+  configure   Configure Scion profile "${PROFILE_NAME}" for the kind Kubernetes runtime.
+  provide     Refresh broker registration, provide this grove, and make broker default.
+  status      Show profile, broker, and Hub broker profile status.
+  smoke       Dispatch a minimal Hub agent with --profile ${PROFILE_NAME} and verify a kind pod appears.
+
+Environment:
+  SCION_BIN                    Scion CLI binary (default: scion)
+  SCION_K8S_PROFILE            Scion profile name (default: kind)
+  SCION_K8S_RUNTIME            Scion runtime name (default: kubernetes)
+  KIND_CLUSTER_NAME            kind cluster name (default: scion-ops)
+  SCION_K8S_NAMESPACE          Agent namespace (default: scion-agents)
+  HUB_ENDPOINT                 Hub endpoint (default: http://127.0.0.1:8090)
+  HUB_BIND_HOST                Server bind host when restart is needed (default: 127.0.0.1)
+  HUB_WEB_PORT                 Server web port when restart is needed (default: 8090)
+  SCION_KIND_SMOKE_TEMPLATE    Smoke template (default: reviewer-claude)
+  SCION_KIND_SMOKE_AGENT       Smoke agent name (default: timestamped)
+  SCION_KIND_SMOKE_WAIT_SECONDS  Pod observation timeout (default: 60)
+EOF
+}
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '\033[36m==> %s\033[0m\n' "$*"
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required on PATH"
+}
+
+broker_id() {
+  "$SCION_BIN" broker status --json 2>/dev/null | jq -r '.brokerId // empty'
+}
+
+broker_name() {
+  "$SCION_BIN" broker status --json 2>/dev/null | jq -r '.brokerName // empty'
+}
+
+cmd_configure() {
+  require "$SCION_BIN"
+  require yq
+
+  log "configure Scion profile ${PROFILE_NAME} for kind cluster ${CLUSTER_NAME}"
+  "$SCRIPT_DIR/kind-scion-runtime.sh" configure-scion
+
+  log "verify Kubernetes runtime profile ${PROFILE_NAME}"
+  "$SCION_BIN" doctor --profile "$PROFILE_NAME"
+}
+
+cmd_provide() {
+  require "$SCION_BIN"
+  require jq
+
+  cmd_configure
+
+  log "refresh broker registration so Hub sees profile ${PROFILE_NAME}"
+  "$SCION_BIN" broker register --force --hub "$HUB_ENDPOINT" --non-interactive --yes
+
+  if [[ "${SCION_BROKER_RESTART_AFTER_REGISTER:-1}" == "1" ]]; then
+    log "restart workstation server so embedded broker reloads refreshed credentials"
+    "$SCION_BIN" server stop || true
+    SCION_BIN="$SCION_BIN" \
+      HUB_BIND_HOST="$HUB_BIND_HOST" \
+      HUB_WEB_PORT="$HUB_WEB_PORT" \
+      HUB_ENDPOINT="$HUB_ENDPOINT" \
+      "$SCRIPT_DIR/hub-mode.sh" up
+  fi
+
+  log "provide this grove from the local broker and make it default"
+  "$SCION_BIN" broker provide --make-default --non-interactive --yes
+}
+
+cmd_status() {
+  require "$SCION_BIN"
+  require jq
+  require yq
+
+  printf 'settings:  %s\n' "$SETTINGS_FILE"
+  printf 'profile:   %s\n' "$PROFILE_NAME"
+  printf 'runtime:   %s\n\n' "$RUNTIME_NAME"
+
+  if [[ -f "$SETTINGS_FILE" ]]; then
+    SCION_K8S_PROFILE="$PROFILE_NAME" SCION_K8S_RUNTIME="$RUNTIME_NAME" yq eval '
+      {
+        "runtime": .runtimes[strenv(SCION_K8S_RUNTIME)],
+        "profile": .profiles[strenv(SCION_K8S_PROFILE)],
+        "image_registry": .image_registry
+      }
+    ' "$SETTINGS_FILE"
+  else
+    die "settings file not found: $SETTINGS_FILE"
+  fi
+
+  printf '\n'
+  "$SCION_BIN" broker status --json | jq '{registered, brokerId, brokerName, brokerStatus, hubConnected, groves}'
+
+  local id
+  id="$(broker_id)"
+  if [[ -n "$id" ]]; then
+    printf '\n'
+    "$SCION_BIN" hub brokers info "$id" --hub "$HUB_ENDPOINT" --non-interactive --json | jq '{id, name, status, profiles}'
+  fi
+}
+
+cmd_smoke() {
+  require "$SCION_BIN"
+  require jq
+  require kubectl
+
+  local id name context
+  id="$(broker_id)"
+  name="$(broker_name)"
+  [[ -n "$id" ]] || die "broker is not registered; run: task broker:kind-provide"
+  [[ -n "$name" ]] || name="$id"
+  context="kind-${CLUSTER_NAME}"
+
+  log "dispatch ${SMOKE_AGENT} through Hub to broker ${name} with profile ${PROFILE_NAME}"
+  "$SCION_BIN" --profile "$PROFILE_NAME" start "$SMOKE_AGENT" \
+    --broker "$name" \
+    --type "$SMOKE_TEMPLATE" \
+    --no-auth \
+    --hub "$HUB_ENDPOINT" \
+    --non-interactive \
+    --yes \
+    "$SMOKE_PROMPT"
+
+  log "wait for kind pod scion.name=${SMOKE_AGENT}"
+  local deadline
+  deadline=$((SECONDS + SMOKE_WAIT_SECONDS))
+  while (( SECONDS <= deadline )); do
+    if kubectl --context "$context" get pods -n "$NAMESPACE" -l "scion.name=${SMOKE_AGENT}" --no-headers 2>/dev/null | grep -q .; then
+      kubectl --context "$context" get pods -n "$NAMESPACE" -l "scion.name=${SMOKE_AGENT}" -o wide
+      if [[ "${SCION_KIND_SMOKE_KEEP:-0}" != "1" ]]; then
+        log "delete smoke agent ${SMOKE_AGENT}"
+        "$SCION_BIN" delete "$SMOKE_AGENT" --hub "$HUB_ENDPOINT" --non-interactive --yes || true
+      fi
+      return 0
+    fi
+    sleep 1
+  done
+
+  "$SCION_BIN" list --hub "$HUB_ENDPOINT" --non-interactive || true
+  die "no kind pod appeared for ${SMOKE_AGENT} within ${SMOKE_WAIT_SECONDS}s"
+}
+
+case "${1:-}" in
+  configure)
+    cmd_configure
+    ;;
+  provide)
+    cmd_provide
+    ;;
+  status)
+    cmd_status
+    ;;
+  smoke)
+    cmd_smoke
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    die "unknown command: $1"
+    ;;
+esac

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 CLUSTER_NAME="${KIND_CLUSTER_NAME:-scion-ops}"
 NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
 SERVICE_ACCOUNT="${SCION_K8S_SERVICE_ACCOUNT:-scion-agent-manager}"
+PROFILE_NAME="${SCION_K8S_PROFILE:-kind}"
+RUNTIME_NAME="${SCION_K8S_RUNTIME:-kubernetes}"
+IMAGE_REGISTRY="${SCION_IMAGE_REGISTRY:-localhost}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 MANIFEST_DIR="${SCION_K8S_MANIFEST_DIR:-${REPO_ROOT}/deploy/kind}"
@@ -27,6 +30,9 @@ Environment:
   SCION_K8S_MANIFEST_DIR     Kustomize manifest directory (default: deploy/kind)
   SCION_K8S_NAMESPACE        Agent namespace (default: scion-agents)
   SCION_K8S_SERVICE_ACCOUNT  Runtime service account (default: scion-agent-manager)
+  SCION_K8S_PROFILE          Scion profile name (default: kind)
+  SCION_K8S_RUNTIME          Scion runtime name (default: kubernetes)
+  SCION_IMAGE_REGISTRY       Agent image registry/prefix (default: localhost)
 EOF
 }
 
@@ -157,21 +163,29 @@ cmd_configure_scion() {
 
   local tmp
   tmp="$(mktemp)"
-  KIND_CONTEXT="$CONTEXT" SCION_K8S_NAMESPACE="$NAMESPACE" yq eval '
+  KIND_CONTEXT="$CONTEXT" \
+    SCION_K8S_NAMESPACE="$NAMESPACE" \
+    SCION_K8S_PROFILE="$PROFILE_NAME" \
+    SCION_K8S_RUNTIME="$RUNTIME_NAME" \
+    SCION_IMAGE_REGISTRY="$IMAGE_REGISTRY" \
+    yq eval '
     .schema_version = (.schema_version // "1") |
-    .runtimes.kind.type = "kubernetes" |
-    .runtimes.kind.context = strenv(KIND_CONTEXT) |
-    .runtimes.kind.namespace = strenv(SCION_K8S_NAMESPACE) |
-    .profiles.kind.runtime = "kind"
+    .runtimes[strenv(SCION_K8S_RUNTIME)].type = "kubernetes" |
+    .runtimes[strenv(SCION_K8S_RUNTIME)].context = strenv(KIND_CONTEXT) |
+    .runtimes[strenv(SCION_K8S_RUNTIME)].namespace = strenv(SCION_K8S_NAMESPACE) |
+    .profiles[strenv(SCION_K8S_PROFILE)].runtime = strenv(SCION_K8S_RUNTIME) |
+    .image_registry = strenv(SCION_IMAGE_REGISTRY)
   ' "$settings_file" > "$tmp"
   mv "$tmp" "$settings_file"
 
   cat <<EOF
 Configured Scion profile:
   file:      ${settings_file}
-  profile:   kind
+  profile:   ${PROFILE_NAME}
+  runtime:   ${RUNTIME_NAME}
   context:   ${CONTEXT}
   namespace: ${NAMESPACE}
+  registry:  ${IMAGE_REGISTRY}
 EOF
 }
 


### PR DESCRIPTION
Closes #3.

## Summary
- add broker kind helper tasks for configure/provide/status/smoke
- configure the global kind profile to use the Kubernetes runtime key expected by Hub broker metadata
- document the Hub/Broker/kind workflow and keep Kubernetes resources in deploy/kind
- make hub startup tolerate an already-running daemon while components finish coming up

## Verification
- bash -n scripts/kind-broker-runtime.sh scripts/kind-scion-runtime.sh scripts/hub-mode.sh scripts/bootstrap-host.sh scripts/build-images.sh
- shellcheck scripts/kind-broker-runtime.sh scripts/kind-scion-runtime.sh scripts/hub-mode.sh scripts/bootstrap-host.sh scripts/build-images.sh
- task broker:kind-status
- task broker:kind-smoke
- scion config validate --non-interactive

## Live smoke result
`task broker:kind-smoke` started `kind-smoke-20260503223800` through Hub using broker `workspace-dodwyer` and profile `kind`; Kubernetes reported pod `scion-ops--kind-smoke-20260503223800` running in namespace `scion-agents`, then the task deleted the smoke agent via Hub.