### PR TITLE
Add kind workspace mount substrate

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -40,3 +40,23 @@ restarts.
 
 Exit criteria: replace dev-only auth/session behavior with Kubernetes Secret
 restore before using the kind control plane outside local testing.
+
+## kind MCP Workspace HostPath
+
+Issue: #15
+
+Decision: local kind clusters mount the host `scion-ops` checkout into the kind
+node with a kind `extraMount`, so a future MCP pod can mount that node path with
+Kubernetes `hostPath`.
+
+Reason: the MCP server needs live repo access for git, task, Scion, and
+artifact inspection. In kind, pod `hostPath` volumes see the node container
+filesystem, so the host checkout must be mounted into the node before any MCP
+Deployment can use it.
+
+Constraint: this is local-kind only and is not an agent workspace pattern. Do
+not use workstation bind mounts for non-kind clusters or for Scion agent
+runtime pods.
+
+Exit criteria: for non-local clusters, replace this with a cloned workspace or
+persistent workspace volume managed by explicit bootstrap/restore tasks.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ kind runs agent pods. The proposed all-in-kind control-plane path is documented
 in `docs/kind-control-plane.md` and should remain Kustomize-first until the
 resource model is proven. The first experimental Hub-only kind slice is applied
 separately with `task kind:control-plane:apply` and verified with
-`task kind:control-plane:status`.
+`task kind:control-plane:status`. New kind clusters also mount this repo into
+the kind node for the future MCP Deployment; verify that substrate with
+`task kind:workspace:status`.
 
 ## Layout
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,6 +75,11 @@ tasks:
     cmds:
       - bash scripts/kind-scion-runtime.sh status
 
+  kind:workspace:status:
+    desc: Verify the kind node can see this repo for future MCP hostPath mounts.
+    cmds:
+      - bash scripts/kind-scion-runtime.sh workspace-status
+
   kind:load-images:
     desc: 'Load local images into kind. Usage: task kind:load-images -- localhost/scion-claude:latest'
     cmds:

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -1,7 +1,8 @@
 # kind Control Plane Deployment
 
-Status: first Hub-only slice implemented. Broker and MCP Kubernetes resources
-are still pending.
+Status: first Hub-only slice implemented. The local kind workspace mount
+substrate for a future MCP Deployment is in place. Broker and MCP Kubernetes
+resources are still pending.
 
 This is the path for running the Scion control plane inside the local kind
 cluster. The current default remains host-managed Hub, broker, and MCP with kind
@@ -44,6 +45,7 @@ Apply and verify:
 
 ```bash
 task kind:up
+task kind:workspace:status
 task kind:load-images -- localhost/scion-base:latest
 task kind:control-plane:apply
 task kind:control-plane:status
@@ -93,6 +95,37 @@ OAuth setup. The Deployment overrides the `scion-base` agent entrypoint and
 runs the Hub process directly as UID/GID 1000 because `sciontool init` is for
 agent containers. The web session secret is still auto-generated per pod start
 and is not production-ready.
+
+## MCP Workspace Mount Substrate
+
+The MCP server needs a live `scion-ops` workspace for git, task, Scion, and
+artifact inspection. In kind, a pod `hostPath` volume sees the kind node
+filesystem, not the developer workstation filesystem directly. For local kind
+clusters, `task kind:up` now creates the cluster with a kind `extraMount`:
+
+| Side | Default path |
+|---|---|
+| Host checkout | repo root |
+| kind node | `/workspace/scion-ops` |
+
+The future MCP Deployment can mount the node path as a Kubernetes `hostPath`.
+This is intentionally limited to local kind. For non-kind clusters, use a
+cloned workspace or persistent workspace volume instead of a workstation bind
+mount.
+
+Existing kind clusters cannot be updated with new `extraMounts`. Verify the
+substrate before deploying MCP resources:
+
+```bash
+task kind:workspace:status
+```
+
+If the mount is missing, recreate only the local kind cluster:
+
+```bash
+task kind:down
+task kind:up
+```
 
 ## Relationship To Existing Docs
 
@@ -144,7 +177,7 @@ restore model.
 | Broker credentials | Kubernetes Secret or re-register on bootstrap | Broker must keep or reacquire trust with Hub. |
 | Grove identity | Host repo `.scion/grove-id` plus Hub state | Recreating either side incorrectly can create duplicate grove identity. |
 | Subscription credentials | Kubernetes Secret sourced from host files or external secret store | Claude, Codex, and Gemini auth should not be baked into images. |
-| MCP workspace | HostPath mount for local kind or cloned persistent workspace | MCP tools need repo access for git/task/artifact inspection. |
+| MCP workspace | HostPath mount through the kind node for local kind, or cloned persistent workspace outside kind | MCP tools need repo access for git/task/artifact inspection. |
 | Agent artifacts | Git pushes, explicit sync, or persistent workspace volume | Do not rely on ephemeral agent pod storage for useful work. |
 
 For local development, prefer restoring secrets/configuration from the host
@@ -172,8 +205,9 @@ deploy/kind/
   kustomization.yaml
 ```
 
