### PR TITLE
Document kind control plane deployment path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+The following is the LiveWyer Cloud Native Operational Engineering Standards (CaNOES)
+
+## 5. Engineering Standards
+
+-  As a AI Agent you will *always* priorotise these standards
+- When you are about to implement something against these standards, prompt the user with a clear description of how it will break these standards and authorise the change. 
+- All non-standard design decisions are written to KNOWNISSUES.md
+
+* Whenever possible remove duplicated data entry, try to maintain a single source of truth
+* Minimise any requirements for local tool installation
+  - Use Dockerfile / docker builds to contain tool requirements
+* Technical elegance is preffered over shoe-horned solutions
+  - If you are constantly having to add forced solutions to problems AKA "going against the grain" then re-review the overall design and suggest a more aligned approach to ensure "elegance"
+* Where possible reuse the same tooling, standards, formats etc to minimise technical knowledge spread
+* Always approach a project as a product
+  - Consider the longterm maintainability as well as the day 0 "from nothing" experience of a new user
+  - Documentation and folder structures should be consistent 
+  - Reduce the spread of temporary or short term files in the codebase
+* Approach the work in a short, provable iterative loop
+  - Avoid making too much change at once without having a testing process for the changes you have made
+  - A git commit of your work is confirmation that we are hapy with the changes made and can focus on the next iterative cycle
+* See things from an operational, systems administrator, cloud native engineer persepctive first
+  - Then review things from an end user experience for simplicity
+* When interacting with code which has created infrastructure assets on a paid cloud account, ensure that any changes can still result in the successful deletion of said resources and nothing is left "orphaned"
+* When dealing with state driven code, confirm all destructive actions
+* Where possible we want the single source of truth to be applied and inhereted by resources, processess etc rather then duplicated in any way. 
+* Kubernetes "convergence" patterns are preferred to "one-shot" interactions
+* Try to avoid creating scripts to orchestrate actions and create minimise entry points which consist of 4 or less commands
+* Kubernetes resources are typically packaged with helm unless we have minimal templating requirements and all config can be placed in a signle file for kubectl apply
+* Any helm deployments from the console will be managed via a helmfile
+* Don't change component versions unless confirmed by user  Provide clear reason for version change
+* Do not manually create resources, unless temporarily testing something all resources must be applied via the codebase that is meant to apply them rather then hacking a quick fix, progress is measured in working code not immediate patches
+*  We start with the latest version of all software, components and dependencies and only revert back to old versions if we have a clear need to do so which is confirmed by the end user
+* DO NOT randomly apply self generated yaml or one-shoot fixes. The goal is for changes to be in the code base so we can recreate the environment from scratch
+* The goal is always to build an infrastructure software product that can be used by a third party with no assumptions. Not just a working target environment.
+ - If we cannot get to the current state using our codebase then we have failed our current task.
+ - This means patching resources with configuration and settings is *NOT ALLOWED* whereas patching to start a process (like reconciling) is.
+ - Configuration flow is important. Duplicate hardcoded configuration in our code should be replaced by a single source of truth which flows through by variables and inheritence.

