### PR TITLE
Enable kind co-located Runtime Broker

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -78,3 +78,22 @@ the PVC, so it must be treated as a privileged control-plane component.
 
 Exit criteria: replace PVC token sharing with explicit Secret restore before
 using the kind control plane outside local testing.
+
+## kind Co-Located Broker First
+
+Issue: #23
+
+Decision: the first in-kind Runtime Broker slice runs inside the Hub pod by
+enabling Scion's co-located Hub+broker server mode.
+
+Reason: a separate broker Deployment needs a reliable HMAC credential bootstrap
+or restore path before it can join Hub mode safely. The co-located Scion server
+path already creates the broker record and broker secret in Hub state, which is
+enough for the local kind control plane to prove Kubernetes runtime access
+without custom registration plumbing.
+
+Constraint: this is a local-development control-plane shape. The broker binds
+to loopback inside the Hub pod and is not exposed as a Kubernetes Service.
+
+Exit criteria: add a separate broker Deployment only after the project has an
+explicit broker credential restore or registration bootstrap flow.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ To advertise the kind Kubernetes runtime through the local broker, run
 The current default deployment keeps Hub, broker, and MCP on the host while
 kind runs agent pods. The proposed all-in-kind control-plane path is documented
 in `docs/kind-control-plane.md` and should remain Kustomize-first until the
-resource model is proven. The first experimental Hub-only kind slice is applied
-separately with `task kind:control-plane:apply` and verified with
-`task kind:control-plane:status`. The experimental kind-hosted MCP service uses
-the same control-plane target; expose it locally with
+resource model is proven. The experimental kind control-plane runs Hub/Web with
+a co-located Runtime Broker plus the HTTP MCP service. Apply it separately with
+`task kind:control-plane:apply` and verify it with
+`task kind:control-plane:status`. Expose the kind-hosted MCP service locally with
 `task kind:mcp:port-forward`. New kind clusters mount this repo into the kind
 node for the MCP Deployment; verify that substrate with
 `task kind:workspace:status`.
@@ -57,7 +57,7 @@ node for the MCP Deployment; verify that substrate with
 - `.scion/templates/` — agent role definitions, including `consensus-runner`
 - `CLAUDE.md` — agent guidance and project engineering standards
 - `KNOWNISSUES.md` — intentional exceptions and risks to revisit
-- `deploy/kind/` — native Kubernetes resources for the local kind runtime and experimental Hub/MCP control plane
+- `deploy/kind/` — native Kubernetes resources for the local kind runtime and experimental Hub/broker/MCP control plane
 - `docs/kind-control-plane.md` — proposed Kustomize path for running Hub, broker, and MCP in kind
 - `docs/kind-broker-runtime.md` — broker registration and kind profile workflow
 - `docs/local-hub-mode.md` — local Hub/Web/Broker workstation workflow

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,6 +106,7 @@ tasks:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-ops-mcp --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- scion --global broker status --json
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc,pvc,cm -l app.kubernetes.io/part-of=scion-control-plane
 
   kind:control-plane:logs:
@@ -120,9 +121,11 @@ tasks:
       - kubectl --context '{{.KIND_CONTEXT}}' delete -k deploy/kind/control-plane --ignore-not-found=true
 
   kind:hub:apply:
-    desc: Apply the experimental Hub-only kind control-plane resources.
+    desc: Apply the experimental Hub/broker kind control-plane resources.
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' apply -f deploy/kind/namespace.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/broker-rbac.yaml
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/broker-kubeconfig.yaml
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-config.yaml
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-pvc.yaml
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' apply -f deploy/kind/control-plane/hub-service.yaml
@@ -132,12 +135,24 @@ tasks:
     desc: Wait for the experimental kind Hub rollout and show its resources.
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- scion --global broker status --json
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc,pvc,cm -l app.kubernetes.io/part-of=scion-control-plane
 
   kind:hub:logs:
     desc: Follow logs from the experimental kind Hub deployment.
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub
+
+  kind:broker:status:
+    desc: Show the co-located Runtime Broker status inside the experimental kind Hub pod.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- scion --global broker status --json
+
+  kind:broker:logs:
+    desc: Follow Hub pod logs for the co-located experimental kind Runtime Broker.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub -c hub
 
   kind:mcp:status:
     desc: Wait for the experimental kind MCP rollout and show its resources.