-The first implementation adds only the Hub resources. Avoid placeholder
-manifests that are not applied by tests.
+The first resource implementation adds only the Hub resources. The workspace
+mount substrate is part of kind cluster creation, not a Kubernetes manifest.
+Avoid placeholder manifests that are not applied by tests.
 
 ## Networking
 
@@ -208,21 +242,22 @@ Key requirements:
 
 1. Add Kustomize resources for Hub and its persistent state. Done for the
    Hub-only slice.
-2. Add MCP deployment with repo/workspace access and HTTP service.
-3. Add broker deployment using in-cluster Kubernetes auth.
-4. Add bootstrap/restore tasks for secrets, grove identity, templates, and
+2. Add local kind workspace mount substrate for MCP repo access. Done.
+3. Add MCP deployment with repo/workspace access and HTTP service.
+4. Add broker deployment using in-cluster Kubernetes auth.
+5. Add bootstrap/restore tasks for secrets, grove identity, templates, and
    broker provide.
-5. Extend `task smoke:e2e` or add a sibling smoke task that validates the
+6. Extend `task smoke:e2e` or add a sibling smoke task that validates the
    kind-hosted control plane.
-6. Consider Helm packaging only after the manifests pass local kind smoke tests
+7. Consider Helm packaging only after the manifests pass local kind smoke tests
    and the required values are clear.
 
 ## Open Questions
 
 - Should local kind use hostPath volumes for Hub/MCP state, or PVCs with backup
   and restore tasks?
-- Should the MCP workspace be a hostPath mount of this repo or a clone inside a
-  persistent volume?
+- Outside local kind, should the MCP workspace be a clone inside a persistent
+  volume or restored through another workspace bootstrap path?
 - Which Hub storage backend should be considered durable enough for local
   recreation?
 - How should the in-kind path restore a stable session/JWT secret before it is

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -37,6 +37,8 @@ kustomization. The helper script should not contain embedded Kubernetes YAML.
 | Scion profile | `kind` |
 | Scion runtime | `kubernetes` |
 | image registry | `localhost` |
+| workspace host path | current repo checkout |
+| workspace node path | `/workspace/scion-ops` |
 
 Override the cluster name with an environment variable:
 
@@ -64,10 +66,26 @@ The task is idempotent. It creates the cluster if missing, reuses it if present,
 applies the `deploy/kind` Kubernetes resources, and sets the kind context
 namespace.
 
+New clusters are created with a kind `extraMount` that exposes this repo inside
+the kind control-plane node at `/workspace/scion-ops`. That node path is the
+substrate a future kind-hosted MCP Deployment can mount with a Kubernetes
+`hostPath` volume. Existing kind clusters cannot be mutated to add this mount;
+if `task kind:workspace:status` reports it missing, recreate the cluster with
+`task kind:down && task kind:up`.
+
+Override the mount paths when needed:
+
+```bash
+SCION_OPS_WORKSPACE_HOST_PATH=/home/david/workspace/github/livewyer-ops/scion-ops \
+SCION_OPS_WORKSPACE_NODE_PATH=/workspace/scion-ops \
+task kind:up
+```
+
 Check the result:
 
 ```bash
 task kind:status
+task kind:workspace:status
 kubectl --context kind-scion-ops get pods -n scion-agents
 ```
 

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -2,15 +2,17 @@
 # Manage the local kind cluster used for Scion Kubernetes runtime testing.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CLUSTER_NAME="${KIND_CLUSTER_NAME:-scion-ops}"
 NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
 SERVICE_ACCOUNT="${SCION_K8S_SERVICE_ACCOUNT:-scion-agent-manager}"
 PROFILE_NAME="${SCION_K8S_PROFILE:-kind}"
 RUNTIME_NAME="${SCION_K8S_RUNTIME:-kubernetes}"
 IMAGE_REGISTRY="${SCION_IMAGE_REGISTRY:-localhost}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 MANIFEST_DIR="${SCION_K8S_MANIFEST_DIR:-${REPO_ROOT}/deploy/kind}"