--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -1,0 +1,24 @@
+# Known Issues
+
+Track intentional exceptions, unresolved risks, and design decisions that need
+revisit before they become hidden assumptions.
+
+## Kustomize-First kind Control Plane
+
+Issue: #15
+
+Decision: start the optional all-in-kind Scion control-plane deployment with
+native Kubernetes manifests and Kustomize, not Helm.
+
+Reason: the first implementation target is a local kind environment with a
+small resource set, minimal templating requirements, and an existing
+`kubectl apply -k deploy/kind` workflow. This keeps the day-zero path
+inspectable and avoids designing a chart values API before the resource model is
+proven.
+
+Constraint: if configuration expands beyond a small local overlay, or if we
+need install/upgrade lifecycle from the console, move to Helm managed through a
+helmfile rather than ad hoc `helm install` commands.
+
+Exit criteria: Kustomize remains acceptable only while the control-plane config
+can stay simple, native, and reproducible from this repo.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To advertise the kind Kubernetes runtime through the local broker, run
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `deploy/kind/` — native Kubernetes resources for the local kind runtime
+- `docs/kind-control-plane.md` — proposed Kustomize path for running Hub/Broker/MCP in kind
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow
 - `docs/testing-plan.md` — layer checks and end-to-end smoke workflow

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ resource model is proven.
 ## Layout
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
+- `CLAUDE.md` — agent guidance and project engineering standards
+- `KNOWNISSUES.md` — intentional exceptions and risks to revisit
 - `deploy/kind/` — native Kubernetes resources for the local kind runtime
 - `docs/kind-control-plane.md` — proposed Kustomize path for running Hub, broker, and MCP in kind
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow

--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ To advertise the kind Kubernetes runtime through the local broker, run
 `task broker:kind-configure`, then `task broker:kind-provide`. See
 `docs/kind-broker-runtime.md`.
 
+The current default deployment keeps Hub, broker, and MCP on the host while
+kind runs agent pods. The proposed all-in-kind control-plane path is documented
+in `docs/kind-control-plane.md` and should remain Kustomize-first until the
+resource model is proven.
+
 ## Layout
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `deploy/kind/` — native Kubernetes resources for the local kind runtime
-- `docs/kind-control-plane.md` — proposed Kustomize path for running Hub/Broker/MCP in kind
+- `docs/kind-control-plane.md` — proposed Kustomize path for running Hub, broker, and MCP in kind
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow
 - `docs/testing-plan.md` — layer checks and end-to-end smoke workflow

--- a/docs/kind-broker-runtime.md
+++ b/docs/kind-broker-runtime.md
@@ -1,11 +1,15 @@
 # kind Broker Runtime
 
-This wires the local workstation Runtime Broker to the kind-backed Kubernetes
-profile. The shape follows the upstream Scion model:
+This wires the host-managed workstation Runtime Broker to the kind-backed
+Kubernetes profile. The shape follows the upstream Scion model:
 
 - Hub is the control plane for groves, agents, templates, and broker routing.
 - Runtime Broker is the compute provider for a grove.
 - Kubernetes is selected by a Scion profile at agent dispatch time.
+
+This is the current default. A future all-in-kind path would run the broker
+inside kind as well; that design, persistence model, and constraints live in
+`docs/kind-control-plane.md`.
 
 References:
 
@@ -14,7 +18,7 @@ References:
 
 ## Prerequisites
 
-Start from the issue #1 and #2 workflows:
+Start from the local kind and host Hub workflows:
 
 ```bash
 task kind:up

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -1,5 +1,8 @@
 # kind Control Plane Deployment
 
+Status: design only. No Hub, broker, or MCP Kubernetes manifests are added by
+this document.
+
 This is the proposed path for running the Scion control plane inside the local
 kind cluster. The current default remains host-managed Hub, broker, and MCP
 with kind used only for agent pods.
@@ -23,6 +26,21 @@ host:
   subscription credentials
   optional restore/bootstrap scripts
 ```
