### PR TITLE
Use kind native ports for Hub and MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ upstream Scion checkout at `~/workspace/github/GoogleCloudPlatform/scion` unless
 you pass `task build -- --src <path>`.
 
 ```bash
+task x          # build, create/update, deploy, and smoke test
 task build      # build all Scion and scion-ops images
 task up         # create/update kind and apply the Kubernetes control plane
 task test       # smoke test Hub, broker, MCP, and Kubernetes agent dispatch
@@ -47,7 +48,7 @@ kind cluster:
 host:
   repo checkout
   container image build source
-  kubectl port-forwards for local inspection and Zed
+  kind native localhost ports for Hub and Zed
 ```
 
 The Kubernetes resources are native Kustomize manifests under `deploy/kind`.
@@ -56,12 +57,12 @@ come later only if the values and lifecycle model justify it.
 
 ## MCP And Zed
 
-The supported MCP transport is the Kubernetes-hosted HTTP service. Start the
-deployment, then expose MCP locally:
+The supported MCP transport is the Kubernetes-hosted HTTP service. `task up`
+creates kind native port mappings, so MCP is available on localhost without a
+`kubectl port-forward` process:
 
 ```bash
 task up
-task kind:mcp:port-forward
 ```
 
 Configure Zed with:
@@ -76,7 +77,7 @@ Configure Zed with:
 }
 ```
 
-Smoke test the forwarded service with `task kind:mcp:smoke`. See
+Smoke test the localhost service with `task kind:mcp:smoke`. See
 `docs/zed-mcp.md`.
 
 ## Layout

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,13 @@ vars:
   SCION_BIN: scion
 
 tasks:
+  x:
+    desc: Build, deploy/update, and smoke test the Kubernetes deployment.
+    cmds:
+      - task: build
+      - task: up
+      - task: test
+
   build:
     desc: Build all Scion images required by the Kubernetes deployment.
     cmds:
@@ -163,10 +170,6 @@ tasks:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub
 
-  kind:hub:port-forward:
-    cmds:
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' port-forward svc/scion-hub '{{.SCION_OPS_KIND_HUB_PORT}}':8090
-
   kind:hub:auth-export:
     silent: true
     cmds:
@@ -193,10 +196,6 @@ tasks:
   kind:mcp:logs:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-ops-mcp
-
-  kind:mcp:port-forward:
-    cmds:
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' port-forward svc/scion-ops-mcp '{{.SCION_OPS_MCP_PORT}}':8765
 
   kind:mcp:smoke:
     cmds:

--- a/deploy/kind/control-plane/hub-service.yaml
+++ b/deploy/kind/control-plane/hub-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: hub
     app.kubernetes.io/part-of: scion-control-plane
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app.kubernetes.io/name: scion-hub
     app.kubernetes.io/component: hub
@@ -15,3 +15,4 @@ spec:
     - name: http
       port: 8090
       targetPort: http
+      nodePort: 30090

--- a/deploy/kind/control-plane/mcp-service.yaml
+++ b/deploy/kind/control-plane/mcp-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: mcp
     app.kubernetes.io/part-of: scion-control-plane
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app.kubernetes.io/name: scion-ops-mcp
     app.kubernetes.io/component: mcp
@@ -15,3 +15,4 @@ spec:
     - name: http
       port: 8765
       targetPort: http
+      nodePort: 30876

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -10,15 +10,18 @@ workspace bootstrap model before they are supported.
 Use the top-level lifecycle tasks:
 
 ```bash
+task x
 task build
 task up
 task test
 task down
 ```
 
-`task up` is both deploy and update. It creates or reuses the kind cluster,
-applies base runtime resources, verifies the workspace mount, loads local
-images, applies the control-plane Kustomize target, and waits for rollout.
+`task x` is the day-zero path: build images, create/update the deployment, and
+run the smoke test. `task up` is both deploy and update. It creates or reuses
+the kind cluster, applies base runtime resources, verifies the workspace mount,
+loads local images, applies the control-plane Kustomize target, and waits for
+rollout.
 
 ## Kubernetes Resources
 
@@ -41,7 +44,8 @@ deploy/kind/
     kustomization.yaml
 ```
 