--- a/deploy/kind/control-plane/broker-kubeconfig.yaml
+++ b/deploy/kind/control-plane/broker-kubeconfig.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scion-broker-kubeconfig
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+data:
+  config: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: in-cluster
+        cluster:
+          server: https://kubernetes.default.svc
+          certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    users:
+      - name: scion-control-plane
+        user:
+          tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    contexts:
+      - name: in-cluster
+        context:
+          cluster: in-cluster
+          user: scion-control-plane
+          namespace: scion-agents
+    current-context: in-cluster

--- a/deploy/kind/control-plane/broker-rbac.yaml
+++ b/deploy/kind/control-plane/broker-rbac.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scion-control-plane
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scion-control-plane-broker
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scion-control-plane-broker
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: scion-control-plane
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scion-control-plane-broker

--- a/deploy/kind/control-plane/hub-config.yaml
+++ b/deploy/kind/control-plane/hub-config.yaml
@@ -9,4 +9,23 @@ metadata:
 data:
   settings.yaml: |
     schema_version: "1"
+    active_profile: kind
     image_registry: localhost
+    hub:
+      endpoint: http://scion-hub:8090
+    server:
+      hub:
+        public_url: http://scion-hub:8090
+      broker:
+        broker_id: 00000000-0000-4000-8000-000000000023
+        broker_name: kind-control-plane
+        host: 127.0.0.1
+        auto_provide: true
+    runtimes:
+      kubernetes:
+        type: kubernetes
+        context: in-cluster
+        namespace: scion-agents
+    profiles:
+      kind:
+        runtime: kubernetes

--- a/deploy/kind/control-plane/hub-deployment.yaml
+++ b/deploy/kind/control-plane/hub-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: hub
         app.kubernetes.io/part-of: scion-control-plane
     spec:
+      serviceAccountName: scion-control-plane
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
@@ -35,6 +36,8 @@ spec:
               value: scion
             - name: LOGNAME
               value: scion
+            - name: KUBECONFIG
+              value: /home/scion/.kube/config
           args:
             - --global
             - server
@@ -43,6 +46,7 @@ spec:
             - --production
             - --enable-hub
             - --enable-web
+            - --enable-runtime-broker
             - --dev-auth
             - --host
             - 0.0.0.0
@@ -60,6 +64,8 @@ spec:
           ports:
             - name: http
               containerPort: 8090
+            - name: broker
+              containerPort: 9800
           readinessProbe:
             httpGet:
               path: /healthz
@@ -86,6 +92,9 @@ spec:
               mountPath: /home/scion/.scion/settings.yaml
               subPath: settings.yaml
               readOnly: true
+            - name: kubeconfig
+              mountPath: /home/scion/.kube
+              readOnly: true
       volumes:
         - name: state
           persistentVolumeClaim:
@@ -93,3 +102,6 @@ spec:
         - name: settings
           configMap:
             name: scion-hub-settings
+        - name: kubeconfig
+          configMap:
+            name: scion-broker-kubeconfig

--- a/deploy/kind/control-plane/kustomization.yaml
+++ b/deploy/kind/control-plane/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: scion-agents
 resources:
+  - broker-rbac.yaml
+  - broker-kubeconfig.yaml
   - hub-config.yaml
   - hub-pvc.yaml
   - hub-service.yaml

--- a/docs/kind-broker-runtime.md
+++ b/docs/kind-broker-runtime.md
@@ -7,9 +7,9 @@ Kubernetes profile. The shape follows the upstream Scion model:
 - Runtime Broker is the compute provider for a grove.
 - Kubernetes is selected by a Scion profile at agent dispatch time.
 
