### PR TITLE
Add kind control-plane dispatch smoke

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -97,3 +97,26 @@ to loopback inside the Hub pod and is not exposed as a Kubernetes Service.
 
 Exit criteria: add a separate broker Deployment only after the project has an
 explicit broker credential restore or registration bootstrap flow.
+
+## kind Hub Local Storage Uploads
+
+Issue: #27
+
+Decision: the kind control-plane smoke uses an inline `generic` harness config
+for its no-auth agent instead of uploading grove templates or harness configs by
+default.
+
+Reason: the current kind Hub uses Scion local storage on the Hub PVC. When the
+host CLI talks to that Hub through a port-forward, template and harness-config
+sync can receive pod-local upload paths such as `/home/scion/.scion/storage/...`
+that are not writable or meaningful from the host. That is acceptable for the
+host-managed workstation Hub, but it is not a good remote-Hub bootstrap pattern.
+
+Constraint: custom grove templates and harness configs are opt-in in the kind
+smoke via `--sync-template` and `--sync-harness-config`; use those only with a
+Hub storage backend that supports remote uploads, or with a future in-cluster
+bootstrap/restore task.
+
+Exit criteria: replace the inline generic smoke fallback with normal template
+and harness-config bootstrap after kind Hub state uses a remote-upload-capable
+storage path or Scion exposes an in-cluster bootstrap workflow.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ locally with `task kind:hub:port-forward` and `task kind:mcp:port-forward`.
 Use `eval "$(task kind:hub:auth-export)"` for host CLI auth against the
 port-forwarded kind Hub. New kind clusters mount this repo into the kind node
 for the MCP Deployment; verify that substrate with
-`task kind:workspace:status`.
+`task kind:workspace:status`. Use `task kind:control-plane:smoke` to link the
+current grove to the kind Hub, verify MCP Hub status, and dispatch a no-auth
+generic agent pod through the co-located broker.
 
 ## Layout
 
@@ -81,7 +83,8 @@ tools read Hub state through the Hub HTTP API. See `docs/zed-mcp.md`.
 
 ## Testing
 
-Use `task smoke:e2e` to validate the local Hub + kind + HTTP MCP stack in one
-run. The project testing plan is in `docs/testing-plan.md`.
+Use `task smoke:e2e` to validate the host-managed Hub + kind + HTTP MCP stack
+in one run. Use `task kind:control-plane:smoke` for the experimental all-in-kind
+Hub/broker/MCP path. The project testing plan is in `docs/testing-plan.md`.
 
 See `/home/david/.claude/plans/https-claude-ai-share-a56e403d-3326-4857-staged-rocket.md` for the full design.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,6 +118,18 @@ tasks:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f -l app.kubernetes.io/part-of=scion-control-plane --all-containers=true --max-log-requests=4
 