+WORKSPACE_HOST_PATH="${SCION_OPS_WORKSPACE_HOST_PATH:-$REPO_ROOT}"
+WORKSPACE_NODE_PATH="${SCION_OPS_WORKSPACE_NODE_PATH:-/workspace/scion-ops}"
 CONTEXT="kind-${CLUSTER_NAME}"
 
 usage() {
@@ -21,6 +23,7 @@ Commands:
   up                  Create/reuse the kind cluster and apply deploy/kind.
   down                Delete the kind cluster.
   status              Show cluster, namespace, RBAC, and node status.
+  workspace-status    Verify the kind node can see the scion-ops workspace.
   load-images IMAGE   Load one or more local images into the kind nodes.
   load-archive FILE   Load one or more image archives into the kind nodes.
   configure-scion     Configure global Scion profile "kind" for this cluster.
@@ -33,6 +36,10 @@ Environment:
   SCION_K8S_PROFILE          Scion profile name (default: kind)
   SCION_K8S_RUNTIME          Scion runtime name (default: kubernetes)
   SCION_IMAGE_REGISTRY       Agent image registry/prefix (default: localhost)
+  SCION_OPS_WORKSPACE_HOST_PATH  Host scion-ops checkout mounted into kind
+                                 (default: this repo)
+  SCION_OPS_WORKSPACE_NODE_PATH  Node path used by future MCP hostPath mounts
+                                 (default: /workspace/scion-ops)
 EOF
 }
 
@@ -57,15 +64,85 @@ kubectl_ctx() {
   kubectl --context "$CONTEXT" "$@"
 }
 