-The direct apply form remains valid:
+The direct apply form remains valid after the kind cluster has been created
+with the required native port mappings:
 
 ```bash
 kubectl --context kind-scion-ops apply -k deploy/kind/control-plane
@@ -68,21 +72,18 @@ access. It does not use host Podman or Docker sockets.
 
 ## Local Access
 
-Services are ClusterIP-only by default. Use port-forwards for local tools:
+Local kind exposes Hub and MCP through kind `extraPortMappings` and fixed
+Kubernetes `NodePort` services. No `kubectl port-forward` process is part of
+the supported workflow.
 
-```bash
-task kind:hub:port-forward
-task kind:mcp:port-forward
-```
-
-In another terminal:
+After `task up`, use:
 
 ```bash
 eval "$(task kind:hub:auth-export)"
 task kind:mcp:smoke
 ```
 
-The Hub forwards to `http://127.0.0.1:18090`; MCP forwards to
+Hub is available at `http://127.0.0.1:18090`; MCP is available at
 `http://127.0.0.1:8765/mcp`.
 
 ## Smoke Test

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -27,6 +27,8 @@ directly deployable.
 | image registry | `localhost` |
 | workspace host path | current repo checkout |
 | workspace node path | `/workspace/scion-ops` |
+| Hub host URL | `http://127.0.0.1:18090` |
+| MCP host URL | `http://127.0.0.1:8765/mcp` |
 
 Override the cluster name with:
 
@@ -52,6 +54,19 @@ If the mount is missing, recreate the local cluster:
 task down
 task up
 ```
+
+## Native Ports
+
+The kind node is also created with `extraPortMappings`:
+
+| Host | kind node | Kubernetes Service |
+|---|---|---|
+| `127.0.0.1:18090` | `30090` | `scion-hub` NodePort |
+| `127.0.0.1:8765` | `30876` | `scion-ops-mcp` NodePort |
+
+Existing kind clusters cannot be mutated to add these mappings. If
+`task kind:status` reports missing kind native ports, recreate the cluster with
+`task down` and `task up`.
 
 ## Images
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -7,10 +7,10 @@ The supported verification path is Kubernetes-only.
 Use this sequence for a full local validation:
 
 ```bash
-task build
-task up
-task test
+task x
 ```
+
+`task x` expands to `task build`, `task up`, and `task test`.
 
 `task test` runs `scripts/kind-control-plane-smoke.py`. It verifies:
 
@@ -41,11 +41,11 @@ task kind:mcp:smoke
 task kind:broker:status
 ```
 
-Use port-forwards for direct local inspection:
+Use the kind-native localhost mappings for direct inspection:
 
 ```bash
-task kind:hub:port-forward
-task kind:mcp:port-forward
+eval "$(task kind:hub:auth-export)"
+task kind:mcp:smoke
 ```
 
 ## Static Verification

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -15,10 +15,10 @@ task up
 Expose MCP locally:
 
 ```bash
-task kind:mcp:port-forward
+task up
 ```
 
-The forwarded URL is:
+The local URL is:
 
 ```text
 http://127.0.0.1:8765/mcp
@@ -49,13 +49,12 @@ agent does not start MCP. Kubernetes owns the MCP server process.
 
 ## Remote Workspace
 
-If Zed runs locally and scion-ops runs on a remote host, start the port-forward
+If Zed runs locally and scion-ops runs on a remote host, run the kind deployment
 on the remote host:
 
 ```bash
 cd /home/david/workspace/github/livewyer-ops/scion-ops
 task up
