### PR TITLE
Add kind MCP control plane service

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -60,3 +60,21 @@ runtime pods.
 
 Exit criteria: for non-local clusters, replace this with a cloned workspace or
 persistent workspace volume managed by explicit bootstrap/restore tasks.
+
+## kind MCP Hub Dev Token Sharing
+
+Issue: #21
+
+Decision: the local kind MCP Deployment mounts the Hub PVC read-only and reads
+the Hub dev-auth token from `/hub-state/dev-token`.
+
+Reason: the current kind Hub slice is intentionally dev-auth based and does not
+yet restore a Kubernetes Secret for Hub auth material. Sharing the generated
+token lets the MCP server use the Hub HTTP API without introducing a separate
+bootstrap system in this slice.
+
+Constraint: this is local-development only. The MCP pod can read Hub state from
+the PVC, so it must be treated as a privileged control-plane component.
+
+Exit criteria: replace PVC token sharing with explicit Secret restore before
+using the kind control plane outside local testing.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ kind runs agent pods. The proposed all-in-kind control-plane path is documented
 in `docs/kind-control-plane.md` and should remain Kustomize-first until the
 resource model is proven. The first experimental Hub-only kind slice is applied
 separately with `task kind:control-plane:apply` and verified with
-`task kind:control-plane:status`. New kind clusters also mount this repo into
-the kind node for the future MCP Deployment; verify that substrate with
+`task kind:control-plane:status`. The experimental kind-hosted MCP service uses
+the same control-plane target; expose it locally with
+`task kind:mcp:port-forward`. New kind clusters mount this repo into the kind
+node for the MCP Deployment; verify that substrate with
 `task kind:workspace:status`.
 
 ## Layout
@@ -55,7 +57,7 @@ the kind node for the future MCP Deployment; verify that substrate with
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `CLAUDE.md` — agent guidance and project engineering standards
 - `KNOWNISSUES.md` — intentional exceptions and risks to revisit
-- `deploy/kind/` — native Kubernetes resources for the local kind runtime and experimental Hub control plane
+- `deploy/kind/` — native Kubernetes resources for the local kind runtime and experimental Hub/MCP control plane
 - `docs/kind-control-plane.md` — proposed Kustomize path for running Hub, broker, and MCP in kind
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -98,17 +98,20 @@ tasks:
   kind:control-plane:apply:
     desc: Apply the experimental kind control-plane resources.
     cmds:
-      - task: kind:hub:apply
+      - kubectl --context '{{.KIND_CONTEXT}}' apply -f deploy/kind/namespace.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' apply -k deploy/kind/control-plane
 
   kind:control-plane:status:
     desc: Show status for the experimental kind control plane.
     cmds:
-      - task: kind:hub:status
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-ops-mcp --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc,pvc,cm -l app.kubernetes.io/part-of=scion-control-plane
 
   kind:control-plane:logs:
     desc: Follow logs from the experimental kind control plane.
     cmds:
-      - task: kind:hub:logs
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f -l app.kubernetes.io/part-of=scion-control-plane --all-containers=true --max-log-requests=4
 
   kind:control-plane:delete:
     desc: Delete the experimental kind control-plane resources.
@@ -120,7 +123,10 @@ tasks:
     desc: Apply the experimental Hub-only kind control-plane resources.
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' apply -f deploy/kind/namespace.yaml
-      - kubectl --context '{{.KIND_CONTEXT}}' apply -k deploy/kind/control-plane
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-config.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-pvc.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-service.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-deployment.yaml
 
   kind:hub:status:
     desc: Wait for the experimental kind Hub rollout and show its resources.
@@ -132,6 +138,27 @@ tasks:
     desc: Follow logs from the experimental kind Hub deployment.
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub
+
+  kind:mcp:status:
+    desc: Wait for the experimental kind MCP rollout and show its resources.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-ops-mcp --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc -l app.kubernetes.io/name=scion-ops-mcp
+
+  kind:mcp:logs:
+    desc: Follow logs from the experimental kind MCP deployment.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-ops-mcp
+
+  kind:mcp:port-forward:
+    desc: Forward the kind MCP service to the local MCP URL port.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' port-forward svc/scion-ops-mcp '{{.SCION_OPS_MCP_PORT}}':8765
+
+  kind:mcp:smoke:
+    desc: Smoke test the forwarded kind MCP service without starting a host fallback.
+    cmds:
+      - PYTHONDONTWRITEBYTECODE=1 uv run scripts/smoke-mcp-server.py --transport http --url '{{.SCION_OPS_MCP_URL}}'
 
   kind:doctor:
     desc: Run Scion diagnostics against the local kind runtime profile.