+
+## Relationship To Existing Docs
+
+- `docs/kind-scion-runtime.md` documents the current kind substrate and agent
+  runtime resources.
+- `docs/local-hub-mode.md` documents the current host-managed Hub/Web/Broker
+  workflow.
+- `docs/kind-broker-runtime.md` documents the current host-managed broker
+  providing the `kind` Kubernetes profile.
+- `docs/zed-mcp.md` documents the current host/remote HTTP MCP registration
+  path; a kind-hosted MCP service should expose the same HTTP URL shape through
+  port-forwarding or controlled ingress.
+- `docs/testing-plan.md` documents the current end-to-end smoke; the all-in-kind
+  deployment should add a sibling smoke rather than overloading that default
+  until it is stable.
 
 ## Why Kustomize First
 

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -1,0 +1,134 @@
+# kind Control Plane Deployment
+
+This is the proposed path for running the Scion control plane inside the local
+kind cluster. The current default remains host-managed Hub, broker, and MCP
+with kind used only for agent pods.
+
+## Direction
+
+Use native Kubernetes resources managed by Kustomize first. Do not introduce a
+Helm chart until the resource model is proven and stable.
+
+The target shape is:
+
+```text
+kind cluster:
+  Scion Hub/API/Web
+  Runtime Broker
+  scion-ops HTTP MCP server
+  Scion agent pods
+
+host:
+  repo checkout
+  subscription credentials
+  optional restore/bootstrap scripts
+```
+
+## Why Kustomize First
+
+The repository already applies native Kubernetes resources from `deploy/kind`
+with:
+
+```bash
+kubectl --context kind-scion-ops apply -k deploy/kind
+```
+
+Kustomize keeps the local deployment inspectable with `kubectl`, avoids
+premature chart values/API design, and matches the existing project preference
+for native deployable resources. Helm can package the result later if we need a
+versioned install/upgrade interface.
+
+## Persistence Model
+
+Deleting and recreating the kind cluster deletes any state that lives only in
+cluster storage. An all-in-kind deployment needs an explicit persistence and
+restore model.
+
+| State | Required persistence | Notes |
+|---|---|---|
+| Hub database/state | PersistentVolumeClaim or external DB | Contains groves, agents, messages, broker registrations, templates, and Hub state. |
+| Hub signing/session material | Kubernetes Secret restored from host or sealed/external secret | Rotating this invalidates sessions/tokens. |
+| Broker credentials | Kubernetes Secret or re-register on bootstrap | Broker must keep or reacquire trust with Hub. |
+| Grove identity | Host repo `.scion/grove-id` plus Hub state | Recreating either side incorrectly can create duplicate grove identity. |
+| Subscription credentials | Kubernetes Secret sourced from host files or external secret store | Claude, Codex, and Gemini auth should not be baked into images. |
+| MCP workspace | HostPath mount for local kind or cloned persistent workspace | MCP tools need repo access for git/task/artifact inspection. |
+| Agent artifacts | Git pushes, explicit sync, or persistent workspace volume | Do not rely on ephemeral agent pod storage for useful work. |
+
+For local development, prefer restoring secrets/configuration from the host
+rather than treating kind as the durable source of truth.
+
+## Proposed Resource Layout
+
+Keep resources under `deploy/kind` so the current `task kind:up` path remains
+the single apply point:
+
+```text
+deploy/kind/
+  namespace.yaml
+  rbac.yaml
+  control-plane/
+    hub-deployment.yaml
+    hub-service.yaml
+    hub-pvc.yaml
+    broker-deployment.yaml
+    broker-rbac.yaml
+    mcp-deployment.yaml
+    mcp-service.yaml
+    kustomization.yaml
+  kustomization.yaml
+```
+
+The first implementation should add only resources that can be validated in the
+local kind cluster. Avoid placeholder manifests that are not applied by tests.
+
+## Networking
+
+Local kind control-plane services should start with ClusterIP services plus
+`kubectl port-forward` or a controlled localhost binding. Exposing Hub or MCP
+directly outside the machine should require an explicit follow-up with TLS and
+authentication.
+
+The MCP server should keep using HTTP transport. Zed can then connect through a
+port-forwarded localhost URL:
+
+```bash
+kubectl --context kind-scion-ops -n scion-agents port-forward svc/scion-ops-mcp 8765:8765
+```
+
+## Broker Constraints
+
+Containerizing the broker is the riskiest part. The broker needs enough access
+to create agent pods and manage their lifecycle, but should not receive host
+Podman socket access for this path. The first all-in-kind broker should support
+only the Kubernetes runtime.
+
+Key requirements:
+
+- in-cluster Kubernetes API access through a service account
+- namespace/RBAC for agent pods, `pods/exec`, `pods/log`, and secrets
+- mounted or restored broker credentials
+- image registry access for Scion agent images
+- stable workspace strategy for agents and MCP
+
+## Phased Implementation
+
+1. Add Kustomize resources for Hub and its persistent state.
+2. Add MCP deployment with repo/workspace access and HTTP service.
+3. Add broker deployment using in-cluster Kubernetes auth.
+4. Add bootstrap/restore tasks for secrets, grove identity, templates, and
+   broker provide.
+5. Extend `task smoke:e2e` or add a sibling smoke task that validates the
+   kind-hosted control plane.
+6. Consider Helm packaging only after the manifests pass local kind smoke tests
+   and the required values are clear.
+
+## Open Questions
+
+- Should local kind use hostPath volumes for Hub/MCP state, or PVCs with backup
+  and restore tasks?
+- Should the MCP workspace be a hostPath mount of this repo or a clone inside a
+  persistent volume?
+- Which Hub storage backend should be considered durable enough for local
+  recreation?
+- Should dev auth remain local-only, or should the in-kind path require a
+  production-style session/JWT secret from the start?

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -56,6 +56,14 @@ premature chart values/API design, and matches the existing project preference
 for native deployable resources. Helm can package the result later if we need a
 versioned install/upgrade interface.
 
