### PR TITLE
Add HTTP MCP transport tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To advertise the kind Kubernetes runtime through the local broker, run
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow
 - `orchestrator/round.sh` — thin launcher for the consensus runner
-- `mcp_servers/scion_ops.py` — stdio MCP server for Zed external agents
+- `mcp_servers/scion_ops.py` — streamable HTTP and stdio MCP server for Zed external agents
 - `rubric/` — reviewer prompt + verdict JSON schema
 - `scripts/kind-scion-runtime.sh` — local kind orchestration helper
 - `scripts/hub-mode.sh` — local Scion Hub workstation helper
@@ -57,9 +57,9 @@ To advertise the kind Kubernetes runtime through the local broker, run
 
 ## Zed MCP
 
-Use `task mcp:smoke` to verify the local MCP server. Add the server to Zed's
-`context_servers` so Claude Agent or Codex can start, monitor, inspect, and
-abort Scion rounds from the Agent Panel. See `docs/zed-mcp.md`.
+Use `task mcp:http` to run the MCP server at `http://127.0.0.1:8765/mcp` for
+Hub-mode external agents. Verify it with `task mcp:http:smoke`. Stdio remains
+available with `task mcp:stdio` and `task mcp:smoke`. See `docs/zed-mcp.md`.
 
 ## Testing
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,20 @@ vars:
     sh: printf 'kind-%s' "${KIND_CLUSTER_NAME:-scion-ops}"
   SCION_K8S_NAMESPACE:
     sh: printf '%s' "${SCION_K8S_NAMESPACE:-scion-agents}"