-This is the current default. A future all-in-kind path would run the broker
-inside kind as well; that design, persistence model, and constraints live in
-`docs/kind-control-plane.md`.
+This is the current default. The experimental all-in-kind path now runs a
+co-located Runtime Broker inside the kind Hub pod; that design, persistence
+model, and constraints live in `docs/kind-control-plane.md`.
 
 References:
 

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -1,7 +1,7 @@
 # kind Control Plane Deployment
 
-Status: Hub and MCP slices implemented for local kind. Broker Kubernetes
-resources are still pending.
+Status: Hub, co-located Runtime Broker, and MCP slices implemented for local
+kind. A separate broker Deployment remains a future bootstrap task.
 
 This is the path for running the Scion control plane inside the local kind
 cluster. The current default remains host-managed Hub, broker, and MCP with kind
@@ -16,8 +16,7 @@ The target shape is:
 
 ```text
 kind cluster:
-  Scion Hub/API/Web
-  Runtime Broker
+  Scion Hub/API/Web with co-located Runtime Broker
   scion-ops HTTP MCP server
   Scion agent pods
 
@@ -27,12 +26,12 @@ host:
   optional restore/bootstrap scripts
 ```
 
-## Implemented Hub And MCP Slices
+## Implemented Control-Plane Slices
 
 The control-plane slices add a separate Kustomize target under
-`deploy/kind/control-plane` for Hub/Web and the scion-ops HTTP MCP server. It
-is not included by `task kind:up`, so the existing host-managed Hub workflow
-stays the default.
+`deploy/kind/control-plane` for Hub/Web, a co-located Runtime Broker, and the
+scion-ops HTTP MCP server. It is not included by `task kind:up`, so the
+existing host-managed Hub workflow stays the default.
 
 Resources:
 
@@ -40,6 +39,8 @@ Resources:
 - `deploy/kind/control-plane/hub-config.yaml`
 - `deploy/kind/control-plane/hub-service.yaml`
 - `deploy/kind/control-plane/hub-pvc.yaml`
+- `deploy/kind/control-plane/broker-rbac.yaml`
+- `deploy/kind/control-plane/broker-kubeconfig.yaml`
 - `deploy/kind/control-plane/mcp-deployment.yaml`
 - `deploy/kind/control-plane/mcp-service.yaml`
 
@@ -51,17 +52,20 @@ task kind:workspace:status
 task kind:load-images -- localhost/scion-base:latest localhost/scion-ops-mcp:latest
 task kind:control-plane:apply
 task kind:control-plane:status
+task kind:broker:status
 ```
 
 If the images have not been built locally, build them first with
 `task images:build` and then load them into kind.
 
-The Hub-specific task names remain available as narrow aliases:
+The Hub/broker-specific task names remain available as narrow aliases:
 
 ```bash
 task kind:hub:apply
 task kind:hub:status
 task kind:hub:logs