+This is an intentional exception to the general project standard that
+Kubernetes resources are typically packaged with Helm. It is documented in
+`KNOWNISSUES.md` and remains valid only while the local kind control-plane
+configuration stays small, native, and reproducible from this repo.
+
+If the deployment needs a chart, console-applied Helm releases should be
+managed through a helmfile.
+
 ## Persistence Model
 
 Deleting and recreating the kind cluster deletes any state that lives only in

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -1,8 +1,9 @@
 # Local kind Runtime
 
-This project uses `kind` as the local Kubernetes target for Scion runtime
-testing. This is the substrate for later Hub/Broker work: issue #1 only creates
-the cluster, namespace, RBAC, and image-loading path.
+This project uses `kind` as the local Kubernetes target for Scion agent runtime
+testing. In the current default workflow, kind runs agent pods while Hub,
+broker, and MCP stay on the host. The proposed all-in-kind control-plane path
+is documented separately in `docs/kind-control-plane.md`.
 
 ## Responsibility Split
 
@@ -11,6 +12,10 @@ with a Kubernetes runtime, Scion creates and manages agent runtime objects such
 as pods and secrets in the configured namespace. This project is responsible for
 the local setup around that runtime: the kind cluster, namespace, and minimum
 RBAC needed by Scion.
+
+These manifests are intentionally native Kustomize resources. Do not move this
+path to Helm unless the kind control-plane resource model has stabilized and we
+need packaged install/upgrade behavior.
 
 Those Kubernetes resources live in `deploy/kind` and are directly deployable:
 