+  SCION_OPS_MCP_HOST:
+    sh: printf '%s' "${SCION_OPS_MCP_HOST:-127.0.0.1}"
+  SCION_OPS_MCP_PORT:
+    sh: printf '%s' "${SCION_OPS_MCP_PORT:-8765}"
+  SCION_OPS_MCP_PATH:
+    sh: printf '%s' "${SCION_OPS_MCP_PATH:-/mcp}"
+  SCION_OPS_MCP_URL:
+    sh: |
+      path="${SCION_OPS_MCP_PATH:-/mcp}"
+      case "$path" in
+        /*) ;;
+        *) path="/$path" ;;
+      esac
+      printf 'http://%s:%s%s' "${SCION_OPS_MCP_HOST:-127.0.0.1}" "${SCION_OPS_MCP_PORT:-8765}" "$path"
   HOME:
     sh: echo "$HOME"
   GOPATH:
@@ -283,9 +297,19 @@ tasks:
   mcp:stdio:
     desc: Run the scion-ops MCP server over stdio for Zed/Claude/Codex.
     cmds:
-      - uv run mcp_servers/scion_ops.py
+      - PYTHONDONTWRITEBYTECODE=1 uv run mcp_servers/scion_ops.py
+
+  mcp:http:
+    desc: Run the scion-ops MCP server over streamable HTTP at the local MCP URL.
+    cmds:
+      - PYTHONDONTWRITEBYTECODE=1 SCION_OPS_MCP_TRANSPORT=streamable-http SCION_OPS_MCP_HOST='{{.SCION_OPS_MCP_HOST}}' SCION_OPS_MCP_PORT='{{.SCION_OPS_MCP_PORT}}' SCION_OPS_MCP_PATH='{{.SCION_OPS_MCP_PATH}}' uv run mcp_servers/scion_ops.py
 
   mcp:smoke:
     desc: Smoke test the scion-ops MCP server by listing tools over stdio.
     cmds:
-      - uv run scripts/smoke-mcp-server.py
+      - PYTHONDONTWRITEBYTECODE=1 uv run scripts/smoke-mcp-server.py
+
+  mcp:http:smoke:
+    desc: Smoke test the HTTP MCP server by listing tools at the local MCP URL.
+    cmds:
+      - PYTHONDONTWRITEBYTECODE=1 uv run scripts/smoke-mcp-server.py --transport http --url '{{.SCION_OPS_MCP_URL}}' --host '{{.SCION_OPS_MCP_HOST}}' --port '{{.SCION_OPS_MCP_PORT}}' --path '{{.SCION_OPS_MCP_PATH}}' --start-server

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -1,14 +1,98 @@
 # Zed MCP Setup
 
-This repo includes a local stdio MCP server for Zed external agents. It exposes
-the existing `task`, `scion`, and git workflow through narrow tools for starting
+This repo includes an MCP server for Zed external agents. It exposes the
+existing `task`, `scion`, and git workflow through narrow tools for starting
 rounds, monitoring agents, reading transcripts, checking result branches, and
 aborting a round with explicit confirmation.
 
-## Option A: Local Command
+For Hub mode, prefer streamable HTTP. It keeps one long-lived service attached
+to the `scion-ops` workspace and lets Zed, Claude, Codex, or a local tunnel
+connect by URL.
 
-Use this when Zed can run the MCP server on the same machine as the
-`scion-ops` workspace:
+## Preferred: Streamable HTTP
+
+Start the server from the repo root:
+
+```bash
+task mcp:http
+```
+
+Defaults:
+
+| Setting | Value |
+|---|---|
+| host | `127.0.0.1` |
+| port | `8765` |
+| path | `/mcp` |
+| URL | `http://127.0.0.1:8765/mcp` |
+
+Override the bind address with environment variables:
+
+```bash
+SCION_OPS_MCP_HOST=127.0.0.1 \
+SCION_OPS_MCP_PORT=8765 \
+SCION_OPS_MCP_PATH=/mcp \
+task mcp:http
+```
+
+Configure Zed with the URL:
+
+```json
+{
+  "context_servers": {
+    "scion-ops": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+Keep the default `127.0.0.1` bind unless the server is behind an authenticated
+reverse proxy or an SSH tunnel. Do not expose this service directly to the
+public internet: the tools can start, stop, inspect, and delete local Scion
+agents.
+
+Smoke test the HTTP transport:
+
+```bash
+task mcp:http:smoke
+```
+
+The smoke task connects to the documented URL first. If no MCP server responds,
+it starts a temporary local server, lists tools, and shuts it down.
+
+## Remote HTTP By SSH Tunnel
+
+When `scion-ops`, `scion`, and the agent workspaces live on a remote host,
+start the HTTP MCP server on that remote host with the default local bind:
+
+```bash
+cd /home/david/workspace/github/livewyer-ops/scion-ops
+task mcp:http
+```
+
+Tunnel it from your local machine:
+
+```bash
+ssh -N -L 8765:127.0.0.1:8765 david@192.168.122.103
+```
+
+Then configure Zed locally with:
+
+```json
+{
+  "context_servers": {
+    "scion-ops": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+## Stdio: Local Command
+
+Use stdio when Zed can run the MCP server on the same machine as the
+`scion-ops` workspace and you want Zed to manage the process lifetime:
 
 ```json
 {
@@ -28,13 +112,13 @@ Use this when Zed can run the MCP server on the same machine as the
 ```
 
 Zed forwards `context_servers` to Claude Agent and Codex external agents via
-ACP. Local stdio MCP servers are the reliable path for those external agents.
+ACP. Stdio remains useful for local command setups and SSH command wrappers.
 
-## Option B: Local Command Over SSH
+## Stdio: Local Command Over SSH
 
-Use this when Zed is local but `scion-ops`, `scion`, and the agent workspaces
-live on a remote host. Zed still sees a local command, but that command is
-`ssh`, and the MCP stdio stream runs on the remote machine.
+Use this when Zed is local but you prefer not to run a long-lived HTTP service
+on the remote host. Zed still sees a local command, but that command is `ssh`,
+and the MCP stdio stream runs on the remote machine.
 
 This repo includes a generated project config at `.zed/settings.json` for:
 
@@ -66,44 +150,6 @@ export SCION_OPS_SSH_KEY="$HOME/.ssh/your-key"
 
 This is usually the least moving parts if SSH is already configured. Keep the
 remote shell quiet: any login banner printed to stdout can break stdio MCP.
-
-## Option C: Remote HTTP
-
-Use this when Zed's custom server UI requires a remote URL, or when you want a
-long-running MCP service on the remote host.
-
-Start the server on the remote host:
-
-```bash
-cd /home/david/workspace/github/livewyer-ops/scion-ops
-SCION_OPS_ROOT="$PWD" \
-SCION_OPS_MCP_TRANSPORT=streamable-http \
-SCION_OPS_MCP_HOST=127.0.0.1 \
-SCION_OPS_MCP_PORT=8765 \
-uv run mcp_servers/scion_ops.py
-```
-
-Tunnel it from your local machine:
-
-```bash
-ssh -N -L 8765:127.0.0.1:8765 user@remote-host
-```
-
-Then configure Zed locally:
-
-```json
-{
-  "context_servers": {
-    "scion-ops": {
-      "url": "http://127.0.0.1:8765/mcp"
-    }
-  }
-}
-```
-
-Do not expose this server directly to the public internet without an
-authenticated reverse proxy. The tools can start, stop, and inspect local
-Scion agents.
 
 ## Useful Prompts
 
@@ -137,12 +183,13 @@ blocker.
 - `scion_ops_verify` - run `task verify`.
 - `scion_ops_tail_round_log` - read `/tmp/scion-round.log`.
 
-## Local Smoke Test
+## Local Smoke Tests
 
 From the repo root:
 
 ```bash
 task mcp:smoke
+task mcp:http:smoke
 ```
 
 For interactive debugging:

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -716,12 +716,15 @@ def monitor_scion_round(round_id: str) -> str:
 
 def main() -> None:
     transport = os.environ.get("SCION_OPS_MCP_TRANSPORT", "stdio").strip().lower()
-    if transport in {"http", "streamable-http", "streamable_http"}:
-        mcp.run(transport="streamable-http")
+    try:
+        if transport in {"http", "streamable-http", "streamable_http"}:
+            mcp.run(transport="streamable-http")
+            return
+        if transport != "stdio":
+            raise SystemExit(f"unsupported SCION_OPS_MCP_TRANSPORT={transport!r}")
+        mcp.run(transport="stdio")
+    except KeyboardInterrupt:
         return
-    if transport != "stdio":
-        raise SystemExit(f"unsupported SCION_OPS_MCP_TRANSPORT={transport!r}")
-    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/scripts/smoke-mcp-server.py
+++ b/scripts/smoke-mcp-server.py
@@ -5,50 +5,169 @@
 #   "mcp>=1.13,<2",
 # ]
 # ///
-"""Smoke test the scion-ops MCP server over stdio."""
+"""Smoke test the scion-ops MCP server."""
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import os
 from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.client.stdio import stdio_client
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_URL = "http://127.0.0.1:8765/mcp"
+REQUIRED_TOOLS = {
+    "scion_ops_list_agents",
+    "scion_ops_round_status",
+    "scion_ops_round_events",
+    "scion_ops_watch_round_events",
+    "scion_ops_start_round",
+    "scion_ops_look",
+}
 
 
-async def main() -> None:
+def _text(result: object) -> str:
+    content = getattr(result, "content", [])
+    return "\n".join(part.text for part in content if hasattr(part, "text"))
+
+
+async def _exercise_session(session: ClientSession) -> set[str]:
+    await session.initialize()
+    tools = await session.list_tools()
+    names = {tool.name for tool in tools.tools}
+    missing = sorted(REQUIRED_TOOLS - names)
+    if missing:
+        raise SystemExit(f"missing tools: {', '.join(missing)}")
+
+    result = await session.call_tool("scion_ops_git_status", {})
+    agents = await session.call_tool("scion_ops_list_agents", {})
+    print(f"tools={len(names)}")
+    print(_text(result)[:1000])
+    print(_text(agents)[:1000])
+    return names
+
+
+async def _smoke_stdio() -> None:
+    env = os.environ.copy()
+    env["SCION_OPS_ROOT"] = str(ROOT)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
     params = StdioServerParameters(
         command="uv",
         args=["run", str(ROOT / "mcp_servers" / "scion_ops.py")],
-        env={"SCION_OPS_ROOT": str(ROOT)},
+        env=env,
     )
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
-            await session.initialize()
-            tools = await session.list_tools()
-            names = {tool.name for tool in tools.tools}
-            required = {
-                "scion_ops_list_agents",
-                "scion_ops_round_status",
-                "scion_ops_round_events",
-                "scion_ops_watch_round_events",
-                "scion_ops_start_round",
-                "scion_ops_look",
-            }
-            missing = sorted(required - names)
-            if missing:
-                raise SystemExit(f"missing tools: {', '.join(missing)}")
+            await _exercise_session(session)
 
-            result = await session.call_tool("scion_ops_git_status", {})
-            text = "\n".join(part.text for part in result.content if hasattr(part, "text"))
-            agents = await session.call_tool("scion_ops_list_agents", {})
-            agent_text = "\n".join(part.text for part in agents.content if hasattr(part, "text"))
-            print(f"tools={len(names)}")
-            print(text[:1000])
-            print(agent_text[:1000])
+
+async def _smoke_http(url: str) -> None:
+    async with streamablehttp_client(url, timeout=5, sse_read_timeout=30) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await _exercise_session(session)
+
+
+async def _start_http_server(host: str, port: int, path: str) -> asyncio.subprocess.Process:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SCION_OPS_ROOT": str(ROOT),
+            "SCION_OPS_MCP_TRANSPORT": "streamable-http",
+            "SCION_OPS_MCP_HOST": host,
+            "SCION_OPS_MCP_PORT": str(port),
+            "SCION_OPS_MCP_PATH": path,
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    return await asyncio.create_subprocess_exec(
+        "uv",
+        "run",
+        str(ROOT / "mcp_servers" / "scion_ops.py"),
+        cwd=ROOT,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=5)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+
+
+async def _wait_for_http(
+    url: str,
+    process: asyncio.subprocess.Process | None,
+    timeout_seconds: int,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    last_error = ""
+    while asyncio.get_running_loop().time() <= deadline:
+        if process and process.returncode is not None:
+            output = ""
+            if process.stdout:
+                output = (await process.stdout.read()).decode(errors="replace")
+            raise RuntimeError(f"HTTP MCP server exited early with {process.returncode}\n{output}")
+        try:
+            await _smoke_http(url)
+            return
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            await asyncio.sleep(0.5)
+    raise RuntimeError(f"HTTP MCP server was not ready at {url}: {last_error}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--transport", choices=("stdio", "http"), default="stdio")
+    parser.add_argument("--url", default=os.environ.get("SCION_OPS_MCP_URL", DEFAULT_URL))
+    parser.add_argument(
+        "--start-server",
+        action="store_true",
+        help="start a temporary HTTP server if the URL is unavailable",
+    )
+    parser.add_argument("--host", default=os.environ.get("SCION_OPS_MCP_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.environ.get("SCION_OPS_MCP_PORT", "8765")))
+    parser.add_argument("--path", default=os.environ.get("SCION_OPS_MCP_PATH", "/mcp"))
+    parser.add_argument("--startup-timeout", type=int, default=20)
+    return parser
+
+
+async def main() -> None:
+    args = _parser().parse_args()
+    if args.transport == "stdio":
+        print("transport=stdio")
+        await _smoke_stdio()
+        return
+
+    print("transport=http")
+    print(f"url={args.url}")
+    process = None
+    try:
+        if args.start_server:
+            try:
+                await _smoke_http(args.url)
+                return
+            except Exception:
+                pass
+            process = await _start_http_server(args.host, args.port, args.path)
+            await _wait_for_http(args.url, process, args.startup_timeout)
+        else:
+            await _smoke_http(args.url)
+    finally:
+        if process:
+            await _stop_process(process)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4.

## Summary
- add `task mcp:http` with documented host/port/path defaults for streamable HTTP MCP
- extend the MCP smoke script to test stdio or HTTP, including a temporary HTTP server when needed
- update Zed MCP docs to make HTTP the preferred Hub-mode path while keeping stdio/SSH documented
- keep MCP task runs from dirtying tracked bytecode artifacts

## Verification
- task mcp:smoke
- task mcp:http:smoke
- uv run scripts/smoke-mcp-server.py --transport http --url http://127.0.0.1:8765/mcp against a live `task mcp:http` server
- task verify
- git diff --check