### PR TITLE
Add kind Hub control plane resources

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -22,3 +22,21 @@ helmfile rather than ad hoc `helm install` commands.
 
 Exit criteria: Kustomize remains acceptable only while the control-plane config
 can stay simple, native, and reproducible from this repo.
+
+## kind Hub Dev Auth
+
+Issue: #15
+
+Decision: the first in-kind Hub slice runs `scion server start` with explicit
+Hub/Web components and dev auth enabled.
+
+Reason: `--production` prevents workstation defaults from starting extra
+components, while `--dev-auth` keeps the local kind Hub usable before OAuth,
+broker credentials, and secret restore are implemented.
+
+Constraint: this is local-development only. The web session secret is
+auto-generated on pod start, so browser sessions do not survive Hub pod
+restarts.
+
+Exit criteria: replace dev-only auth/session behavior with Kubernetes Secret
+restore before using the kind control plane outside local testing.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ To advertise the kind Kubernetes runtime through the local broker, run
 The current default deployment keeps Hub, broker, and MCP on the host while
 kind runs agent pods. The proposed all-in-kind control-plane path is documented
 in `docs/kind-control-plane.md` and should remain Kustomize-first until the
-resource model is proven.
+resource model is proven. The first experimental Hub-only kind slice is applied
+separately with `task kind:hub:apply` and verified with `task kind:hub:status`.
 
 ## Layout
 
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `CLAUDE.md` — agent guidance and project engineering standards
 - `KNOWNISSUES.md` — intentional exceptions and risks to revisit
-- `deploy/kind/` — native Kubernetes resources for the local kind runtime
+- `deploy/kind/` — native Kubernetes resources for the local kind runtime and experimental Hub control plane
 - `docs/kind-control-plane.md` — proposed Kustomize path for running Hub, broker, and MCP in kind
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,23 @@ tasks:
     cmds:
       - bash scripts/kind-scion-runtime.sh configure-scion
 
+  kind:hub:apply:
+    desc: Apply the experimental Hub-only kind control-plane resources.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' apply -f deploy/kind/namespace.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' apply -k deploy/kind/control-plane
+
+  kind:hub:status:
+    desc: Wait for the experimental kind Hub rollout and show its resources.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc,pvc,cm -l app.kubernetes.io/part-of=scion-control-plane
+
+  kind:hub:logs:
+    desc: Follow logs from the experimental kind Hub deployment.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub
+
   kind:doctor:
     desc: Run Scion diagnostics against the local kind runtime profile.
     cmds:

--- a/deploy/kind/control-plane/hub-config.yaml
+++ b/deploy/kind/control-plane/hub-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scion-hub-settings
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: hub
+    app.kubernetes.io/part-of: scion-control-plane
+data:
+  settings.yaml: |
+    schema_version: "1"
+    image_registry: localhost

--- a/deploy/kind/control-plane/hub-deployment.yaml
+++ b/deploy/kind/control-plane/hub-deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scion-hub
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: hub
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scion-hub
+      app.kubernetes.io/component: hub
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: scion-hub
+        app.kubernetes.io/component: hub
+        app.kubernetes.io/part-of: scion-control-plane
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: hub
+          image: localhost/scion-base:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - scion
+          env:
+            - name: HOME
+              value: /home/scion
+            - name: USER
+              value: scion
+            - name: LOGNAME
+              value: scion
+          args:
+            - --global
+            - server
+            - start
+            - --foreground
+            - --production
+            - --enable-hub
+            - --enable-web
+            - --dev-auth
+            - --host
+            - 0.0.0.0
+            - --web-port
+            - "8090"
+            - --db
+            - /home/scion/.scion/hub.db
+            - --storage-dir
+            - /home/scion/.scion/storage
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          ports:
+            - name: http
+              containerPort: 8090
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          volumeMounts:
+            - name: state
+              mountPath: /home/scion/.scion
+            - name: settings
+              mountPath: /home/scion/.scion/settings.yaml
+              subPath: settings.yaml
+              readOnly: true
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: scion-hub-state
+        - name: settings
+          configMap:
+            name: scion-hub-settings

--- a/deploy/kind/control-plane/hub-pvc.yaml
+++ b/deploy/kind/control-plane/hub-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scion-hub-state
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: hub
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kind/control-plane/hub-service.yaml
+++ b/deploy/kind/control-plane/hub-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scion-hub
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: hub
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: hub
+  ports:
+    - name: http
+      port: 8090
+      targetPort: http

--- a/deploy/kind/control-plane/kustomization.yaml
+++ b/deploy/kind/control-plane/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: scion-agents
+resources:
+  - hub-config.yaml
+  - hub-pvc.yaml
+  - hub-service.yaml
+  - hub-deployment.yaml

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -1,11 +1,11 @@
 # kind Control Plane Deployment
 
-Status: design only. No Hub, broker, or MCP Kubernetes manifests are added by
-this document.
+Status: first Hub-only slice implemented. Broker and MCP Kubernetes resources
+are still pending.
 