+task kind:broker:status
+task kind:broker:logs
 ```
 
 MCP-specific status, logs, and port-forward helpers are also available:
@@ -98,14 +102,21 @@ minimal `settings.yaml` comes from the `scion-hub-settings` ConfigMap so the
 required `image_registry: localhost` setting is reproducible from this repo.
 Deleting the kind cluster deletes the PVC-backed state.
 
-This first slice intentionally runs `scion --global server start` in explicit
-component mode with `--production --enable-hub --enable-web --dev-auth`:
-production mode prevents workstation defaults from starting the broker
-automatically, while dev auth keeps the local kind deployment usable without
-OAuth setup. The Deployment overrides the `scion-base` agent entrypoint and
-runs the Hub process directly as UID/GID 1000 because `sciontool init` is for
-agent containers. The web session secret is still auto-generated per pod start
-and is not production-ready.
+The Hub slice intentionally runs `scion --global server start` in explicit
+component mode with `--production --enable-hub --enable-web
+--enable-runtime-broker --dev-auth`. Production mode avoids workstation
+defaults, while the explicit Runtime Broker flag uses Scion's built-in
+co-located Hub+broker path. That path creates the broker record and HMAC secret
+inside Hub state, so the local kind deployment does not need a custom broker
+registration sidecar.
+
+The broker binds to `127.0.0.1` inside the Hub pod and is not exposed as a
+Service. It uses the `kind` profile from `scion-hub-settings`, an in-cluster
+kubeconfig ConfigMap, and the `scion-control-plane` service account to create
+agent pods in `scion-agents`. The Deployment overrides the `scion-base` agent
+entrypoint and runs the Hub process directly as UID/GID 1000 because
+`sciontool init` is for agent containers. The web session secret is still
+auto-generated per pod start and is not production-ready.
 
 ## MCP Workspace Mount Substrate
 
@@ -191,7 +202,7 @@ restore model.
 |---|---|---|
 | Hub database/state | PersistentVolumeClaim or external DB | Contains groves, agents, messages, broker registrations, templates, and Hub state. |
 | Hub signing/session material | Kubernetes Secret restored from host or sealed/external secret | Rotating this invalidates sessions/tokens. |
-| Broker credentials | Kubernetes Secret or re-register on bootstrap | Broker must keep or reacquire trust with Hub. |
+| Broker credentials | Co-located broker secret in Hub state for the current kind slice; Kubernetes Secret or registration bootstrap for a future separate broker | Broker must keep or reacquire trust with Hub. |
 | Grove identity | Host repo `.scion/grove-id` plus Hub state | Recreating either side incorrectly can create duplicate grove identity. |
 | Subscription credentials | Kubernetes Secret sourced from host files or external secret store | Claude, Codex, and Gemini auth should not be baked into images. |
 | MCP workspace | HostPath mount through the kind node for local kind, or cloned persistent workspace outside kind | MCP tools need repo access for git/task/artifact inspection. The local kind MCP mount is read-write. |
@@ -212,21 +223,21 @@ deploy/kind/
   namespace.yaml
   rbac.yaml
   control-plane/
+    broker-kubeconfig.yaml
+    broker-rbac.yaml
     hub-config.yaml
     hub-deployment.yaml
     hub-service.yaml
     hub-pvc.yaml
     mcp-deployment.yaml
     mcp-service.yaml
-    broker-deployment.yaml
-    broker-rbac.yaml
     kustomization.yaml
   kustomization.yaml
 ```
 
-Implemented resources are Hub and MCP only. The workspace mount substrate is
-part of kind cluster creation, not a Kubernetes manifest. Avoid placeholder
-manifests that are not applied by tests.
+Implemented resources are Hub, co-located broker RBAC/kubeconfig, and MCP. The
+workspace mount substrate is part of kind cluster creation, not a Kubernetes
+manifest. Avoid placeholder manifests that are not applied by tests.
 
 ## Networking
 
@@ -252,27 +263,30 @@ task kind:mcp:smoke
 
 Containerizing the broker is the riskiest part. The broker needs enough access
 to create agent pods and manage their lifecycle, but should not receive host
-Podman socket access for this path. The first all-in-kind broker should support
-only the Kubernetes runtime.
+Podman socket access for this path. The first all-in-kind broker runs
+co-located in the Hub pod and supports only the Kubernetes runtime.
 
 Key requirements:
 
 - in-cluster Kubernetes API access through a service account
 - namespace/RBAC for agent pods, `pods/exec`, `pods/log`, and secrets
-- mounted or restored broker credentials
+- co-located broker HMAC secret in Hub state
 - image registry access for Scion agent images
 - stable workspace strategy for agents and MCP
 
+A separate broker Deployment remains out of scope until there is an explicit
+broker credential restore or registration bootstrap flow.
+
 ## Phased Implementation
 
-1. Add Kustomize resources for Hub and its persistent state. Done for the
-   Hub-only slice.
+1. Add Kustomize resources for Hub and its persistent state. Done.
 2. Add local kind workspace mount substrate for MCP repo access. Done.
 3. Add MCP deployment with repo/workspace access and HTTP service. Done for the
    local kind slice.