+ensure_workspace_host_path() {
+  [[ "$WORKSPACE_HOST_PATH" = /* ]] || die "SCION_OPS_WORKSPACE_HOST_PATH must be an absolute path: $WORKSPACE_HOST_PATH"
+  [[ "$WORKSPACE_NODE_PATH" = /* ]] || die "SCION_OPS_WORKSPACE_NODE_PATH must be an absolute path: $WORKSPACE_NODE_PATH"
+  [[ -d "$WORKSPACE_HOST_PATH" ]] || die "workspace host path not found: $WORKSPACE_HOST_PATH"
+  [[ -f "${WORKSPACE_HOST_PATH}/Taskfile.yml" ]] || die "workspace host path does not look like scion-ops: $WORKSPACE_HOST_PATH"
+}
+
+create_cluster_config() {
+  local config
+  config="$(mktemp)"
+  cat > "$config" <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: ${WORKSPACE_HOST_PATH}
+    containerPath: ${WORKSPACE_NODE_PATH}
+EOF
+  printf '%s\n' "$config"
+}
+
+kind_node_name() {
+  kind get nodes --name "$CLUSTER_NAME" 2>/dev/null | head -n 1
+}
+
+container_runtime_for_node() {
+  local node="$1"
+  local runtime
+
+  for runtime in docker podman; do
+    if command -v "$runtime" >/dev/null 2>&1 && "$runtime" container inspect "$node" >/dev/null 2>&1; then
+      printf '%s\n' "$runtime"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+workspace_mount_present() {
+  local node
+  local runtime
+
+  node="$(kind_node_name)"
+  [[ -n "$node" ]] || return 1
+  runtime="$(container_runtime_for_node "$node")" || return 1
+
+  "$runtime" exec "$node" test -f "${WORKSPACE_NODE_PATH}/Taskfile.yml" &&
+    "$runtime" exec "$node" test -d "${WORKSPACE_NODE_PATH}/.git"
+}
+
+warn_missing_workspace_mount() {
+  cat >&2 <<EOF
+Warning: workspace mount is not available inside kind node ${WORKSPACE_NODE_PATH}.
+Existing kind clusters cannot be updated with new extraMounts. Recreate this
+cluster with 'task kind:down && task kind:up' before deploying a kind-hosted MCP.
+EOF
+}
+
 ensure_cluster() {
   require kind
   if cluster_exists; then
     log "reuse kind cluster $CLUSTER_NAME"
+    if ! workspace_mount_present; then
+      warn_missing_workspace_mount
+    fi
     return
   fi
 
+  ensure_workspace_host_path
   log "create kind cluster $CLUSTER_NAME"
-  kind create cluster --name "$CLUSTER_NAME"
+  local config
+  config="$(create_cluster_config)"
+  if ! kind create cluster --name "$CLUSTER_NAME" --config "$config"; then
+    rm -f "$config"
+    return 1
+  fi
+  rm -f "$config"
 }
 
 apply_manifests() {
@@ -94,6 +171,7 @@ kind cluster ready
 
 Next:
   task kind:configure-scion
+  task kind:workspace:status
   task kind:doctor
 EOF
 }
@@ -114,7 +192,9 @@ cmd_status() {
 
   printf 'cluster:   %s\n' "$CLUSTER_NAME"
   printf 'context:   %s\n' "$CONTEXT"
-  printf 'namespace: %s\n\n' "$NAMESPACE"
+  printf 'namespace: %s\n' "$NAMESPACE"
+  printf 'workspace host: %s\n' "$WORKSPACE_HOST_PATH"
+  printf 'workspace node: %s\n\n' "$WORKSPACE_NODE_PATH"
 
   if ! cluster_exists; then
     die "kind cluster $CLUSTER_NAME does not exist"
@@ -125,6 +205,32 @@ cmd_status() {
   kubectl_ctx get namespace "$NAMESPACE"
   printf '\n'
   kubectl_ctx get serviceaccount,role,rolebinding -n "$NAMESPACE" | grep -E "NAME|${SERVICE_ACCOUNT}|scion-agent-manager"
+  printf '\n\n'
+  if workspace_mount_present; then
+    printf 'workspace mount: ok\n'
+  else
+    printf 'workspace mount: unavailable; run task kind:workspace:status for details\n'
+  fi
+}
+
+cmd_workspace_status() {
+  require kind
+
+  printf 'cluster:        %s\n' "$CLUSTER_NAME"
+  printf 'workspace host: %s\n' "$WORKSPACE_HOST_PATH"
+  printf 'workspace node: %s\n\n' "$WORKSPACE_NODE_PATH"
+
+  if ! cluster_exists; then
+    die "kind cluster $CLUSTER_NAME does not exist; run: task kind:up"
+  fi
+
+  if workspace_mount_present; then
+    printf 'workspace mount: ok\n'
+    return
+  fi
+
+  warn_missing_workspace_mount
+  return 1
 }
 
 cmd_load_images() {
@@ -201,6 +307,10 @@ case "${1:-}" in
   status)
     shift
     cmd_status "$@"
+    ;;
+  workspace-status)
+    shift
+    cmd_workspace_status "$@"
     ;;
   load-images)
     shift


### PR DESCRIPTION
Closes #19
Refs #15

## Summary
- create new kind clusters with the scion-ops repo mounted into the kind node for future MCP hostPath use
- add `task kind:workspace:status` and surface missing mounts for pre-existing clusters
- document the local-kind-only hostPath exception and recreate path

## Verification
- `bash -n scripts/kind-scion-runtime.sh`
- `task --list | rg 'kind:(workspace|up|status)'`\n- `git diff --check`\n- `task kind:workspace:status` on the existing pre-change cluster reports the expected missing-mount warning\n- `KIND_CLUSTER_NAME=scion-ops-mount-test task kind:up`\n- `KIND_CLUSTER_NAME=scion-ops-mount-test task kind:workspace:status`\n- `KIND_CLUSTER_NAME=scion-ops-mount-test task kind:status`\n- `kubectl --context kind-scion-ops-mount-test wait --for=condition=Ready node/scion-ops-mount-test-control-plane --timeout=120s`\n- `KIND_CLUSTER_NAME=scion-ops-mount-test task kind:down`\n- `task kind:up` on the existing cluster warns about the missing mount but remains non-failing