@@ -125,8 +130,9 @@ podman save localhost/scion-claude:latest -o /tmp/scion-claude.tar
 task kind:load-archive -- /tmp/scion-claude.tar
 ```
 
-For repeated local development, a local registry can replace `kind load`, but
-that should be introduced with the broker/runtime issue if we need it.
+For repeated local development, a local registry can replace `kind load`. If
+the all-in-kind control plane adopts a registry, document it in
+`docs/kind-control-plane.md` as part of the persistence/bootstrap model.
 
 ## Cleanup
 

--- a/docs/local-hub-mode.md
+++ b/docs/local-hub-mode.md
@@ -8,8 +8,10 @@ mode a single local Scion server runs:
 - Runtime Broker: execution plane for creating and managing agents.
 - Web Frontend: browser dashboard for the same Hub state.
 
-For issue #2, the broker remains the co-located workstation broker. Moving the
-execution plane onto the kind Kubernetes runtime is a follow-up task.
+This is the current default for local development. It keeps Hub, broker, and
+MCP host-managed while kind runs agent pods through the Kubernetes runtime
+profile. The proposed all-in-kind alternative is documented in
+`docs/kind-control-plane.md` and is not the default path yet.
 
 ## Defaults
 
@@ -90,6 +92,10 @@ task hub:down
 
 Stopping the workstation server also stops the co-located Runtime Broker. Agents
 managed by that broker are no longer reachable until the server is restarted.
+
+If the all-in-kind control plane is enabled later, lifecycle and persistence
+checks should move to `kubectl` and the Kustomize resources described in
+`docs/kind-control-plane.md`.
 
 ## Local-Only Escape Hatch
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -3,6 +3,11 @@
 Use the narrow checks while changing one layer, and `task smoke:e2e` before
 trusting the full local Hub-mode stack.
 
+This plan covers the current default: host-managed Hub, broker, and MCP with
+kind used as the Kubernetes agent runtime. The proposed all-in-kind control
+plane is documented in `docs/kind-control-plane.md`; it should get its own
+smoke task once the Kustomize resources are implemented.
+
 ## Layer Checks
 
 Host and Scion CLI:
@@ -41,6 +46,10 @@ HTTP MCP transport and Hub-backed tool surface:
 ```bash
 task mcp:http:smoke
 ```
+
+For the future all-in-kind path, these checks should be mirrored with
+`kubectl apply -k`, service readiness, port-forwarded MCP access, and a
+kind-hosted broker dispatch.
 
 ## End-To-End Smoke
 

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -9,6 +9,11 @@ For Hub mode, prefer streamable HTTP. It keeps one long-lived MCP service
 attached to the `scion-ops` workspace and lets Zed, Claude, Codex, or a tunnel
 connect by URL.
 
+The examples below assume the current default deployment: Hub, broker, and MCP
+run on the host or remote host that owns the workspace. If MCP later runs inside
+kind, use the same Zed URL shape but expose it through the service/port-forward
+described in `docs/kind-control-plane.md`.
+
 ## Choose A Mode
 
 | Mode | Zed config | Who starts the MCP server | Best fit |
@@ -18,6 +23,7 @@ connect by URL.
 | Remote HTTP URL | `url` | Remote supervisor starts MCP behind network controls | Shared or always-on remote setup |
 | Local stdio | `command` and `args` | Zed launches `uv run .../scion_ops.py` | Everything runs on one machine |
 | SSH stdio | `command` and `args` running `ssh` | Zed launches local `ssh`; SSH launches remote MCP | No long-lived HTTP service |
+| kind-hosted HTTP URL | `url` | Kubernetes runs MCP; user starts port-forward or ingress | Proposed all-in-kind path |
 
 In all modes, the external agent does not independently discover or start this
 MCP server. Zed reads `context_servers`, connects to the configured MCP server,
@@ -130,6 +136,10 @@ task mcp:http:smoke
 The smoke task connects to the configured URL first. If no MCP server responds,
 it starts a temporary local server, lists tools, calls Hub status and agent
 listing, then shuts it down.
+
+For a future kind-hosted MCP deployment, keep Zed configured with a URL but
+point it at the forwarded service endpoint, for example
+`http://127.0.0.1:8765/mcp`.
 
 ## Remote HTTP By SSH Tunnel
 


### PR DESCRIPTION
Refs #15

## Summary
- document the Kustomize-first direction for running Scion Hub/API/Web, Runtime Broker, MCP, and agents inside kind
- capture the persistence model for deleting/recreating kind: Hub state, signing/session material, broker credentials, grove identity, subscription credentials, MCP workspace, and agent artifacts
- define the proposed native-manifest layout under deploy/kind without adding unvalidated placeholder YAML
- align README, kind runtime, broker runtime, local Hub, Zed MCP, and testing docs so the current host-managed default and future all-in-kind path are both explicit
- call out networking, broker constraints, phased implementation, and open questions before we implement manifests

## Verification
- git diff --check