+  kind:control-plane:smoke:
+    desc: Bootstrap the kind Hub and dispatch a no-auth smoke agent through the co-located broker.
+    cmds:
+      - |
+        PYTHONDONTWRITEBYTECODE=1 \
+        SCION_BIN='{{.SCION_BIN}}' \
+        HUB_ENDPOINT='{{.SCION_OPS_KIND_HUB_URL}}' \
+        SCION_OPS_KIND_HUB_PORT='{{.SCION_OPS_KIND_HUB_PORT}}' \
+        SCION_OPS_KIND_HUB_URL='{{.SCION_OPS_KIND_HUB_URL}}' \
+        SCION_OPS_MCP_URL='{{.SCION_OPS_MCP_URL}}' \
+        uv run scripts/kind-control-plane-smoke.py {{.CLI_ARGS}}
+
   kind:control-plane:delete:
     desc: Delete the experimental kind control-plane resources.
     prompt: This deletes experimental kind control-plane resources from {{.KIND_CONTEXT}}. Continue?

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -79,6 +79,53 @@ task kind:mcp:port-forward
 task kind:mcp:smoke
 ```
 
+Run the end-to-end kind control-plane smoke with:
+
+```bash
+task kind:control-plane:smoke
+```
+
+The smoke creates or reuses the kind runtime substrate, applies the
+control-plane Kustomize target, reads the dev-auth token from the Hub pod,
+starts temporary local port-forwards for Hub and MCP if needed, links the
+current grove to the kind Hub, makes the co-located broker the current grove's
+default provider, checks the kind-hosted MCP Hub status, dispatches a no-auth
+generic smoke agent, verifies that a pod appears in kind, and deletes the smoke
+agent after a successful run.
+
+The bootstrap is intentionally one-off. It passes `--hub` or
+`SCION_HUB_ENDPOINT` to Scion commands and does not run `task hub:link` or
+`scion config set hub.endpoint`, so the host's global Scion Hub endpoint is not
+rewritten. It does create or update current-grove state inside the kind Hub PVC.
+By default it uses Scion's inline config support with the `generic` harness and
+does not upload templates or harness configs. Pass `--template` to use an
+existing Hub template, `--sync-template` to upload that template first, and
+`--sync-harness-config` only when you explicitly want to test Hub
+harness-config upload as well. Template and harness uploads require a Hub
+storage backend that supports remote uploads; local kind Hub state uses local
+storage and is not a reliable target for host-side upload sync.
+
+Useful overrides:
+
+| Variable | Default |
+|---|---|
+| `SCION_KIND_CP_SMOKE_TEMPLATE` | unset, uses inline generic config |
+| `SCION_KIND_CP_SMOKE_AGENT` | generated `kind-cp-smoke-*` name |
+| `SCION_KIND_CP_SMOKE_KEEP_AGENT` | unset, deletes on success |
+| `SCION_KIND_CP_SMOKE_SKIP_SETUP` | unset, applies kind resources |
+| `SCION_KIND_CP_SMOKE_SYNC_TEMPLATE` | unset, no template upload |
+| `SCION_KIND_CP_SMOKE_SYNC_HARNESS_CONFIG` | unset, no harness-config upload |
+| `SCION_KIND_CP_SMOKE_TIMEOUT` | `90` |
+| `SCION_OPS_KIND_HUB_PORT` | `18090` |
+| `SCION_OPS_MCP_URL` | `http://127.0.0.1:8765/mcp` |
+
+Pass `--skip-setup` when the kind cluster and control plane are already applied,
+`--no-port-forward` when you want to manage the Hub and MCP port-forwards in
+separate terminals, or `--skip-bootstrap` when the current grove and broker
+provider already exist in the kind Hub. Pass `--skip-mcp` to verify only the Hub
+and co-located broker dispatch path; in that mode the script uses the Hub-only
+apply/status tasks and does not require the kind workspace mount.
+
 To inspect the Hub HTTP endpoint from the host, use a local-only port-forward:
 
 ```bash

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -63,9 +63,18 @@ task kind:mcp:smoke
 
 Run `task kind:hub:port-forward` and `task kind:mcp:port-forward` in separate
 terminals while using the exported host CLI environment and MCP smoke.
-The kind control plane now starts a co-located Runtime Broker in the Hub pod.
-A kind-hosted dispatch smoke remains a follow-up because it needs a dedicated
-bootstrap flow for grove linking, templates, and restored agent credentials.
+For the full all-in-kind dispatch path, use:
+
+```bash
+task kind:control-plane:smoke
+```
+
+That smoke links the current grove to the port-forwarded kind Hub without
+rewriting host global Scion config, makes `kind-control-plane` the grove's
+default provider, checks the kind-hosted MCP Hub status, dispatches an inline
+generic no-auth smoke agent through the co-located Runtime Broker, verifies that
+a kind pod appears, and deletes the smoke agent after success unless
+`SCION_KIND_CP_SMOKE_KEEP_AGENT=1` is set.
 
 ## End-To-End Smoke
 
@@ -115,15 +124,42 @@ Useful overrides:
 | `SCION_E2E_MCP_WATCH_SECONDS` | `90` |
 | `SCION_OPS_MCP_URL` | `http://127.0.0.1:8765/mcp` |
 
+## kind Control-Plane Smoke
+
+Run the experimental all-in-kind path with:
+
+```bash
+task kind:control-plane:smoke
+```
+
+Use `--skip-setup` when the kind cluster and control plane already exist:
+
+```bash
+task kind:control-plane:smoke -- --skip-setup
+```
+
+Use `--no-port-forward` when `task kind:hub:port-forward` and
+`task kind:mcp:port-forward` are already running in separate terminals. The
+smoke defaults to an inline `generic` harness config with `--no-auth`, so it
+proves dispatch and pod creation without requiring subscription credentials,
+custom template upload, or harness-config upload in the kind Hub. Use
+`--skip-mcp` for a Hub/broker-only dispatch check on an existing kind cluster
+that was created before the workspace mount was added.
+
 ## Images
 
-The default smoke template uses the Claude harness image. Build and load it
-before running the end-to-end smoke if the kind node does not already have it:
+The host-managed end-to-end smoke default template uses the Claude harness
+image. Build and load it before running `task smoke:e2e` if the kind node does
+not already have it:
 
 ```bash
 task images:build -- --harness claude
 task kind:load-images -- localhost/scion-base:latest localhost/scion-claude:latest
 ```
+
+The kind control-plane smoke uses `localhost/scion-base:latest` for Hub and the
+inline generic smoke pod, plus `localhost/scion-ops-mcp:latest` for the
+kind-hosted MCP service.
 
 If the kind provider cannot see Podman images directly, use an archive:
 