-4. Add broker deployment using in-cluster Kubernetes auth.
+4. Add co-located broker support using in-cluster Kubernetes auth. Done for the
+   local kind slice.
 5. Add bootstrap/restore tasks for secrets, grove identity, templates, and
-   broker provide.
+   future separate broker provide.
 6. Extend `task smoke:e2e` or add a sibling smoke task that validates the
    kind-hosted control plane.
 7. Consider Helm packaging only after the manifests pass local kind smoke tests
@@ -288,3 +302,5 @@ Key requirements:
   recreation?
 - How should the in-kind path restore a stable session/JWT secret before it is
   used beyond local development?
+- Should a future separate Runtime Broker be bootstrapped from a restored
+  Kubernetes Secret or from a registration job once Scion supports that flow?

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -6,7 +6,8 @@ trusting the full local Hub-mode stack.
 This plan covers the current default: host-managed Hub, broker, and MCP with
 kind used as the Kubernetes agent runtime. The experimental all-in-kind control
 plane is documented in `docs/kind-control-plane.md`; it should get its own
-smoke task once the broker resources are implemented.
+dispatch smoke once the co-located broker path is promoted beyond rollout
+checks.
 
 ## Layer Checks
 
@@ -47,18 +48,21 @@ HTTP MCP transport and Hub-backed tool surface:
 task mcp:http:smoke
 ```
 
-For the experimental kind-hosted Hub/MCP path, mirror the HTTP MCP check with:
+For the experimental kind-hosted Hub/broker/MCP path, mirror the HTTP MCP check with:
 
 ```bash
 task kind:workspace:status
 task kind:control-plane:apply
 task kind:control-plane:status
+task kind:broker:status
 task kind:mcp:port-forward
 task kind:mcp:smoke
 ```
 
 Run `task kind:mcp:smoke` in a second terminal while the port-forward is active.
-The kind-hosted broker dispatch remains a follow-up.
+The kind control plane now starts a co-located Runtime Broker in the Hub pod.
+A kind-hosted dispatch smoke remains a follow-up because it needs a dedicated
+bootstrap flow for grove linking, templates, and restored agent credentials.
 
 ## End-To-End Smoke
 


### PR DESCRIPTION
## Summary

- enable Scion's co-located Runtime Broker in the experimental kind Hub pod
- add broker kubeconfig and scoped RBAC for in-cluster Kubernetes runtime access
- add kind broker status/log tasks and update docs/known issues for the co-located broker shape

Closes #23

## Verification

- `kubectl kustomize deploy/kind/control-plane`
- `git diff --check`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:up`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:workspace:status`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:load-archive -- /tmp/scion-ops-broker-images.KeWCIL/scion-base.tar /tmp/scion-ops-broker-images.KeWCIL/scion-ops-mcp.tar`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:control-plane:apply`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:control-plane:status`
- `kubectl --context kind-scion-ops-broker-test -n scion-agents logs deploy/scion-hub -c hub | rg -n "Runtime broker using runtime|Registered global grove|Runtime Broker API server starting|Hub integration initialized"`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:broker:status`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:mcp:port-forward`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:mcp:smoke`
- `kubectl --context kind-scion-ops-broker-test -n scion-agents auth can-i create pods --as=system:serviceaccount:scion-agents:scion-control-plane`
- `kubectl --context kind-scion-ops-broker-test -n scion-agents auth can-i create pods/exec --as=system:serviceaccount:scion-agents:scion-control-plane`
- `kubectl --context kind-scion-ops-broker-test -n scion-agents auth can-i create persistentvolumeclaims --as=system:serviceaccount:scion-agents:scion-control-plane`
- `KIND_CLUSTER_NAME=scion-ops-broker-test task kind:down`

Note: `task kind:mcp:smoke` still reports expected `hub_state` 404s for this disposable Hub because the mounted workspace grove is not linked into that fresh Hub state. The MCP protocol/tool smoke exits 0.