--- a/deploy/kind/control-plane/kustomization.yaml
+++ b/deploy/kind/control-plane/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - hub-pvc.yaml
   - hub-service.yaml
   - hub-deployment.yaml
+  - mcp-service.yaml
+  - mcp-deployment.yaml

--- a/deploy/kind/control-plane/mcp-deployment.yaml
+++ b/deploy/kind/control-plane/mcp-deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scion-ops-mcp
+  labels:
+    app.kubernetes.io/name: scion-ops-mcp
+    app.kubernetes.io/component: mcp
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scion-ops-mcp
+      app.kubernetes.io/component: mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: scion-ops-mcp
+        app.kubernetes.io/component: mcp
+        app.kubernetes.io/part-of: scion-control-plane
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: mcp
+          image: localhost/scion-ops-mcp:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              export SCION_GROVE_ID="${SCION_GROVE_ID:-$(cat "${SCION_OPS_ROOT}/.scion/grove-id" 2>/dev/null || true)}"
+              export SCION_OPS_GROVE_ID="${SCION_OPS_GROVE_ID:-$SCION_GROVE_ID}"
+              git config --global --add safe.directory "${SCION_OPS_ROOT}" >/dev/null 2>&1 || true
+              exec python "${SCION_OPS_ROOT}/mcp_servers/scion_ops.py"
+          env:
+            - name: HOME
+              value: /home/scion
+            - name: USER
+              value: scion
+            - name: LOGNAME
+              value: scion
+            - name: SHELL
+              value: /bin/zsh
+            - name: SCION_OPS_ROOT
+              value: /workspace/scion-ops
+            - name: SCION_OPS_MCP_TRANSPORT
+              value: streamable-http
+            - name: SCION_OPS_MCP_HOST
+              value: 0.0.0.0
+            - name: SCION_OPS_MCP_PORT
+              value: "8765"
+            - name: SCION_OPS_MCP_PATH
+              value: /mcp
+            - name: SCION_OPS_HUB_ENDPOINT
+              value: http://scion-hub:8090
+            - name: SCION_HUB_ENDPOINT
+              value: http://scion-hub:8090
+            - name: SCION_DEV_TOKEN_FILE
+              value: /hub-state/dev-token
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          ports:
+            - name: http
+              containerPort: 8765
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace/scion-ops
+            - name: hub-state
+              mountPath: /hub-state
+              readOnly: true
+      volumes:
+        - name: workspace
+          hostPath:
+            path: /workspace/scion-ops
+            type: Directory
+        - name: hub-state
+          persistentVolumeClaim:
+            claimName: scion-hub-state
+            readOnly: true

--- a/deploy/kind/control-plane/mcp-service.yaml
+++ b/deploy/kind/control-plane/mcp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scion-ops-mcp
+  labels:
+    app.kubernetes.io/name: scion-ops-mcp
+    app.kubernetes.io/component: mcp
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: scion-ops-mcp
+    app.kubernetes.io/component: mcp
+  ports:
+    - name: http
+      port: 8765
+      targetPort: http

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -1,7 +1,6 @@
 # kind Control Plane Deployment
 
-Status: first Hub-only slice implemented. The local kind workspace mount
-substrate for a future MCP Deployment is in place. Broker and MCP Kubernetes
+Status: Hub and MCP slices implemented for local kind. Broker Kubernetes
 resources are still pending.
 
 This is the path for running the Scion control plane inside the local kind
@@ -28,11 +27,12 @@ host:
   optional restore/bootstrap scripts
 ```
 
-## Implemented Hub Slice
+## Implemented Hub And MCP Slices
 
-The first slice adds a separate Kustomize target under
-`deploy/kind/control-plane` for a Hub/Web process only. It is not included by
-`task kind:up`, so the existing host-managed Hub workflow stays the default.
+The control-plane slices add a separate Kustomize target under
+`deploy/kind/control-plane` for Hub/Web and the scion-ops HTTP MCP server. It
+is not included by `task kind:up`, so the existing host-managed Hub workflow
+stays the default.
 
 Resources:
 
@@ -40,19 +40,21 @@ Resources:
 - `deploy/kind/control-plane/hub-config.yaml`
 - `deploy/kind/control-plane/hub-service.yaml`
 - `deploy/kind/control-plane/hub-pvc.yaml`
+- `deploy/kind/control-plane/mcp-deployment.yaml`
+- `deploy/kind/control-plane/mcp-service.yaml`
 
 Apply and verify:
 
 ```bash
 task kind:up
 task kind:workspace:status
