### PR TITLE
Prefer configured kind provider for inspection

### DIFF
--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -120,8 +120,21 @@ kind_node_name() {
 container_runtime_for_node() {
   local node="$1"
   local runtime
+  local runtimes
 
-  for runtime in docker podman; do
+  case "$KIND_PROVIDER" in
+    podman)
+      runtimes=(podman docker)
+      ;;
+    docker)
+      runtimes=(docker podman)
+      ;;
+    *)
+      runtimes=("$KIND_PROVIDER" podman docker)
+      ;;
+  esac
+
+  for runtime in "${runtimes[@]}"; do
     if command -v "$runtime" >/dev/null 2>&1 && "$runtime" container inspect "$node" >/dev/null 2>&1; then
       printf '%s\n' "$runtime"
       return 0


### PR DESCRIPTION
## Summary
- inspect the configured kind provider before falling back to other runtimes
- avoid stale Docker kind containers masking the active Podman-backed cluster

## Verification
- bash -n scripts/kind-scion-runtime.sh
- task verify
- bash scripts/kind-scion-runtime.sh status

Closes #40