--- a/scripts/kind-control-plane-smoke.py
+++ b/scripts/kind-control-plane-smoke.py
@@ -1,0 +1,905 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "mcp>=1.13,<2",
+# ]
+# ///
+"""Smoke test the kind-hosted Scion control plane."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_HUB_PORT = int(os.environ.get("SCION_OPS_KIND_HUB_PORT", "18090"))
+DEFAULT_HUB_ENDPOINT = os.environ.get(
+    "SCION_OPS_KIND_HUB_URL",
+    f"http://127.0.0.1:{DEFAULT_HUB_PORT}",
+)
+DEFAULT_MCP_URL = os.environ.get("SCION_OPS_MCP_URL", "http://127.0.0.1:8765/mcp")
+DEFAULT_GENERIC_PROMPT = "printf 'scion kind control-plane smoke\\n'; pwd; sleep 30"
+DEFAULT_TEMPLATE_PROMPT = "Smoke test: report the current working directory and stop."
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+EXPORT_RE = re.compile(r"^export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+IMAGE_HINT = (
+    "Build and load the smoke agent image, then retry:\n"
+    "  task images:build -- --harness claude\n"
+    "  task kind:load-images -- localhost/scion-base:latest localhost/scion-claude:latest"
+)
+
+
+@dataclass
+class CommandResult:
+    args: list[str]
+    returncode: int
+    output: str
+
+
+class SmokeFailure(RuntimeError):
+    def __init__(
+        self,
+        category: str,
+        message: str,
+        *,
+        hint: str = "",
+        output: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.hint = hint
+        self.output = output
+
+
+def log(message: str) -> None:
+    print(f"==> {message}", flush=True)
+
+
+def command_line(args: list[str]) -> str:
+    return shlex.join(args)
+
+
+def classify_output(output: str, default: str) -> str:
+    text = "\n".join(
+        line
+        for line in output.lower().splitlines()
+        if "development authentication enabled" not in line
+    )
+    if "unauthorized" in text or "forbidden" in text or "authentication" in text:
+        return "hub_auth"
+    if "not_found" in text or "not found" in text:
+        return "hub_state"
+    if "env-gather" in text or "required environment variable" in text:
+        return "hub_state"
+    if "broker" in text or "provider" in text or "dispatch" in text:
+        return "broker_dispatch"
+    if "imagepullbackoff" in text or "errimagepull" in text or "pull image" in text:
+        return "image"
+    if "kubernetes" in text or "kubectl" in text or "pod" in text or "namespace" in text:
+        return "kubernetes"
+    return default
+
+
+def hint_for_output(output: str, default: str) -> str:
+    category = classify_output(output, "")
+    if category == "hub_auth":
+        return 'Refresh kind Hub auth:\n  eval "$(task kind:hub:auth-export)"'
+    if category == "broker_dispatch":
+        return "Check the co-located broker:\n  task kind:broker:status"
+    if category == "image":
+        return IMAGE_HINT
+    if category == "kubernetes":
+        return (
+            "Check the kind control plane:\n"
+            "  task kind:workspace:status\n"
+            "  task kind:control-plane:status"
+        )
+    return default
+
+
+def run(
+    args: list[str],
+    *,
+    env: dict[str, str],
+    category: str,
+    hint: str = "",
+    timeout: int = 180,
+    check: bool = True,
+    quiet: bool = False,
+) -> CommandResult:
+    if not quiet:
+        print(f"+ {command_line(args)}", flush=True)
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise SmokeFailure(category, f"{args[0]} is not on PATH", hint=hint, output=str(exc)) from exc
+    except subprocess.TimeoutExpired as exc:
+        output = exc.stdout or ""
+        if isinstance(output, bytes):
+            output = output.decode(errors="replace")
+        raise SmokeFailure(
+            category,
+            f"command timed out after {timeout}s: {command_line(args)}",
+            hint=hint,
+            output=output,
+        ) from exc
+
+    output = proc.stdout or ""
+    if output and not quiet:
+        print(output.rstrip(), flush=True)
+    if check and proc.returncode != 0:
+        raise SmokeFailure(
+            classify_output(output, category),
+            f"command failed with exit {proc.returncode}: {command_line(args)}",
+            hint=hint_for_output(output, hint),
+            output=output,
+        )
+    return CommandResult(args=args, returncode=proc.returncode, output=output)
+
+
+def parse_exports(output: str) -> dict[str, str]:
+    exports: dict[str, str] = {}
+    for line in output.splitlines():
+        match = EXPORT_RE.match(line.strip())
+        if match:
+            key, value = match.groups()
+            exports[key] = value.strip().strip("'\"")
+    return exports
+
+
+def hub_port(endpoint: str) -> int:
+    parsed = urllib.parse.urlparse(endpoint)
+    if parsed.port:
+        return parsed.port
+    if parsed.scheme == "https":
+        return 443
+    return 80
+
+
+def service_url(endpoint: str, path: str) -> str:
+    return endpoint.rstrip("/") + "/" + path.lstrip("/")
+
+
+def http_ready(endpoint: str) -> bool:
+    try:
+        with urllib.request.urlopen(service_url(endpoint, "/healthz"), timeout=1) as response:
+            return 200 <= response.status < 300
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def process_output(process: subprocess.Popen[str]) -> str:
+    if process.stdout is None:
+        return ""
+    try:
+        output, _ = process.communicate(timeout=1)
+        return output or ""
+    except subprocess.TimeoutExpired:
+        return ""
+
+
+def start_port_forward(
+    *,
+    env: dict[str, str],
+    context: str,
+    namespace: str,
+    service: str,
+    local_port: int,
+    remote_port: int,
+) -> subprocess.Popen[str]:
+    args = [
+        "kubectl",
+        "--context",
+        context,
+        "-n",
+        namespace,
+        "port-forward",
+        f"svc/{service}",
+        f"{local_port}:{remote_port}",
+    ]
+    print(f"+ {command_line(args)}", flush=True)
+    return subprocess.Popen(
+        args,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def stop_process(process: subprocess.Popen[str] | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def ensure_hub_forward(
+    *,
+    env: dict[str, str],
+    endpoint: str,
+    context: str,
+    namespace: str,
+    allow_start: bool,
+    timeout_seconds: int,
+) -> subprocess.Popen[str] | None:
+    if http_ready(endpoint):
+        log(f"reuse kind Hub at {endpoint}")
+        return None
+    if not allow_start:
+        raise SmokeFailure(
+            "hub_unavailable",
+            f"kind Hub is not reachable at {endpoint}",
+            hint="Start a port-forward:\n  task kind:hub:port-forward",
+        )
+
+    local_port = hub_port(endpoint)
+    log(f"start kind Hub port-forward at {endpoint}")
+    process = start_port_forward(
+        env=env,
+        context=context,
+        namespace=namespace,
+        service="scion-hub",
+        local_port=local_port,
+        remote_port=8090,
+    )
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() <= deadline:
+        if process.poll() is not None:
+            raise SmokeFailure(
+                "hub_unavailable",
+                f"kind Hub port-forward exited with {process.returncode}",
+                hint="Check the Hub service:\n  task kind:control-plane:status",
+                output=process_output(process),
+            )
+        if http_ready(endpoint):
+            return process
+        time.sleep(0.25)
+    output = process_output(process)
+    stop_process(process)
+    raise SmokeFailure(
+        "hub_unavailable",
+        f"kind Hub was not reachable at {endpoint} within {timeout_seconds}s",
+        hint="Check the Hub service:\n  task kind:control-plane:status",
+        output=output,
+    )
+
+
+def extract_json_object(output: str) -> dict[str, Any]:
+    cleaned = ANSI_RE.sub("", output)
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"{", cleaned):
+        try:
+            data, _ = decoder.raw_decode(cleaned[match.start() :])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            return data
+    raise json.JSONDecodeError("no JSON object found", cleaned, 0)
+
+
+def ensure_kind_hub_auth(env: dict[str, str], *, endpoint: str) -> None:
+    env["SCION_OPS_KIND_HUB_PORT"] = str(hub_port(endpoint))
+    result = run(
+        ["task", "kind:hub:auth-export"],
+        env=env,
+        category="hub_auth",
+        hint="Deploy the kind control plane first:\n  task kind:control-plane:apply",
+        timeout=60,
+        quiet=True,
+    )
+    exports = parse_exports(result.output)
+    token = exports.get("SCION_DEV_TOKEN", "")
+    if not token.startswith("scion_dev_"):
+        raise SmokeFailure(
+            "hub_auth",
+            "could not read SCION_DEV_TOKEN from the kind Hub pod",
+            hint="Check the Hub pod:\n  task kind:control-plane:status\n  task kind:hub:logs",
+            output=result.output,
+        )
+    env["SCION_DEV_TOKEN"] = token
+    env["SCION_HUB_ENDPOINT"] = endpoint
+    env["HUB_ENDPOINT"] = endpoint
+
+
+def template_harness_config(template: str) -> str:
+    config = ROOT / ".scion" / "templates" / template / "scion-agent.yaml"
+    if not config.exists():
+        return ""
+    match = re.search(r"^\s*default_harness_config:\s*['\"]?([^'\"\s#]+)", config.read_text(), re.M)
+    return match.group(1) if match else ""
+
+
+def bootstrap_grove(
+    *,
+    env: dict[str, str],
+    scion_bin: str,
+    endpoint: str,
+    template: str | None,
+    broker: str,
+    sync_harness: bool,
+    sync_template: bool,
+) -> None:
+    log("link current grove to the kind Hub")
+    run(
+        [scion_bin, "hub", "link", "--hub", endpoint, "--non-interactive", "--yes"],
+        env=env,
+        category="hub_state",
+        hint="Check kind Hub auth:\n  eval \"$(task kind:hub:auth-export)\"",
+        timeout=90,
+    )
+
+    harness = template_harness_config(template or "")
+    if sync_harness and harness:
+        log(f"sync harness config {harness}")
+        run(
+            [
+                scion_bin,
+                "harness-config",
+                "sync",
+                harness,
+                "--hub",
+                endpoint,
+                "--non-interactive",
+                "--yes",
+            ],
+            env=env,
+            category="hub_state",
+            hint=f"Prepare local harness config first:\n  task hub:prepare-{harness}-harness",
+            timeout=120,
+        )
+
+    if sync_template and template:
+        log(f"sync smoke template {template}")
+        run(
+            [
+                scion_bin,
+                "templates",
+                "sync",
+                template,
+                "--hub",
+                endpoint,
+                "--non-interactive",
+                "--yes",
+            ],
+            env=env,
+            category="hub_state",
+            hint="Check local templates under .scion/templates",
+            timeout=120,
+        )
+
+    log(f"provide current grove from broker {broker}")
+    run(
+        [
+            scion_bin,
+            "broker",
+            "provide",
+            "--broker",
+            broker,
+            "--make-default",
+            "--non-interactive",
+            "--yes",
+        ],
+        env=env,
+        category="broker_dispatch",
+        hint="Check the co-located broker:\n  task kind:broker:status",
+        timeout=120,
+    )
+
+
+def verify_broker(
+    *,
+    env: dict[str, str],
+    scion_bin: str,
+    endpoint: str,
+    broker: str,
+) -> None:
+    result = run(
+        [
+            scion_bin,
+            "hub",
+            "brokers",
+            "info",
+            broker,
+            "--hub",
+            endpoint,
+            "--json",
+            "--non-interactive",
+        ],
+        env=env,
+        category="broker_dispatch",
+        hint="Check the co-located broker:\n  task kind:broker:status",
+        timeout=60,
+    )
+    try:
+        data = extract_json_object(result.output)
+    except json.JSONDecodeError as exc:
+        raise SmokeFailure(
+            "broker_dispatch",
+            f"could not parse broker info for {broker}",
+            output=result.output,
+        ) from exc
+
+    status = str(data.get("status") or data.get("brokerStatus") or "").lower()
+    if status and status != "online":
+        raise SmokeFailure(
+            "broker_dispatch",
+            f"broker {broker} is not online: {status}",
+            hint="Check the co-located broker:\n  task kind:broker:status",
+            output=json.dumps(data, indent=2),
+        )
+
+
+async def mcp_hub_status(url: str, *, read_timeout: int = 30) -> dict[str, Any]:
+    async with streamablehttp_client(url, timeout=5, sse_read_timeout=read_timeout) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("scion_ops_hub_status", {})
+    text = "\n".join(part.text for part in result.content if hasattr(part, "text"))
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SmokeFailure(
+            "mcp_transport",
+            "MCP hub status returned non-JSON output",
+            hint="Check the kind MCP server:\n  task kind:mcp:status",
+            output=text,
+        ) from exc
+
+
+async def ensure_mcp(
+    *,
+    env: dict[str, str],
+    url: str,
+    context: str,
+    namespace: str,
+    allow_start: bool,
+    timeout_seconds: int,
+) -> tuple[subprocess.Popen[str] | None, dict[str, Any]]:
+    try:
+        return None, await mcp_hub_status(url, read_timeout=20)
+    except Exception as first_error:
+        if not allow_start:
+            raise SmokeFailure(
+                "mcp_transport",
+                f"kind MCP is not reachable at {url}: {first_error}",
+                hint="Start a port-forward:\n  task kind:mcp:port-forward",
+            ) from first_error
+
+    parsed = urllib.parse.urlparse(url)
+    local_port = parsed.port or 8765
+    log(f"start kind MCP port-forward at {url}")
+    process = start_port_forward(
+        env=env,
+        context=context,
+        namespace=namespace,
+        service="scion-ops-mcp",
+        local_port=local_port,
+        remote_port=8765,
+    )
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() <= deadline:
+        if process.poll() is not None:
+            raise SmokeFailure(
+                "mcp_transport",
+                f"kind MCP port-forward exited with {process.returncode}",
+                hint="Check the MCP service:\n  task kind:mcp:status",
+                output=process_output(process),
+            )
+        try:
+            return process, await mcp_hub_status(url, read_timeout=20)
+        except Exception as exc:
+            last_error = exc
+            await asyncio.sleep(0.5)
+    output = process_output(process)
+    stop_process(process)
+    raise SmokeFailure(
+        "mcp_transport",
+        f"kind MCP was not ready at {url}: {last_error}",
+        hint="Check the MCP service:\n  task kind:mcp:status",
+        output=output,
+    )
+
+
+def check_mcp_status(payload: dict[str, Any]) -> None:
+    if payload.get("ok") is not False:
+        return
+    raise SmokeFailure(
+        str(payload.get("error_kind") or "mcp_transport"),
+        f"MCP Hub status failed: {payload.get('error') or payload}",
+        hint="Check current grove bootstrap and MCP logs:\n  task kind:mcp:logs",
+        output=json.dumps(payload, indent=2),
+    )
+
+
+def pod_data(env: dict[str, str], context: str, namespace: str, agent: str) -> dict[str, Any]:
+    result = run(
+        [
+            "kubectl",
+            "--context",
+            context,
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            f"scion.name={agent}",
+            "-o",
+            "json",
+        ],
+        env=env,
+        category="kubernetes",
+        check=False,
+        quiet=True,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise SmokeFailure(
+            "kubernetes",
+            "kubectl could not read smoke pod state",
+            hint="Check the kind runtime:\n  task kind:status",
+            output=result.output,
+        )
+    return json.loads(result.output)
+
+
+def pod_waiting_reason(pod: dict[str, Any]) -> tuple[str, str]:
+    statuses = pod.get("status", {}).get("containerStatuses") or []
+    statuses += pod.get("status", {}).get("initContainerStatuses") or []
+    for status in statuses:
+        waiting = status.get("state", {}).get("waiting")
+        if waiting:
+            return str(waiting.get("reason") or ""), str(waiting.get("message") or "")
+    return "", ""
+
+
+def describe_pods(env: dict[str, str], context: str, namespace: str, agent: str) -> str:
+    result = run(
+        [
+            "kubectl",
+            "--context",
+            context,
+            "describe",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            f"scion.name={agent}",
+        ],
+        env=env,
+        category="kubernetes",
+        check=False,
+        quiet=True,
+        timeout=30,
+    )
+    return result.output
+
+
+def wait_for_kind_pod(
+    *,
+    env: dict[str, str],
+    context: str,
+    namespace: str,
+    agent: str,
+    timeout_seconds: int,
+) -> list[dict[str, Any]]:
+    log(f"wait for kind pod scion.name={agent}")
+    deadline = time.monotonic() + timeout_seconds
+    last_data: dict[str, Any] | None = None
+    while time.monotonic() <= deadline:
+        data = pod_data(env, context, namespace, agent)
+        last_data = data
+        pods = [item for item in data.get("items", []) if isinstance(item, dict)]
+        if pods:
+            for pod in pods:
+                reason, message = pod_waiting_reason(pod)
+                if reason.lower() in {"errimagepull", "imagepullbackoff", "invalidimagename"}:
+                    describe = describe_pods(env, context, namespace, agent)
+                    raise SmokeFailure(
+                        "image",
+                        f"kind pod cannot pull its image: {reason}",
+                        hint=IMAGE_HINT,
+                        output=f"{message}\n\n{describe}",
+                    )
+            run(
+                [
+                    "kubectl",
+                    "--context",
+                    context,
+                    "get",
+                    "pods",
+                    "-n",
+                    namespace,
+                    "-l",
+                    f"scion.name={agent}",
+                    "-o",
+                    "wide",
+                ],
+                env=env,
+                category="kubernetes",
+                timeout=20,
+            )
+            return pods
+        time.sleep(1)
+
+    raise SmokeFailure(
+        "kubernetes",
+        f"no kind pod appeared for {agent} within {timeout_seconds}s",
+        hint="Check Hub provider routing and the kind broker:\n  task kind:broker:status",
+        output=json.dumps(last_data or {}, indent=2),
+    )
+
+
+def cleanup_command(agent: str, hub_endpoint: str) -> str:
+    return f"scion delete {shlex.quote(agent)} --hub {shlex.quote(hub_endpoint)} --non-interactive --yes"
+
+
+def print_cleanup(agent: str, hub_endpoint: str, context: str, namespace: str) -> None:
+    print("\nCleanup commands:")
+    print(f"  {cleanup_command(agent, hub_endpoint)}")
+    print(f"  kubectl --context {context} get pods -n {namespace} -l scion.name={agent}")
+
+
+def write_generic_inline_config(tmpdir: Path) -> Path:
+    path = tmpdir / "generic-smoke.yaml"
+    path.write_text(
+        "\n".join(
+            [
+                'schema_version: "1"',
+                "harness_config: generic",
+                "image: localhost/scion-base:latest",
+                "user: scion",
+                "command_args:",
+                "  - /bin/sh",
+                "  - -lc",
+                "max_duration: 2m",
+                "",
+            ]
+        )
+    )
+    return path
+
+
+def parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", default=os.environ.get("SCION_KIND_CP_SMOKE_AGENT", ""))
+    parser.add_argument(
+        "--template",
+        default=os.environ.get("SCION_KIND_CP_SMOKE_TEMPLATE", ""),
+        help="use an existing Hub template instead of the inline generic no-auth config",
+    )
+    parser.add_argument("--broker", default=os.environ.get("SCION_KIND_CP_BROKER", "kind-control-plane"))
+    parser.add_argument("--prompt", default=os.environ.get("SCION_KIND_CP_SMOKE_PROMPT", ""))
+    parser.add_argument("--profile", default=os.environ.get("SCION_K8S_PROFILE", "kind"))
+    parser.add_argument("--cluster", default=os.environ.get("KIND_CLUSTER_NAME", "scion-ops"))
+    parser.add_argument("--namespace", default=os.environ.get("SCION_K8S_NAMESPACE", "scion-agents"))
+    parser.add_argument("--hub", default=os.environ.get("HUB_ENDPOINT", DEFAULT_HUB_ENDPOINT))
+    parser.add_argument("--mcp-url", default=DEFAULT_MCP_URL)
+    parser.add_argument("--timeout", type=int, default=int(os.environ.get("SCION_KIND_CP_SMOKE_TIMEOUT", "90")))
+    parser.add_argument("--startup-timeout", type=int, default=30)
+    parser.add_argument(
+        "--skip-setup",
+        action="store_true",
+        default=os.environ.get("SCION_KIND_CP_SMOKE_SKIP_SETUP", "").lower()
+        in {"1", "true", "yes", "on"},
+        help="skip kind:up, workspace status, and control-plane apply",
+    )
+    parser.add_argument(
+        "--skip-bootstrap",
+        action="store_true",
+        help="skip grove link, harness config sync, template sync, and broker provide",
+    )
+    parser.add_argument(
+        "--sync-harness-config",
+        action="store_true",
+        default=os.environ.get("SCION_KIND_CP_SMOKE_SYNC_HARNESS_CONFIG", "").lower()
+        in {"1", "true", "yes", "on"},
+        help="also sync the selected template's default harness config",
+    )
+    parser.add_argument("--skip-harness-sync", action="store_false", dest="sync_harness_config")
+    parser.add_argument(
+        "--sync-template",
+        action="store_true",
+        default=os.environ.get("SCION_KIND_CP_SMOKE_SYNC_TEMPLATE", "").lower()
+        in {"1", "true", "yes", "on"},
+        help="sync --template before dispatching; requires a Hub storage backend that supports remote uploads",
+    )
+    parser.add_argument("--skip-template-sync", action="store_false", dest="sync_template")
+    parser.add_argument("--skip-mcp", action="store_true")
+    parser.add_argument(
+        "--no-port-forward",
+        action="store_true",
+        help="require existing Hub/MCP port-forwards instead of starting temporary ones",
+    )
+    parser.add_argument(
+        "--keep-agent",
+        action="store_true",
+        default=os.environ.get("SCION_KIND_CP_SMOKE_KEEP_AGENT", "").lower()
+        in {"1", "true", "yes", "on"},
+        help="leave the smoke agent behind for inspection",
+    )
+    return parser
+
+
+async def smoke(args: argparse.Namespace) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HUB_ENDPOINT": args.hub,
+            "SCION_HUB_ENDPOINT": args.hub,
+            "SCION_OPS_ROOT": str(ROOT),
+            "SCION_OPS_MCP_URL": args.mcp_url,
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    scion_bin = env.get("SCION_BIN", "scion")
+    context = f"kind-{args.cluster}"
+    agent = args.agent or f"kind-cp-smoke-{time.strftime('%Y%m%d%H%M%S')}"
+    prompt = args.prompt or (DEFAULT_TEMPLATE_PROMPT if args.template else DEFAULT_GENERIC_PROMPT)
+    hub_forward: subprocess.Popen[str] | None = None
+    mcp_forward: subprocess.Popen[str] | None = None
+    agent_started = False
+    success = False
+
+    with tempfile.TemporaryDirectory(prefix="scion-kind-cp-smoke-") as tmp:
+        tmpdir = Path(tmp)
+        inline_config = None if args.template else write_generic_inline_config(tmpdir)
+
+        try:
+            if not args.skip_setup:
+                run(["task", "kind:up"], env=env, category="kubernetes", timeout=300)
+                if args.skip_mcp:
+                    run(["task", "kind:hub:apply"], env=env, category="kubernetes", timeout=180)
+                else:
+                    run(["task", "kind:workspace:status"], env=env, category="kubernetes", timeout=90)
+                    run(["task", "kind:control-plane:apply"], env=env, category="kubernetes", timeout=180)
+
+            status_task = "kind:hub:status" if args.skip_mcp else "kind:control-plane:status"
+            run(["task", status_task], env=env, category="kubernetes", timeout=180)
+            ensure_kind_hub_auth(env, endpoint=args.hub)
+            hub_forward = ensure_hub_forward(
+                env=env,
+                endpoint=args.hub,
+                context=context,
+                namespace=args.namespace,
+                allow_start=not args.no_port_forward,
+                timeout_seconds=args.startup_timeout,
+            )
+
+            if not args.skip_bootstrap:
+                bootstrap_grove(
+                    env=env,
+                    scion_bin=scion_bin,
+                    endpoint=args.hub,
+                    template=args.template or None,
+                    broker=args.broker,
+                    sync_harness=args.sync_harness_config,
+                    sync_template=args.sync_template,
+                )
+
+            verify_broker(env=env, scion_bin=scion_bin, endpoint=args.hub, broker=args.broker)
+
+            if not args.skip_mcp:
+                mcp_forward, hub_status = await ensure_mcp(
+                    env=env,
+                    url=args.mcp_url,
+                    context=context,
+                    namespace=args.namespace,
+                    allow_start=not args.no_port_forward,
+                    timeout_seconds=args.startup_timeout,
+                )
+                check_mcp_status(hub_status)
+
+            log(f"dispatch {agent} through kind Hub broker {args.broker}")
+            start_args = [
+                scion_bin,
+                "--profile",
+                args.profile,
+                "start",
+                agent,
+                "--broker",
+                args.broker,
+                "--no-auth",
+                "--hub",
+                args.hub,
+                "--non-interactive",
+                "--yes",
+            ]
+            if args.template:
+                start_args += ["--type", args.template, "--no-upload"]
+            elif inline_config:
+                start_args += ["--config", str(inline_config)]
+            start_args.append(prompt)
+            run(
+                start_args,
+                env=env,
+                category="broker_dispatch",
+                hint="Check Hub provider routing and the kind broker:\n  task kind:broker:status",
+                timeout=120,
+            )
+            agent_started = True
+
+            pods = wait_for_kind_pod(
+                env=env,
+                context=context,
+                namespace=args.namespace,
+                agent=agent,
+                timeout_seconds=args.timeout,
+            )
+
+            print("\nkind control-plane smoke passed")
+            print(f"  agent:      {agent}")
+            print(f"  hub:        {args.hub}")
+            print(f"  mcp:        {'skipped' if args.skip_mcp else args.mcp_url}")
+            print(f"  broker:     {args.broker}")
+            print(f"  config:     {args.template or 'inline-generic'}")
+            print(f"  kind:       {context}/{args.namespace}")
+            print(f"  pod_count:  {len(pods)}")
+            success = True
+        finally:
+            if agent_started and success and not args.keep_agent:
+                log(f"delete smoke agent {agent}")
+                run(
+                    [scion_bin, "delete", agent, "--hub", args.hub, "--non-interactive", "--yes"],
+                    env=env,
+                    category="cleanup",
+                    check=False,
+                    timeout=60,
+                )
+            elif agent_started:
+                print_cleanup(agent, args.hub, context, args.namespace)
+            stop_process(mcp_forward)
+            stop_process(hub_forward)
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        asyncio.run(smoke(args))
+    except SmokeFailure as exc:
+        print(f"\nkind control-plane smoke failed [{exc.category}]: {exc}", file=sys.stderr)
+        if exc.hint:
+            print(f"\nNext checks:\n{exc.hint}", file=sys.stderr)
+        if exc.output:
+            print("\nDiagnostic output:", file=sys.stderr)
+            print(exc.output.rstrip(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #27

## Summary

- add `task kind:control-plane:smoke` and `scripts/kind-control-plane-smoke.py`
- bootstrap the current grove into the port-forwarded kind Hub without `task hub:link` or `scion config set hub.endpoint`
- use an inline `generic` no-auth smoke config by default, with template/harness sync left as explicit opt-ins for storage backends that support remote uploads
- document the kind control-plane smoke flow, image requirements, existing-cluster `--skip-mcp` path, and the local-storage upload limitation

## Verification

- `uv run scripts/kind-control-plane-smoke.py --help`
- `python3 -c 'import ast, pathlib; ast.parse(pathlib.Path("scripts/kind-control-plane-smoke.py").read_text())'`
- `git diff --check`
- `task verify` (no recognized manifest, no-op)
- `task kind:control-plane:smoke -- --skip-mcp --skip-setup`
- `KIND_CLUSTER_NAME=scion-ops-cp-smoke task kind:control-plane:smoke` in a disposable kind cluster with workspace mount; passed full Hub + MCP + broker dispatch path, then deleted `scion-ops-cp-smoke`