-task kind:load-images -- localhost/scion-base:latest
+task kind:load-images -- localhost/scion-base:latest localhost/scion-ops-mcp:latest
 task kind:control-plane:apply
 task kind:control-plane:status
 ```
 
-If `localhost/scion-base:latest` has not been built locally, build it first
-with `task images:build` and then load it into kind.
+If the images have not been built locally, build them first with
+`task images:build` and then load them into kind.
 
 The Hub-specific task names remain available as narrow aliases:
 
@@ -60,6 +62,15 @@ The Hub-specific task names remain available as narrow aliases:
 task kind:hub:apply
 task kind:hub:status
 task kind:hub:logs
+```
+
+MCP-specific status, logs, and port-forward helpers are also available:
+
+```bash
+task kind:mcp:status
+task kind:mcp:logs
+task kind:mcp:port-forward
+task kind:mcp:smoke
 ```
 
 To inspect the Hub HTTP endpoint from the host, use a local-only port-forward:
@@ -108,10 +119,9 @@ clusters, `task kind:up` now creates the cluster with a kind `extraMount`:
 | Host checkout | repo root |
 | kind node | `/workspace/scion-ops` |
 
-The future MCP Deployment can mount the node path as a Kubernetes `hostPath`.
-This is intentionally limited to local kind. For non-kind clusters, use a
-cloned workspace or persistent workspace volume instead of a workstation bind
-mount.
+The MCP Deployment mounts the node path as a Kubernetes `hostPath`. This is
+intentionally limited to local kind. For non-kind clusters, use a cloned
+workspace or persistent workspace volume instead of a workstation bind mount.
 
 Existing kind clusters cannot be updated with new `extraMounts`. Verify the
 substrate before deploying MCP resources:
@@ -126,6 +136,13 @@ If the mount is missing, recreate only the local kind cluster:
 task kind:down
 task kind:up
 ```
+
+The MCP image is `localhost/scion-ops-mcp:latest`. It is built from
+`image-build/scion-ops-mcp/Dockerfile` on top of `scion-base`, adding `task`
+and the Python MCP dependencies while running the server from the mounted
+workspace. The Deployment reads Hub state through the `scion-hub` ClusterIP
+service and reads the local dev-auth token from the Hub PVC mounted read-only at
+`/hub-state`.
 
 ## Relationship To Existing Docs
 
@@ -177,7 +194,8 @@ restore model.
 | Broker credentials | Kubernetes Secret or re-register on bootstrap | Broker must keep or reacquire trust with Hub. |
 | Grove identity | Host repo `.scion/grove-id` plus Hub state | Recreating either side incorrectly can create duplicate grove identity. |
 | Subscription credentials | Kubernetes Secret sourced from host files or external secret store | Claude, Codex, and Gemini auth should not be baked into images. |
-| MCP workspace | HostPath mount through the kind node for local kind, or cloned persistent workspace outside kind | MCP tools need repo access for git/task/artifact inspection. |
+| MCP workspace | HostPath mount through the kind node for local kind, or cloned persistent workspace outside kind | MCP tools need repo access for git/task/artifact inspection. The local kind MCP mount is read-write. |
+| MCP Hub auth | Read-only view of Hub PVC dev token for local kind, restored Secret outside kind | The current local slice depends on Hub dev auth and is not production-ready. |
 | Agent artifacts | Git pushes, explicit sync, or persistent workspace volume | Do not rely on ephemeral agent pod storage for useful work. |
 
 For local development, prefer restoring secrets/configuration from the host
@@ -194,20 +212,21 @@ deploy/kind/
   namespace.yaml
   rbac.yaml
   control-plane/
+    hub-config.yaml
     hub-deployment.yaml
     hub-service.yaml
     hub-pvc.yaml
-    broker-deployment.yaml
-    broker-rbac.yaml
     mcp-deployment.yaml
     mcp-service.yaml
+    broker-deployment.yaml
+    broker-rbac.yaml
     kustomization.yaml
   kustomization.yaml
 ```
 
