### PR TITLE
Add kind Hub host access helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ in `docs/kind-control-plane.md` and should remain Kustomize-first until the
 resource model is proven. The experimental kind control-plane runs Hub/Web with
 a co-located Runtime Broker plus the HTTP MCP service. Apply it separately with
 `task kind:control-plane:apply` and verify it with
-`task kind:control-plane:status`. Expose the kind-hosted MCP service locally with
-`task kind:mcp:port-forward`. New kind clusters mount this repo into the kind
-node for the MCP Deployment; verify that substrate with
+`task kind:control-plane:status`. Expose the kind-hosted Hub and MCP services
+locally with `task kind:hub:port-forward` and `task kind:mcp:port-forward`.
+Use `eval "$(task kind:hub:auth-export)"` for host CLI auth against the
+port-forwarded kind Hub. New kind clusters mount this repo into the kind node
+for the MCP Deployment; verify that substrate with
 `task kind:workspace:status`.
 
 ## Layout

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,10 @@ vars:
     sh: printf '%s' "${HUB_WEB_PORT:-8090}"
   HUB_ENDPOINT:
     sh: printf '%s' "${HUB_ENDPOINT:-${SCION_HUB_ENDPOINT:-http://127.0.0.1:${HUB_WEB_PORT:-8090}}}"
+  SCION_OPS_KIND_HUB_PORT:
+    sh: printf '%s' "${SCION_OPS_KIND_HUB_PORT:-18090}"
+  SCION_OPS_KIND_HUB_URL:
+    sh: printf 'http://127.0.0.1:%s' "${SCION_OPS_KIND_HUB_PORT:-18090}"
   KIND_CLUSTER_NAME:
     sh: printf '%s' "${KIND_CLUSTER_NAME:-scion-ops}"
   KIND_CONTEXT:
@@ -142,6 +146,21 @@ tasks:
     desc: Follow logs from the experimental kind Hub deployment.
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub
+
+  kind:hub:port-forward:
+    desc: Forward the experimental kind Hub service to localhost.
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' port-forward svc/scion-hub '{{.SCION_OPS_KIND_HUB_PORT}}':8090
+
+  kind:hub:auth-export:
+    desc: Print host export lines for the port-forwarded experimental kind Hub.
+    silent: true
+    cmds:
+      - |
+        token="$(kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- cat /home/scion/.scion/dev-token)"
+        printf 'export SCION_HUB_ENDPOINT=%s\n' '{{.SCION_OPS_KIND_HUB_URL}}'
+        printf 'export HUB_ENDPOINT=%s\n' '{{.SCION_OPS_KIND_HUB_URL}}'
+        printf 'export SCION_DEV_TOKEN=%s\n' "$token"
 
   kind:broker:status:
     desc: Show the co-located Runtime Broker status inside the experimental kind Hub pod.

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -64,6 +64,8 @@ The Hub/broker-specific task names remain available as narrow aliases:
 task kind:hub:apply
 task kind:hub:status
 task kind:hub:logs
+task kind:hub:port-forward
+eval "$(task kind:hub:auth-export)"
 task kind:broker:status
 task kind:broker:logs
 ```
@@ -80,12 +82,19 @@ task kind:mcp:smoke
 To inspect the Hub HTTP endpoint from the host, use a local-only port-forward:
 
 ```bash
-kubectl --context kind-scion-ops -n scion-agents port-forward svc/scion-hub 18090:8090
+task kind:hub:port-forward
+```
+
+In another terminal, export the matching endpoint and dev-auth token:
+
+```bash
+eval "$(task kind:hub:auth-export)"
 curl http://127.0.0.1:18090/healthz
 ```
 
 The Service is ClusterIP-only. There is no host port binding unless the
-port-forward is running.
+port-forward is running. Override the local port with
+`SCION_OPS_KIND_HUB_PORT`.
 
 Remove the experimental control-plane resources with:
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -55,11 +55,14 @@ task kind:workspace:status
 task kind:control-plane:apply
 task kind:control-plane:status
 task kind:broker:status
+task kind:hub:port-forward
+eval "$(task kind:hub:auth-export)"
 task kind:mcp:port-forward
 task kind:mcp:smoke
 ```
 
-Run `task kind:mcp:smoke` in a second terminal while the port-forward is active.
+Run `task kind:hub:port-forward` and `task kind:mcp:port-forward` in separate
+terminals while using the exported host CLI environment and MCP smoke.
 The kind control plane now starts a co-located Runtime Broker in the Hub pod.
 A kind-hosted dispatch smoke remains a follow-up because it needs a dedicated
 bootstrap flow for grove linking, templates, and restored agent credentials.


### PR DESCRIPTION
## Summary

- add a `kind:hub:port-forward` task for localhost access to the kind Hub ClusterIP service
- add a silent `kind:hub:auth-export` task that exports the port-forwarded Hub endpoint and dev token
- update README/testing/control-plane docs with the host access workflow

Closes #25

## Verification

- `git diff --check`
- `task --list | rg 'kind:hub:(auth-export|port-forward)'`
- `task kind:hub:auth-export`
- `task kind:hub:port-forward`
- `curl -fsS http://127.0.0.1:18090/healthz`
