### PR TITLE
Add kind control plane aggregate tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The current default deployment keeps Hub, broker, and MCP on the host while
 kind runs agent pods. The proposed all-in-kind control-plane path is documented
 in `docs/kind-control-plane.md` and should remain Kustomize-first until the
 resource model is proven. The first experimental Hub-only kind slice is applied
-separately with `task kind:hub:apply` and verified with `task kind:hub:status`.
+separately with `task kind:control-plane:apply` and verified with
+`task kind:control-plane:status`.
 
 ## Layout
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,27 @@ tasks:
     cmds:
       - bash scripts/kind-scion-runtime.sh configure-scion
 
+  kind:control-plane:apply:
+    desc: Apply the experimental kind control-plane resources.
+    cmds:
+      - task: kind:hub:apply
+
+  kind:control-plane:status:
+    desc: Show status for the experimental kind control plane.
+    cmds:
+      - task: kind:hub:status
+
+  kind:control-plane:logs:
+    desc: Follow logs from the experimental kind control plane.
+    cmds:
+      - task: kind:hub:logs
+
+  kind:control-plane:delete:
+    desc: Delete the experimental kind control-plane resources.
+    prompt: This deletes experimental kind control-plane resources from {{.KIND_CONTEXT}}. Continue?
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' delete -k deploy/kind/control-plane --ignore-not-found=true
+
   kind:hub:apply:
     desc: Apply the experimental Hub-only kind control-plane resources.
     cmds:

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -45,12 +45,20 @@ Apply and verify:
 ```bash
 task kind:up
 task kind:load-images -- localhost/scion-base:latest
-task kind:hub:apply
-task kind:hub:status
+task kind:control-plane:apply
+task kind:control-plane:status
 ```
 
 If `localhost/scion-base:latest` has not been built locally, build it first
 with `task images:build` and then load it into kind.
+
+The Hub-specific task names remain available as narrow aliases:
+
+```bash
+task kind:hub:apply
+task kind:hub:status
+task kind:hub:logs
+```
 
 To inspect the Hub HTTP endpoint from the host, use a local-only port-forward:
 
@@ -61,6 +69,15 @@ curl http://127.0.0.1:18090/healthz
 
 The Service is ClusterIP-only. There is no host port binding unless the
 port-forward is running.
+
+Remove the experimental control-plane resources with:
+
+```bash
+task kind:control-plane:delete
+```
+
+This deletes resources from `deploy/kind/control-plane`. It does not delete the
+kind cluster or the base agent-runtime resources from `deploy/kind`.
 
 The Hub stores its mutable global Scion directory, SQLite database, dev token,
 templates, and local storage directory on the `scion-hub-state` PVC. The


### PR DESCRIPTION
## Summary
- add aggregate kind control-plane apply/status/log/delete tasks for the experimental all-in-kind path
- keep Hub-specific task names as narrow aliases while future MCP/broker resources are added
- update docs to use the aggregate apply/status commands and document teardown

## Verification
- task --list | rg 'kind:control-plane|kind:hub'
- git diff --check
- task kind:control-plane:apply
- task kind:control-plane:status

Part of #15.