-The first resource implementation adds only the Hub resources. The workspace
-mount substrate is part of kind cluster creation, not a Kubernetes manifest.
-Avoid placeholder manifests that are not applied by tests.
+Implemented resources are Hub and MCP only. The workspace mount substrate is
+part of kind cluster creation, not a Kubernetes manifest. Avoid placeholder
+manifests that are not applied by tests.
 
 ## Networking
 
@@ -220,7 +239,13 @@ The MCP server should keep using HTTP transport. Zed can then connect through a
 port-forwarded localhost URL:
 
 ```bash
-kubectl --context kind-scion-ops -n scion-agents port-forward svc/scion-ops-mcp 8765:8765
+task kind:mcp:port-forward
+```
+
+In another terminal, smoke test the forwarded service:
+
+```bash
+task kind:mcp:smoke
 ```
 
 ## Broker Constraints
@@ -243,7 +268,8 @@ Key requirements:
 1. Add Kustomize resources for Hub and its persistent state. Done for the
    Hub-only slice.
 2. Add local kind workspace mount substrate for MCP repo access. Done.
-3. Add MCP deployment with repo/workspace access and HTTP service.
+3. Add MCP deployment with repo/workspace access and HTTP service. Done for the
+   local kind slice.
 4. Add broker deployment using in-cluster Kubernetes auth.
 5. Add bootstrap/restore tasks for secrets, grove identity, templates, and
    broker provide.

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -135,6 +135,7 @@ Load the images into kind:
 ```bash
 task kind:load-images -- \
   localhost/scion-base:latest \
+  localhost/scion-ops-mcp:latest \
   localhost/scion-claude:latest \
   localhost/scion-codex:latest \
   localhost/scion-gemini:latest

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -4,9 +4,9 @@ Use the narrow checks while changing one layer, and `task smoke:e2e` before
 trusting the full local Hub-mode stack.
 
 This plan covers the current default: host-managed Hub, broker, and MCP with
-kind used as the Kubernetes agent runtime. The proposed all-in-kind control
+kind used as the Kubernetes agent runtime. The experimental all-in-kind control
 plane is documented in `docs/kind-control-plane.md`; it should get its own
-smoke task once the Kustomize resources are implemented.
+smoke task once the broker resources are implemented.
 
 ## Layer Checks
 
@@ -47,9 +47,18 @@ HTTP MCP transport and Hub-backed tool surface:
 task mcp:http:smoke
 ```
 
-For the future all-in-kind path, these checks should be mirrored with
-`kubectl apply -k`, service readiness, port-forwarded MCP access, and a
-kind-hosted broker dispatch.
+For the experimental kind-hosted Hub/MCP path, mirror the HTTP MCP check with:
+
+```bash
+task kind:workspace:status
+task kind:control-plane:apply
+task kind:control-plane:status
+task kind:mcp:port-forward
+task kind:mcp:smoke
+```
+
+Run `task kind:mcp:smoke` in a second terminal while the port-forward is active.
+The kind-hosted broker dispatch remains a follow-up.
 
 ## End-To-End Smoke
 

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -137,9 +137,22 @@ The smoke task connects to the configured URL first. If no MCP server responds,
 it starts a temporary local server, lists tools, calls Hub status and agent
 listing, then shuts it down.
 
-For a future kind-hosted MCP deployment, keep Zed configured with a URL but
-point it at the forwarded service endpoint, for example
+For the experimental kind-hosted MCP deployment, keep Zed configured with a URL
+but point it at the forwarded service endpoint, for example
 `http://127.0.0.1:8765/mcp`.
+
+For the experimental kind-hosted MCP slice, start the port-forward with:
+
+```bash
+task kind:mcp:port-forward
+```
+
+In another terminal, smoke test the forwarded service without starting a host
+fallback:
+
+```bash
+task kind:mcp:smoke
+```
 
 ## Remote HTTP By SSH Tunnel
 

--- a/image-build/scion-ops-mcp/Dockerfile
+++ b/image-build/scion-ops-mcp/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE=localhost/scion-base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+ARG TASK_VERSION=v3.44.0
+ENV VIRTUAL_ENV=/opt/scion-ops-mcp/venv
+
+RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION} \
+  && python3 -m venv "${VIRTUAL_ENV}" \
+  && "${VIRTUAL_ENV}/bin/pip" install --no-cache-dir "mcp>=1.13,<2" "PyYAML>=6,<7"
+
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    SCION_OPS_ROOT=/workspace/scion-ops \
+    SCION_OPS_MCP_TRANSPORT=streamable-http \
+    SCION_OPS_MCP_HOST=0.0.0.0 \
+    SCION_OPS_MCP_PORT=8765 \
+    SCION_OPS_MCP_PATH=/mcp
+
+WORKDIR /workspace/scion-ops
+USER 1000:1000
+EXPOSE 8765
+
+ENTRYPOINT ["python", "/workspace/scion-ops/mcp_servers/scion_ops.py"]

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -22,6 +22,7 @@ SCION_SRC="${HOME}/workspace/github/GoogleCloudPlatform/scion"
 TAG="latest"
 REGISTRY="localhost"
 HARNESSES=(claude codex gemini)   # skip opencode by default to save time/disk