-task kind:mcp:port-forward
 ```
 
 Then tunnel the local port to the remote host:

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -421,7 +421,7 @@ class HubClient:
             raise HubAPIError(
                 "Hub integration is disabled for this workspace",
                 category="hub_state",
-                details={"next": "run task up, then expose the kind Hub or MCP service with a Kubernetes port-forward"},
+                details={"next": "run task up so kind creates native Hub and MCP host port mappings"},
             )
         if not self.cfg.endpoint:
             raise HubAPIError("Hub endpoint is not configured", category="hub_state")

--- a/scripts/kind-control-plane-smoke.py
+++ b/scripts/kind-control-plane-smoke.py
@@ -196,105 +196,22 @@ def http_ready(endpoint: str) -> bool:
         return False
 
 
-def process_output(process: subprocess.Popen[str]) -> str:
-    if process.stdout is None:
-        return ""
-    try:
-        output, _ = process.communicate(timeout=1)
-        return output or ""
-    except subprocess.TimeoutExpired:
-        return ""
-
-
-def start_port_forward(
-    *,
-    env: dict[str, str],
-    context: str,
-    namespace: str,
-    service: str,
-    local_port: int,
-    remote_port: int,
-) -> subprocess.Popen[str]:
-    args = [
-        "kubectl",
-        "--context",
-        context,
-        "-n",
-        namespace,
-        "port-forward",
-        f"svc/{service}",
-        f"{local_port}:{remote_port}",
-    ]
-    print(f"+ {command_line(args)}", flush=True)
-    return subprocess.Popen(
-        args,
-        cwd=ROOT,
-        env=env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-
-
-def stop_process(process: subprocess.Popen[str] | None) -> None:
-    if process is None or process.poll() is not None:
-        return
-    process.terminate()
-    try:
-        process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.wait(timeout=5)
-
-
-def ensure_hub_forward(
-    *,
-    env: dict[str, str],
-    endpoint: str,
-    context: str,
-    namespace: str,
-    allow_start: bool,
-    timeout_seconds: int,
-) -> subprocess.Popen[str] | None:
-    if http_ready(endpoint):
-        log(f"reuse kind Hub at {endpoint}")
-        return None
-    if not allow_start:
-        raise SmokeFailure(
-            "hub_unavailable",
-            f"kind Hub is not reachable at {endpoint}",
-            hint="Start a port-forward:\n  task kind:hub:port-forward",
-        )
-
-    local_port = hub_port(endpoint)
-    log(f"start kind Hub port-forward at {endpoint}")
-    process = start_port_forward(
-        env=env,
-        context=context,
-        namespace=namespace,
-        service="scion-hub",
-        local_port=local_port,
-        remote_port=8090,
-    )
+def ensure_hub_ready(*, endpoint: str, timeout_seconds: int) -> None:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() <= deadline:
-        if process.poll() is not None:
-            raise SmokeFailure(
-                "hub_unavailable",
-                f"kind Hub port-forward exited with {process.returncode}",
-                hint="Check the Hub service:\n  task kind:control-plane:status",
-                output=process_output(process),
-            )
         if http_ready(endpoint):
-            return process
+            log(f"kind Hub is reachable at {endpoint}")
+            return
         time.sleep(0.25)
-    output = process_output(process)
-    stop_process(process)
     raise SmokeFailure(
         "hub_unavailable",
         f"kind Hub was not reachable at {endpoint} within {timeout_seconds}s",
-        hint="Check the Hub service:\n  task kind:control-plane:status",
-        output=output,
+        hint=(
+            "Check native kind port exposure and Hub rollout:\n"
+            "  task kind:status\n"
+            "  task kind:control-plane:status\n"
+            "If this is an old cluster, recreate it with task down and task up."
+        ),
     )
 
 
@@ -485,56 +402,28 @@ async def mcp_hub_status(url: str, *, read_timeout: int = 30) -> dict[str, Any]:
 
 async def ensure_mcp(
     *,
-    env: dict[str, str],
     url: str,
-    context: str,
-    namespace: str,
-    allow_start: bool,
     timeout_seconds: int,
-) -> tuple[subprocess.Popen[str] | None, dict[str, Any]]:
-    try:
-        return None, await mcp_hub_status(url, read_timeout=20)
-    except Exception as first_error:
-        if not allow_start:
-            raise SmokeFailure(
-                "mcp_transport",
-                f"kind MCP is not reachable at {url}: {first_error}",
-                hint="Start a port-forward:\n  task kind:mcp:port-forward",
-            ) from first_error
-
-    parsed = urllib.parse.urlparse(url)
-    local_port = parsed.port or 8765
-    log(f"start kind MCP port-forward at {url}")
-    process = start_port_forward(
-        env=env,
-        context=context,
-        namespace=namespace,
-        service="scion-ops-mcp",
-        local_port=local_port,
-        remote_port=8765,
-    )
+) -> dict[str, Any]:
     deadline = time.monotonic() + timeout_seconds
     last_error: Exception | None = None
     while time.monotonic() <= deadline:
-        if process.poll() is not None:
-            raise SmokeFailure(
-                "mcp_transport",
-                f"kind MCP port-forward exited with {process.returncode}",
-                hint="Check the MCP service:\n  task kind:mcp:status",
-                output=process_output(process),
-            )
         try:
-            return process, await mcp_hub_status(url, read_timeout=20)
+            payload = await mcp_hub_status(url, read_timeout=20)
+            log(f"kind MCP is reachable at {url}")
+            return payload
         except Exception as exc:
             last_error = exc
             await asyncio.sleep(0.5)
-    output = process_output(process)
-    stop_process(process)
     raise SmokeFailure(
         "mcp_transport",
         f"kind MCP was not ready at {url}: {last_error}",
-        hint="Check the MCP service:\n  task kind:mcp:status",
-        output=output,
+        hint=(
+            "Check native kind port exposure and MCP rollout:\n"
+            "  task kind:status\n"
+            "  task kind:mcp:status\n"
+            "If this is an old cluster, recreate it with task down and task up."
+        ),
     )
 
 
@@ -744,11 +633,6 @@ def parser() -> argparse.ArgumentParser:
     parser.add_argument("--skip-template-sync", action="store_false", dest="sync_template")
     parser.add_argument("--skip-mcp", action="store_true")
     parser.add_argument(
-        "--no-port-forward",
-        action="store_true",
-        help="require existing Hub/MCP port-forwards instead of starting temporary ones",
-    )
-    parser.add_argument(
         "--keep-agent",
         action="store_true",
         default=os.environ.get("SCION_KIND_CP_SMOKE_KEEP_AGENT", "").lower()
@@ -773,8 +657,6 @@ async def smoke(args: argparse.Namespace) -> None:
     context = f"kind-{args.cluster}"
     agent = args.agent or f"kind-cp-smoke-{time.strftime('%Y%m%d%H%M%S')}"
     prompt = args.prompt or (DEFAULT_TEMPLATE_PROMPT if args.template else DEFAULT_GENERIC_PROMPT)
-    hub_forward: subprocess.Popen[str] | None = None
-    mcp_forward: subprocess.Popen[str] | None = None
     agent_started = False
     success = False
 
@@ -794,12 +676,8 @@ async def smoke(args: argparse.Namespace) -> None:
             status_task = "kind:hub:status" if args.skip_mcp else "kind:control-plane:status"
             run(["task", status_task], env=env, category="kubernetes", timeout=180)
             ensure_kind_hub_auth(env, endpoint=args.hub)
-            hub_forward = ensure_hub_forward(
-                env=env,
+            ensure_hub_ready(
                 endpoint=args.hub,
-                context=context,
-                namespace=args.namespace,
-                allow_start=not args.no_port_forward,
                 timeout_seconds=args.startup_timeout,
             )
 
@@ -817,12 +695,8 @@ async def smoke(args: argparse.Namespace) -> None:
             verify_broker(env=env, scion_bin=scion_bin, endpoint=args.hub, broker=args.broker)
 
             if not args.skip_mcp:
-                mcp_forward, hub_status = await ensure_mcp(
-                    env=env,
+                hub_status = await ensure_mcp(
                     url=args.mcp_url,
-                    context=context,
-                    namespace=args.namespace,
-                    allow_start=not args.no_port_forward,
                     timeout_seconds=args.startup_timeout,
                 )
                 check_mcp_status(hub_status)
@@ -885,8 +759,6 @@ async def smoke(args: argparse.Namespace) -> None:
                 )
             elif agent_started:
                 print_cleanup(agent, args.hub, context, args.namespace)
-            stop_process(mcp_forward)
-            stop_process(hub_forward)
 
 
 def main() -> int:

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -13,6 +13,11 @@ IMAGE_REGISTRY="${SCION_IMAGE_REGISTRY:-localhost}"
 MANIFEST_DIR="${SCION_K8S_MANIFEST_DIR:-${REPO_ROOT}/deploy/kind}"
 WORKSPACE_HOST_PATH="${SCION_OPS_WORKSPACE_HOST_PATH:-$REPO_ROOT}"
 WORKSPACE_NODE_PATH="${SCION_OPS_WORKSPACE_NODE_PATH:-/workspace/scion-ops}"
+KIND_LISTEN_ADDRESS="${SCION_OPS_KIND_LISTEN_ADDRESS:-127.0.0.1}"
+HUB_HOST_PORT="${SCION_OPS_KIND_HUB_PORT:-18090}"
+MCP_HOST_PORT="${SCION_OPS_MCP_PORT:-8765}"
+HUB_NODE_PORT="30090"
+MCP_NODE_PORT="30876"
 CONTEXT="kind-${CLUSTER_NAME}"
 
 usage() {
@@ -40,6 +45,10 @@ Environment:
                                  (default: this repo)
   SCION_OPS_WORKSPACE_NODE_PATH  Node path used by future MCP hostPath mounts
                                  (default: /workspace/scion-ops)
+  SCION_OPS_KIND_LISTEN_ADDRESS  Host listen address for kind port mappings
+                                 (default: 127.0.0.1)
+  SCION_OPS_KIND_HUB_PORT        Host port for the Hub service (default: 18090)
+  SCION_OPS_MCP_PORT             Host port for the MCP service (default: 8765)
 EOF
 }
 
@@ -79,6 +88,15 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  extraPortMappings:
+  - containerPort: ${HUB_NODE_PORT}
+    hostPort: ${HUB_HOST_PORT}
+    listenAddress: "${KIND_LISTEN_ADDRESS}"
+    protocol: TCP
+  - containerPort: ${MCP_NODE_PORT}
+    hostPort: ${MCP_HOST_PORT}
+    listenAddress: "${KIND_LISTEN_ADDRESS}"
+    protocol: TCP
   extraMounts:
   - hostPath: ${WORKSPACE_HOST_PATH}
     containerPath: ${WORKSPACE_NODE_PATH}
@@ -116,21 +134,60 @@ workspace_mount_present() {
     "$runtime" exec "$node" test -d "${WORKSPACE_NODE_PATH}/.git"
 }
 
+kind_native_ports_present() {
+  local node
+  local runtime
+  local bindings
+
+  node="$(kind_node_name)"
+  [[ -n "$node" ]] || return 1
+  runtime="$(container_runtime_for_node "$node")" || return 1
+  bindings="$("$runtime" container inspect --format '{{json .HostConfig.PortBindings}}' "$node" 2>/dev/null || true)"
+
+  [[ "$bindings" == *"\"${HUB_NODE_PORT}/tcp\""* ]] &&
+    [[ "$bindings" == *"\"${MCP_NODE_PORT}/tcp\""* ]] &&
+    [[ "$bindings" == *"\"HostPort\":\"${HUB_HOST_PORT}\""* ]] &&
+    [[ "$bindings" == *"\"HostPort\":\"${MCP_HOST_PORT}\""* ]]
+}
+
 warn_missing_workspace_mount() {
   cat >&2 <<EOF
 Warning: workspace mount is not available inside kind node ${WORKSPACE_NODE_PATH}.
 Existing kind clusters cannot be updated with new extraMounts. Recreate this
-cluster with 'task kind:down && task kind:up' before deploying a kind-hosted MCP.
+cluster with 'task down' and then 'task up' before deploying scion-ops.
 EOF
+}
+
+warn_missing_kind_native_ports() {
+  cat >&2 <<EOF
+Warning: kind native port mappings are not available on cluster ${CLUSTER_NAME}.
+Existing kind clusters cannot be updated with new extraPortMappings. Recreate
+this cluster with 'task down' and then 'task up'.
+
+Required mappings:
+  ${KIND_LISTEN_ADDRESS}:${HUB_HOST_PORT} -> kind node ${HUB_NODE_PORT} -> scion-hub
+  ${KIND_LISTEN_ADDRESS}:${MCP_HOST_PORT} -> kind node ${MCP_NODE_PORT} -> scion-ops-mcp
+EOF
+}
+
+validate_cluster_substrate() {
+  local missing=0
+  if ! workspace_mount_present; then
+    warn_missing_workspace_mount
+    missing=1
+  fi
+  if ! kind_native_ports_present; then
+    warn_missing_kind_native_ports
+    missing=1
+  fi
+  [[ "$missing" -eq 0 ]] || die "existing kind cluster $CLUSTER_NAME is missing required scion-ops substrate; recreate it with task down and task up"
 }
 
 ensure_cluster() {
   require kind
   if cluster_exists; then
     log "reuse kind cluster $CLUSTER_NAME"
-    if ! workspace_mount_present; then
-      warn_missing_workspace_mount
-    fi
+    validate_cluster_substrate
     return
   fi
 
@@ -195,6 +252,8 @@ cmd_status() {
   printf 'namespace: %s\n' "$NAMESPACE"
   printf 'workspace host: %s\n' "$WORKSPACE_HOST_PATH"
   printf 'workspace node: %s\n\n' "$WORKSPACE_NODE_PATH"
+  printf 'Hub host URL: http://%s:%s\n' "$KIND_LISTEN_ADDRESS" "$HUB_HOST_PORT"
+  printf 'MCP host URL: http://%s:%s/mcp\n\n' "$KIND_LISTEN_ADDRESS" "$MCP_HOST_PORT"
 
   if ! cluster_exists; then
     die "kind cluster $CLUSTER_NAME does not exist"
@@ -210,6 +269,11 @@ cmd_status() {
     printf 'workspace mount: ok\n'
   else
     printf 'workspace mount: unavailable; run task kind:workspace:status for details\n'
+  fi
+  if kind_native_ports_present; then
+    printf 'kind native ports: ok\n'
+  else
+    printf 'kind native ports: unavailable; recreate the cluster with task down and task up\n'
   fi
 }
 


### PR DESCRIPTION
Closes #33

Summary:
- Replace kubectl port-forward workflow with kind extraPortMappings plus fixed NodePort services.
- Expose Hub at localhost:18090 and MCP at localhost:8765 by default.
- Remove smoke-test background port-forward startup and require native localhost endpoints instead.
- Add task x as the one-command day-zero workflow: build, up, test.
- Fail clearly when an existing kind cluster lacks the required workspace mount or native port mappings.

Verification:
- task verify
- task test -- --help
- KIND_CLUSTER_NAME=scion-ops-cp-smoke SCION_OPS_KIND_HUB_PORT=28090 SCION_OPS_MCP_PORT=28765 task up
- KIND_CLUSTER_NAME=scion-ops-cp-smoke SCION_OPS_KIND_HUB_PORT=28090 SCION_OPS_MCP_PORT=28765 task test -- --skip-setup
- kind delete cluster --name scion-ops-cp-smoke

Notes:
- The disposable verification used alternate host ports to avoid colliding with existing local clusters.
- Existing kind clusters must be recreated to get extraPortMappings.