-This is the proposed path for running the Scion control plane inside the local
-kind cluster. The current default remains host-managed Hub, broker, and MCP
-with kind used only for agent pods.
+This is the path for running the Scion control plane inside the local kind
+cluster. The current default remains host-managed Hub, broker, and MCP with kind
+used only for agent pods.
 
 ## Direction
 
@@ -26,6 +26,56 @@ host:
   subscription credentials
   optional restore/bootstrap scripts
 ```
+
+## Implemented Hub Slice
+
+The first slice adds a separate Kustomize target under
+`deploy/kind/control-plane` for a Hub/Web process only. It is not included by
+`task kind:up`, so the existing host-managed Hub workflow stays the default.
+
+Resources:
+
+- `deploy/kind/control-plane/hub-deployment.yaml`
+- `deploy/kind/control-plane/hub-config.yaml`
+- `deploy/kind/control-plane/hub-service.yaml`
+- `deploy/kind/control-plane/hub-pvc.yaml`
+
+Apply and verify:
+
+```bash
+task kind:up
+task kind:load-images -- localhost/scion-base:latest
+task kind:hub:apply
+task kind:hub:status
+```
+
+If `localhost/scion-base:latest` has not been built locally, build it first
+with `task images:build` and then load it into kind.
+
+To inspect the Hub HTTP endpoint from the host, use a local-only port-forward:
+
+```bash
+kubectl --context kind-scion-ops -n scion-agents port-forward svc/scion-hub 18090:8090
+curl http://127.0.0.1:18090/healthz
+```
+
+The Service is ClusterIP-only. There is no host port binding unless the
+port-forward is running.
+
+The Hub stores its mutable global Scion directory, SQLite database, dev token,
+templates, and local storage directory on the `scion-hub-state` PVC. The
+minimal `settings.yaml` comes from the `scion-hub-settings` ConfigMap so the
+required `image_registry: localhost` setting is reproducible from this repo.
+Deleting the kind cluster deletes the PVC-backed state.
+
+This first slice intentionally runs `scion --global server start` in explicit
+component mode with `--production --enable-hub --enable-web --dev-auth`:
+production mode prevents workstation defaults from starting the broker
+automatically, while dev auth keeps the local kind deployment usable without
+OAuth setup. The Deployment overrides the `scion-base` agent entrypoint and
+runs the Hub process directly as UID/GID 1000 because `sciontool init` is for
+agent containers. The web session secret is still auto-generated per pod start
+and is not production-ready.
 
 ## Relationship To Existing Docs
 
@@ -83,10 +133,11 @@ restore model.
 For local development, prefer restoring secrets/configuration from the host
 rather than treating kind as the durable source of truth.
 
-## Proposed Resource Layout
+## Resource Layout
 
-Keep resources under `deploy/kind` so the current `task kind:up` path remains
-the single apply point:
+Keep resources under `deploy/kind`. The experimental control-plane target is
+separate from the current `task kind:up` target until the full all-in-kind path
+has passed smoke tests:
 
 ```text
 deploy/kind/
@@ -104,8 +155,8 @@ deploy/kind/
   kustomization.yaml
 ```
 
-The first implementation should add only resources that can be validated in the
-local kind cluster. Avoid placeholder manifests that are not applied by tests.
+The first implementation adds only the Hub resources. Avoid placeholder
+manifests that are not applied by tests.
 
 ## Networking
 
@@ -138,7 +189,8 @@ Key requirements:
 
 ## Phased Implementation
 
-1. Add Kustomize resources for Hub and its persistent state.
+1. Add Kustomize resources for Hub and its persistent state. Done for the
+   Hub-only slice.
 2. Add MCP deployment with repo/workspace access and HTTP service.
 3. Add broker deployment using in-cluster Kubernetes auth.
 4. Add bootstrap/restore tasks for secrets, grove identity, templates, and
@@ -156,5 +208,5 @@ Key requirements:
   persistent volume?
 - Which Hub storage backend should be considered durable enough for local
   recreation?
-- Should dev auth remain local-only, or should the in-kind path require a
-  production-style session/JWT secret from the start?
+- How should the in-kind path restore a stable session/JWT secret before it is
+  used beyond local development?


### PR DESCRIPTION
## Summary
- add a separate Kustomize target for an experimental Hub/Web Deployment in kind
- add ClusterIP Service, PVC-backed state, and ConfigMap-backed minimal settings
- add Taskfile commands and docs for applying, checking, logging, and health inspection

## Verification
- kubectl kustomize deploy/kind/control-plane
- kubectl --context kind-scion-ops apply -k deploy/kind/control-plane
- task kind:hub:status
- kubectl --context kind-scion-ops -n scion-agents port-forward svc/scion-hub 18090:8090
- curl -fsSL http://127.0.0.1:18090/healthz

Part of #15.