+BUILD_MCP=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOCAL_IMG_BUILD="$REPO_ROOT/image-build"
@@ -33,6 +34,7 @@ while [[ $# -gt 0 ]]; do
     --registry)  REGISTRY="$2"; shift 2 ;;
     --harness)   HARNESSES=("$2"); shift 2 ;;
     --all-harnesses) HARNESSES=(claude codex gemini opencode); shift ;;
+    --skip-mcp)  BUILD_MCP=0; shift ;;
     -h|--help)
       cat <<EOF
 Usage: $(basename "$0") [options]
@@ -41,6 +43,7 @@ Usage: $(basename "$0") [options]
   --registry <name>  Image prefix (default: $REGISTRY)
   --harness <name>   Build only this harness (repeatable)
   --all-harnesses    Build claude codex gemini opencode (default: claude codex gemini)
+  --skip-mcp         Do not build the scion-ops MCP image
 EOF
       exit 0
       ;;
@@ -88,6 +91,13 @@ for h in "${HARNESSES[@]}"; do
         "$harness_dir" \
         --build-arg "BASE_IMAGE=${REGISTRY}/scion-base:${TAG}"
 done
+
+if [[ "$BUILD_MCP" == "1" ]]; then
+  build "scion-ops-mcp" \
+        "$LOCAL_IMG_BUILD/scion-ops-mcp/Dockerfile" \
+        "$LOCAL_IMG_BUILD/scion-ops-mcp" \
+        --build-arg "BASE_IMAGE=${REGISTRY}/scion-base:${TAG}"
+fi
 
 green ""
 green "All images built."


### PR DESCRIPTION
Closes #21
Refs #15

## Summary
- add a `localhost/scion-ops-mcp:latest` image for the existing streamable HTTP MCP server
- add native Kustomize MCP Deployment/Service resources using the kind workspace mount and read-only Hub PVC dev token
- update kind control-plane tasks and docs for build/load/apply/status/logs/port-forward/smoke

## Verification
- `bash -n scripts/build-images.sh scripts/kind-scion-runtime.sh`
- `bash scripts/build-images.sh --help`
- `kubectl kustomize deploy/kind/control-plane >/tmp/scion-ops-control-plane.yaml`
- `git diff --check`
- `podman build --tag localhost/scion-ops-mcp:latest --file image-build/scion-ops-mcp/Dockerfile --build-arg BASE_IMAGE=localhost/scion-base:latest image-build/scion-ops-mcp`
- `podman run --rm --entrypoint /opt/scion-ops-mcp/venv/bin/python localhost/scion-ops-mcp:latest -c 'import mcp, yaml; print("mcp-image-ok")'`\n- `KIND_CLUSTER_NAME=scion-ops-mcp-test task kind:up`\n- `KIND_CLUSTER_NAME=scion-ops-mcp-test task kind:workspace:status`\n- `KIND_CLUSTER_NAME=scion-ops-mcp-test task kind:load-archive -- /tmp/scion-ops-images/scion-base.tar /tmp/scion-ops-images/scion-ops-mcp.tar`\n- `KIND_CLUSTER_NAME=scion-ops-mcp-test task kind:control-plane:apply`\n- `KIND_CLUSTER_NAME=scion-ops-mcp-test task kind:control-plane:status`\n- `task kind:mcp:smoke` through a temporary port-forward to the disposable cluster\n- `kubectl --context kind-scion-ops-mcp-test -n scion-agents exec deploy/scion-ops-mcp -- sh -c 'test -r /hub-state/dev-token && test -f /workspace/scion-ops/Taskfile.yml && command -v task && command -v scion && python -c "import mcp, yaml" && echo mcp-pod-runtime-ok'`\n- `KIND_CLUSTER_NAME=scion-ops-mcp-test task kind:down`