### PR TITLE
Add default Hub bootstrap and project targeting

### DIFF
--- a/.scion/templates/consensus-runner/system-prompt.md
+++ b/.scion/templates/consensus-runner/system-prompt.md
@@ -87,14 +87,13 @@ The audit file is a working artifact. It does not need to be committed.
 
 1. Initialize `state/<round_id>.json`.
 2. Spawn both implementers in parallel:
-   - Claude: `scion start <claude_impl> --type impl-claude --branch <claude_impl> --harness-auth auth-file --non-interactive --notify "<implementation task>"`
-   - Codex: `scion start <codex_impl> --type impl-codex --branch <codex_impl> --harness-auth auth-file --non-interactive --notify "<implementation task>"`
+   - Claude: `scion start <claude_impl> --type impl-claude --branch <claude_impl> --no-auth --no-upload --non-interactive --notify "<implementation task>"`
+   - Codex: `scion start <codex_impl> --type impl-codex --branch <codex_impl> --harness-auth auth-file --no-upload --non-interactive --notify "<implementation task>"`
 3. Wait for both implementers to reach `completed`. Use `sciontool status blocked` while waiting. Inspect failed or stalled agents with `scion look`.
 4. For each review round up to `max_review_rounds`:
    - Create review snapshot branches with `git branch -f <snapshot_branch> <implementation_branch>`.
-   - Spawn `reviewer-claude` on the Codex snapshot branch.
-   - Spawn `reviewer-codex` on the Claude snapshot branch.
-   - Use `--harness-auth auth-file` for both reviewer starts.
+   - Spawn `reviewer-claude` on the Codex snapshot branch with `--no-auth --no-upload`.
+   - Spawn `reviewer-codex` on the Claude snapshot branch with `--harness-auth auth-file --no-upload`.
    - Include your coordinator agent name in each review prompt and require the reviewer to send its `verdict.json` back to you with `scion message`.
    - Collect both JSON verdicts from Scion messages or visible terminal output.
    - Append the verdicts to `state/<round_id>.json`.
@@ -102,13 +101,13 @@ The audit file is a working artifact. It does not need to be committed.
    - If consensus is not reached, send only blocking issues back to the relevant implementer. If the implementer stopped, resume it first with `scion resume <agent> --non-interactive`, then message the feedback with `--notify`.
 5. If no consensus after the maximum review rounds, set audit status `escalate`, report the blocking issues, mark the Scion task completed as escalated, and stop.
 6. Pick the winner by highest final-round score: `correctness + completeness`. On a tie, prefer a branch whose tests passed; if still tied, choose Claude.
-7. Create or reset local branch `round-<round_id>-integration` from the winner branch. Spawn the integrator using the winner's implementation template on that integration branch, with `--harness-auth auth-file`. Instruct it to:
+7. Create or reset local branch `round-<round_id>-integration` from the winner branch. Spawn the integrator using the winner's implementation template on that integration branch. Use `--no-auth --no-upload` if the winner is Claude; use `--harness-auth auth-file --no-upload` if the winner is Codex. Instruct it to:
    - inspect the loser branch for useful ideas,
    - apply agreed reviewer feedback,
    - run tests,
    - commit,
    - push `round-<round_id>-integration`.
-8. Create `round-<round_id>-final-review-snapshot` from `round-<round_id>-integration`, then spawn the final reviewer on that snapshot branch with `--harness-auth auth-file`.
+8. Create `round-<round_id>-final-review-snapshot` from `round-<round_id>-integration`, then spawn the final reviewer on that snapshot branch with `--harness-auth auth-file --no-upload`.
    - If `final_reviewer` is missing or exactly `gemini`, first start `final-reviewer-gemini`.
    - If `final_reviewer` is exactly `codex`, start `final-reviewer-codex`.
    - Do not start `final-reviewer-codex` when `final_reviewer` is `gemini` unless a previous `final-reviewer-gemini` start command failed because the template, harness, image, or auth file was unavailable.
@@ -143,10 +142,12 @@ When spawning or messaging implementers, require:
 - `git push -u origin HEAD` when `origin` is configured,
 - `sciontool status task_completed "<summary>"`.
 
-All child agents must be started with `--harness-auth auth-file` so Claude uses
-the `CLAUDE_AUTH` subscription credential file, Codex uses the `CODEX_AUTH`
-subscription credential file, and Gemini uses the `GEMINI_OAUTH_CREDS` personal
-OAuth credential file provisioned by the Hub.
+Claude child agents must be started with `--no-auth --no-upload` so the Claude
+CLI reads the Hub-projected `CLAUDE_AUTH` subscription file at
+`~/.claude/.credentials.json`. Codex and Gemini child agents must be started
+with `--harness-auth auth-file --no-upload` so Scion selects the Hub-projected
+`CODEX_AUTH` and `GEMINI_OAUTH_CREDS` subscription credential files. Templates
+are pre-synced by `task bootstrap`; do not upload templates during a round.
 
 ## Final Review Requirements
 

--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -103,9 +103,9 @@ explicit broker credential restore or registration bootstrap flow.
 
 Issue: #29
 
-Decision: the kind control-plane smoke uses an inline `generic` harness config
-for its no-auth agent instead of uploading grove templates or harness configs by
-default.
+Decision: keep the kind control-plane smoke on an inline `generic` harness
+config, but use `task bootstrap` as the normal template and harness restore
+path for rounds.
 
 Reason: the current kind Hub uses Scion local storage on the Hub PVC. When a
 host CLI talks to that Hub through a port-forward, template and harness-config
@@ -113,32 +113,30 @@ sync can receive pod-local upload paths such as `/home/scion/.scion/storage/...`
 that are not writable or meaningful from the host. That is not a supported
 Kubernetes bootstrap pattern.
 
-Constraint: custom grove templates and harness configs are opt-in in the kind
-smoke via `--sync-template` and `--sync-harness-config`; use those only with a
-Hub storage backend that supports remote uploads, or with a future in-cluster
-bootstrap/restore task.
+Constraint: do not sync scion-ops templates or harness configs to the kind Hub
+from the host CLI. `task bootstrap` copies the files into the Hub pod and runs
+Scion sync commands there, where `/home/scion/.scion/storage` is meaningful.
 
-Exit criteria: replace the inline generic smoke fallback with normal template
-and harness-config bootstrap after kind Hub state uses a remote-upload-capable
-storage path or Scion exposes an in-cluster bootstrap workflow.
+Exit criteria: remove the inline generic smoke fallback only after spending
+subscription model usage in smoke tests is acceptable.
 
 ## Subscription-Backed Kubernetes Rounds
 
 Issue: #29
 
-Decision: keep `task test` on an inline no-auth generic smoke agent until
-Claude, Codex, Gemini credentials, templates, and harness configs have a
-remote-safe Kubernetes bootstrap path.
+Decision: `task bootstrap` restores shared Hub-scoped credentials, Hub harness
+configs, and Hub global scion-ops templates before subscription-backed rounds.
+`task test` remains a no-auth smoke to avoid spending model usage in the normal
+health check.
 
 Reason: the product goal is a one-line Scion consensus round through the
 Kubernetes-hosted Hub and MCP server, but baking subscription credentials into
 images or relying on host-local upload paths would create hidden state and a
 non-reproducible setup.
 
-Constraint: `task round` remains the intended product operation, but it should
-not be treated as a complete subscription-backed Kubernetes flow until issue
-#29 is closed.
+Constraint: target projects must be visible inside the MCP pod workspace mount
+and should have important local work committed or pushed before a round starts.
+Hub/Kubernetes agents work from git branches, not uncommitted editor buffers.
 
-Exit criteria: credentials are restored as Kubernetes/Hub state from explicit
-inputs, templates and harness configs sync without host-local storage paths,
-and a Claude/Codex/Gemini consensus round passes through the Kubernetes Hub.
+Exit criteria: a Claude/Codex/Gemini consensus round passes through the
+Kubernetes Hub from a Zed MCP request against the selected target project.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 Kubernetes-only operating layer for running dueling Scion agents against a
 Scion Hub, co-located Runtime Broker, HTTP MCP server, and agent pods.
 
-The supported deployment target is Kubernetes. For local development this repo
-uses `kind` with Podman as the default provider; host workstation Hub, host
-broker, local-only Scion, and stdio MCP workflows are no longer supported
-project modes.
+The supported deployment target is Kubernetes. Local development uses `kind`
+with Podman as the default provider.
 
 ## Quickstart
 
@@ -15,9 +13,10 @@ upstream Scion checkout at `~/workspace/github/GoogleCloudPlatform/scion` unless
 you pass `task build -- --src <path>`.
 
 ```bash
-task x          # build, create/update, deploy, and smoke test
+task x          # build, create/update, bootstrap, deploy, and smoke test
 task build      # build all Scion and scion-ops images
 task up         # create/update kind and apply the Kubernetes control plane
+task bootstrap  # restore Hub credentials, harness configs, and templates
 task test       # smoke test Hub, broker, MCP, and Kubernetes agent dispatch
 task down       # destroy the local kind deployment
 ```
@@ -27,11 +26,10 @@ cluster, base runtime resources, image loading, and control-plane Kustomize
 target. Hidden aliases `task deploy`, `task update`, and `task destroy` map to
 the same lifecycle operations for agents that use those words.
 
-The current smoke test dispatches the checked-in no-auth generic smoke config
-through the kind-hosted Hub and co-located broker. Subscription-backed Claude,
-Codex, and Gemini consensus rounds remain the next bootstrap step in issue #29:
-credentials, harness configs, and templates must be restored into the
-Kubernetes-hosted Hub without relying on host-local upload paths.
+`task bootstrap` is the default credential and template restore path. It links
+the target repo as a Hub grove, provides the kind broker, stores shared
+subscription credentials as Hub secrets, and syncs the scion-ops templates from
+inside the Hub pod so host-local upload paths are not used.
 
 ## Kubernetes Shape
 
@@ -43,11 +41,11 @@ kind cluster:
     PVC-backed Scion state
   scion-ops-mcp Deployment
     streamable HTTP MCP server
-    mounted scion-ops workspace
+    mounted host workspace tree
   Scion agent pods
 
 host:
-  repo checkout
+  repo checkout and target project checkouts
   container image build source
   kind native host ports for Hub and Zed
 ```
@@ -94,12 +92,21 @@ Smoke test the HTTP service with `task kind:mcp:smoke`. See `docs/zed-mcp.md`.
 - `orchestrator/` — consensus round launcher and agent utilities
 - `rubric/` — reviewer prompt and verdict schema
 - `scripts/build-images.sh` — image build helper
+- `scripts/kind-bootstrap.sh` — Hub credential, harness, and template restore
 - `scripts/kind-scion-runtime.sh` — kind substrate helper
 - `scripts/kind-control-plane-smoke.py` — Kubernetes control-plane smoke
 
 ## Rounds
 
-`task round -- "prompt"` remains the intended one-line product operation for a
-full consensus round. Do not treat it as complete for subscription-backed
-Kubernetes operation until issue #29 restores Claude, Codex, Gemini credentials,
-templates, and harness configs into the Kubernetes-hosted Hub.
+`task round -- "prompt"` starts a consensus round against the selected target
+project. Bootstrap the target once, then pass its project root when starting a
+round from the scion-ops checkout:
+
+```bash
+task bootstrap -- /home/david/workspace/github/example/project
+SCION_OPS_PROJECT_ROOT=/home/david/workspace/github/example/project task round -- "prompt"
+```
+
+The MCP tool `scion_ops_start_round` accepts the same target as `project_root`.
+Agents work from the target repo's Hub grove and branch context; uncommitted
+local work is not included unless it is committed or pushed before the round.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,10 +40,11 @@ vars:
 
 tasks:
   x:
-    desc: Build, deploy/update, and smoke test the Kubernetes deployment.
+    desc: Build, deploy/update, bootstrap, and smoke test the Kubernetes deployment.
     cmds:
       - task: build
       - task: up
+      - task: bootstrap
       - task: test
 
   build:
@@ -64,6 +65,11 @@ tasks:
     desc: Smoke test the Kubernetes-hosted Hub, broker, MCP, and agent runtime.
     cmds:
       - task kind:control-plane:smoke -- {{.CLI_ARGS}}
+
+  bootstrap:
+    desc: Restore Hub secrets, harness configs, and templates for rounds.
+    cmds:
+      - task kind:bootstrap -- {{.CLI_ARGS}}
 
   round:
     desc: Start a Scion consensus round after Kubernetes Hub credential bootstrap.
@@ -198,6 +204,14 @@ tasks:
     cmds:
       - PYTHONDONTWRITEBYTECODE=1 uv run scripts/smoke-mcp-server.py --transport http --url '{{.SCION_OPS_MCP_URL}}'
 
+  kind:bootstrap:
+    cmds:
+      - bash scripts/kind-bootstrap.sh {{.CLI_ARGS}}
+
+  kind:round:preflight:
+    cmds:
+      - bash scripts/kind-round-preflight.sh {{.CLI_ARGS}}
+
   kind:doctor:
     cmds:
       - '{{.SCION_BIN}} doctor --profile kind'
@@ -223,3 +237,4 @@ tasks:
       - git diff --check
       - task --list
       - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py')]"
+      - bash -n scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh orchestrator/run-round.sh orchestrator/round.sh

--- a/deploy/kind/control-plane/mcp-deployment.yaml
+++ b/deploy/kind/control-plane/mcp-deployment.yaml
@@ -31,6 +31,14 @@ spec:
             - -ec
           args:
             - |
+              if [ ! -f "${SCION_OPS_ROOT}/Taskfile.yml" ]; then
+                for candidate in /workspace/scion-ops /workspace/*/scion-ops /workspace/*/*/scion-ops /workspace/*/*/*/scion-ops; do
+                  if [ -f "${candidate}/Taskfile.yml" ] && [ -f "${candidate}/mcp_servers/scion_ops.py" ]; then
+                    export SCION_OPS_ROOT="${candidate}"
+                    break
+                  fi
+                done
+              fi
               export SCION_GROVE_ID="${SCION_GROVE_ID:-$(cat "${SCION_OPS_ROOT}/.scion/grove-id" 2>/dev/null || true)}"
               export SCION_OPS_GROVE_ID="${SCION_OPS_GROVE_ID:-$SCION_GROVE_ID}"
               git config --global --add safe.directory "${SCION_OPS_ROOT}" >/dev/null 2>&1 || true
@@ -46,6 +54,10 @@ spec:
               value: /bin/zsh
             - name: SCION_OPS_ROOT
               value: /workspace/scion-ops
+            - name: SCION_OPS_HOST_WORKSPACE_ROOT
+              value: /home/david/workspace
+            - name: SCION_OPS_CONTAINER_WORKSPACE_ROOT
+              value: /workspace
             - name: SCION_OPS_MCP_TRANSPORT
               value: streamable-http
             - name: SCION_OPS_MCP_HOST
@@ -87,14 +99,14 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: workspace
-              mountPath: /workspace/scion-ops
+              mountPath: /workspace
             - name: hub-state
               mountPath: /hub-state
               readOnly: true
       volumes:
         - name: workspace
           hostPath:
-            path: /workspace/scion-ops
+            path: /workspace
             type: Directory
         - name: hub-state
           persistentVolumeClaim:

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -13,15 +13,16 @@ Use the top-level lifecycle tasks:
 task x
 task build
 task up
+task bootstrap
 task test
 task down
 ```
 
 `task x` is the day-zero path: build images, create/update the deployment, and
-run the smoke test. `task up` is both deploy and update. It creates or reuses
-the kind cluster, applies base runtime resources, verifies the workspace mount,
-loads local images, applies the control-plane Kustomize target, and waits for
-rollout.
+run the bootstrap and smoke test. `task up` is both deploy and update. It
+creates or reuses the kind cluster, applies base runtime resources, verifies the
+workspace mount, loads local images, applies the control-plane Kustomize target,
+and waits for rollout.
 
 ## Kubernetes Resources
 
@@ -73,8 +74,9 @@ The Hub Deployment runs:
 - an in-cluster Kubernetes runtime profile
 
 The MCP Deployment runs the scion-ops streamable HTTP MCP server and reads Hub
-state through the `scion-hub` ClusterIP service. In local kind, MCP mounts this
-repo via a kind node `extraMount` and Kubernetes `hostPath`.
+state through the `scion-hub` ClusterIP service. In local kind, MCP mounts the
+host workspace tree via a kind node `extraMount` and Kubernetes `hostPath`, so
+tools operate on the mounted git checkout selected by `project_root`.
 
 The broker creates agent pods in `scion-agents` using in-cluster Kubernetes API
 access. It does not use host Podman or Docker sockets.
@@ -89,6 +91,7 @@ After `task up`, use:
 
 ```bash
 eval "$(task kind:hub:auth-export)"
+task bootstrap
 task kind:mcp:smoke
 ```
 
@@ -116,9 +119,23 @@ Useful overrides:
 | `SCION_OPS_KIND_HUB_PORT` | `18090` |
 | `SCION_OPS_KIND_LISTEN_ADDRESS` | `192.168.122.103` |
 | `SCION_OPS_MCP_URL` | `http://192.168.122.103:8765/mcp` |
+| `SCION_OPS_WORKSPACE_HOST_PATH` | `~/workspace` when it contains the scion-ops checkout, otherwise the checkout's parent |
+| `SCION_OPS_WORKSPACE_NODE_PATH` | `/workspace` |
 | `SCION_KIND_CP_SMOKE_KEEP_AGENT` | unset, deletes on success |
 | `SCION_KIND_CP_SMOKE_SKIP_SETUP` | unset, applies kind resources |
 | `SCION_KIND_CP_SMOKE_TIMEOUT` | `90` |
+
+## Project Targeting
+
+The codebase being changed is always the target project. `task bootstrap --
+<project-root>` links that target as a Hub grove and provides the kind broker.
+Shared credentials are stored as Hub-scoped secrets, and scion-ops templates are
+synced as Hub global templates.
+
+The MCP tool contract mirrors that shape: pass `project_root` to
+`scion_ops_project_status`, `scion_ops_start_round`, `scion_ops_round_status`,
+`scion_ops_watch_round_events`, and git diff/status tools when operating on a
+target project.
 
 ## Persistence
 
@@ -131,9 +148,5 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Broker registration | Hub state for co-located broker | yes |
 | MCP workspace | host checkout mounted into kind node | no |
 | Agent artifacts | agent workspaces and pushed git branches | pod-local state is ephemeral |
-| Subscription credentials | not yet restored into kind Hub | issue #29 |
-| Templates/harness configs | checked-in generic smoke config only by default | issue #29 |
-
-Issue #29 is the required follow-up for remote-safe credential, template, and
-harness bootstrap. Until that lands, do not claim full Claude/Codex/Gemini
-consensus rounds as a complete Kubernetes operation.
+| Subscription credentials | Hub-scoped secrets restored by `task bootstrap` | yes |
+| Templates/harness configs | Hub global templates and Hub harness configs restored by `task bootstrap` | yes |

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -26,8 +26,8 @@ directly deployable.
 | namespace | `scion-agents` |
 | runtime service account | `scion-agent-manager` |
 | image registry | `localhost` |
-| workspace host path | current repo checkout |
-| workspace node path | `/workspace/scion-ops` |
+| workspace host path | `~/workspace` when it contains the scion-ops checkout, otherwise the checkout's parent |
+| workspace node path | `/workspace` |
 | Hub host URL | `http://192.168.122.103:18090` |
 | MCP host URL | `http://192.168.122.103:8765/mcp` |
 
@@ -45,9 +45,13 @@ SCION_OPS_KIND_PROVIDER=docker task up
 
 ## Workspace Mount
 
-The kind node is created with an `extraMount` from the host checkout to
-`/workspace/scion-ops`. The MCP Deployment mounts that node path as a
-Kubernetes `hostPath`.
+The kind node is created with an `extraMount` from the host workspace tree to
+`/workspace`. The MCP Deployment mounts that node path as a Kubernetes
+`hostPath` and auto-discovers the scion-ops checkout under it.
+
+This is what lets one MCP server operate on multiple local git checkouts. The
+target repo must be under the mounted host workspace tree; otherwise recreate
+kind with `SCION_OPS_WORKSPACE_HOST_PATH` set to a common parent.
 
 Existing kind clusters cannot be mutated to add the mount. Check it with:
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -10,7 +10,9 @@ Use this sequence for a full local validation:
 task x
 ```
 
-`task x` expands to `task build`, `task up`, and `task test`.
+`task x` expands to `task build`, `task up`, `task bootstrap`, and `task test`.
+The bootstrap step restores shared Hub credentials, harness configs, and
+templates before a round is started.
 
 `task test` runs `scripts/kind-control-plane-smoke.py`. It verifies:
 
@@ -61,8 +63,7 @@ recreate the Kubernetes cluster.
 
 ## Known Test Gap
 
-The Kubernetes smoke intentionally uses the checked-in generic no-auth smoke
-config. It does not prove Claude, Codex, or Gemini subscription-backed
-consensus rounds. That is blocked on issue #29, which must restore credentials,
-templates, and harness configs into the Kubernetes-hosted Hub without
-host-local upload paths.
+The Kubernetes smoke still uses the checked-in generic no-auth smoke config, so
+it proves broker dispatch and MCP readiness without spending subscription model
+usage. The next full validation is a short `scion_ops_start_round` call against
+a clean target branch after `task bootstrap` passes.

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -1,8 +1,7 @@
 # Zed MCP Setup
 
 scion-ops supports Zed through the Kubernetes-hosted streamable HTTP MCP
-service. Stdio MCP and host-launched MCP servers are not supported project
-modes.
+service.
 
 ## Start The Service
 
@@ -64,11 +63,17 @@ Then use the same remote-host URL in Zed:
 ```
 
 The MCP server operates from the workspace mounted in the Kubernetes
-Deployment, which defaults to:
+Deployment. The default kind mount is the host workspace tree at:
 
 ```text
-/workspace/scion-ops
+/workspace
 ```
+
+The MCP server auto-discovers the scion-ops checkout inside that tree and maps
+host project paths under `/home/david/workspace` to their in-pod `/workspace`
+paths. If a target repo is outside the mounted tree, recreate kind with
+`SCION_OPS_WORKSPACE_HOST_PATH` set to a parent directory that contains both
+scion-ops and the target repo.
 
 ## Tool State
 
@@ -79,6 +84,14 @@ trusted local tunnel, VPN, or authenticated ingress.
 
 ## Rounds
 
-The MCP tool `scion_ops_start_round` calls `task round`. Full
-subscription-backed Kubernetes rounds require issue #29 so credentials,
-templates, and harness configs are restored into the Kubernetes-hosted Hub.
+Use one shape for every project:
+
+```text
+Use scion-ops to start a round on project_root=/home/david/workspace/github/example/project:
+"improve README.md"
+```
+
+The external agent should call `scion_ops_project_status` first, then
+`scion_ops_start_round` with the same `project_root`. The target repo should be
+on a clean branch with any important local work committed or pushed; Kubernetes
+agents work from git branches, not uncommitted editor state.

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -37,6 +37,8 @@ from mcp.server.fastmcp import FastMCP
 ROOT = Path(os.environ.get("SCION_OPS_ROOT", Path(__file__).resolve().parents[1])).resolve()
 DEFAULT_TIMEOUT_SECONDS = 45
 NAME_RE = re.compile(r"^[A-Za-z0-9._:/@+-]+$")
+DEFAULT_HOST_WORKSPACE_ROOT = "/home/david/workspace"
+DEFAULT_CONTAINER_WORKSPACE_ROOT = "/workspace"
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -50,7 +52,9 @@ mcp = FastMCP(
     "scion-ops",
     instructions=(
         "Use these tools to start and monitor scion-ops consensus rounds, "
-        "inspect Scion agents, and review the resulting git branches."
+        "inspect Scion agents, and review the resulting git branches. "
+        "Pass project_root for the project being changed; if omitted, the "
+        "server uses its current working checkout."
     ),
     host=os.environ.get("SCION_OPS_MCP_HOST", "127.0.0.1"),
     port=int(os.environ.get("SCION_OPS_MCP_PORT", "8765")),
@@ -103,9 +107,10 @@ def _run(
     *,
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
     env: dict[str, str] | None = None,
+    cwd: Path | None = None,
     check: bool = False,
 ) -> dict[str, Any]:
-    root = _repo_root()
+    root = cwd or _repo_root()
     try:
         result = subprocess.run(
             args,
@@ -186,13 +191,13 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     return merged
 
 
-def _settings_paths() -> list[Path]:
+def _settings_paths(project_root: Path | None = None) -> list[Path]:
     paths: list[Path] = [Path.home() / ".scion" / "settings.yaml"]
     explicit = os.environ.get("SCION_OPS_GROVE_SETTINGS")
     if explicit:
         paths.append(Path(explicit).expanduser())
 
-    root = _repo_root()
+    root = project_root or _repo_root()
     local_settings = root / ".scion" / "settings.yaml"
     if local_settings.exists():
         paths.append(local_settings)
@@ -215,10 +220,10 @@ def _settings_paths() -> list[Path]:
     return deduped
 
 
-def _effective_settings() -> tuple[dict[str, Any], list[str]]:
+def _effective_settings(project_root: Path | None = None) -> tuple[dict[str, Any], list[str]]:
     settings: dict[str, Any] = {}
     sources: list[str] = []
-    for path in _settings_paths():
+    for path in _settings_paths(project_root):
         data = _load_yaml(path)
         if data:
             settings = _deep_merge(settings, data)
@@ -248,6 +253,61 @@ def _read_text_file(path: Path) -> str:
         return path.read_text(errors="replace").strip()
     except OSError:
         return ""
+
+
+def _path_mappings() -> list[tuple[Path, Path]]:
+    mappings: list[tuple[Path, Path]] = []
+    raw = os.environ.get("SCION_OPS_PROJECT_PATH_MAP", "")
+    for item in re.split(r"[;,\n]", raw):
+        if not item.strip() or "=" not in item:
+            continue
+        host, container = item.split("=", 1)
+        mappings.append((Path(host).expanduser(), Path(container).expanduser()))
+
+    host_root = Path(os.environ.get("SCION_OPS_HOST_WORKSPACE_ROOT", DEFAULT_HOST_WORKSPACE_ROOT)).expanduser()
+    container_root = Path(
+        os.environ.get("SCION_OPS_CONTAINER_WORKSPACE_ROOT", DEFAULT_CONTAINER_WORKSPACE_ROOT)
+    ).expanduser()
+    mappings.append((host_root, container_root))
+    return mappings
+
+
+def _map_project_path(path: Path) -> Path:
+    if path.exists():
+        return path
+    path_str = str(path)
+    for host_root, container_root in _path_mappings():
+        host = str(host_root)
+        if path_str == host:
+            candidate = container_root
+        elif path_str.startswith(host.rstrip("/") + "/"):
+            candidate = container_root / path_str[len(host.rstrip("/")) + 1 :]
+        else:
+            continue
+        if candidate.exists():
+            return candidate
+    return path
+
+
+def _project_root(project_root: str = "", *, require_git: bool = True) -> Path:
+    raw = project_root.strip() if project_root else ""
+    path = Path(raw).expanduser() if raw else _repo_root()
+    path = _map_project_path(path)
+    if not path.is_absolute():
+        path = (_repo_root() / path).resolve()
+    else:
+        path = path.resolve()
+    if require_git:
+        if not path.exists():
+            raise ValueError(f"project_root is not visible to MCP: {path}")
+        _run(["git", "config", "--global", "--add", "safe.directory", str(path)], timeout=10, cwd=_repo_root())
+        result = _run(["git", "rev-parse", "--show-toplevel"], timeout=10, cwd=path)
+        if not result["ok"]:
+            raise ValueError(f"project_root is not a git repository visible to MCP: {path}")
+        return Path(result["output"].strip()).resolve()
+    if not path.exists():
+        raise ValueError(f"project_root is not visible to MCP: {path}")
+    return path
 
 
 @dataclass(frozen=True)
@@ -364,8 +424,8 @@ def _hub_auth(endpoint: str) -> HubAuth | None:
     return None
 
 
-def _hub_config() -> HubConfig:
-    settings, sources = _effective_settings()
+def _hub_config(project_root: Path | None = None) -> HubConfig:
+    settings, sources = _effective_settings(project_root)
     endpoint = (
         os.environ.get("SCION_OPS_HUB_ENDPOINT")
         or os.environ.get("SCION_HUB_ENDPOINT")
@@ -379,8 +439,10 @@ def _hub_config() -> HubConfig:
         or _nested(settings, "hub", "endpoint")
     )
 
+    project_grove_id = _read_text_file(project_root / ".scion" / "grove-id") if project_root else ""
     grove_id = (
-        os.environ.get("SCION_OPS_GROVE_ID")
+        project_grove_id
+        or os.environ.get("SCION_OPS_GROVE_ID")
         or os.environ.get("SCION_HUB_GROVE_ID")
         or _nested(settings, "hub", "grove_id")
         or _nested(settings, "hub", "groveId")
@@ -413,8 +475,9 @@ def _hub_error_payload(error: HubAPIError, operation: str, cfg: HubConfig | None
 
 
 class HubClient:
-    def __init__(self) -> None:
-        self.cfg = _hub_config()
+    def __init__(self, project_root: str = "") -> None:
+        self.project_root = _project_root(project_root, require_git=False) if project_root else None
+        self.cfg = _hub_config(self.project_root)
 
     def _require_ready(self) -> None:
         if not self.cfg.enabled:
@@ -648,8 +711,8 @@ def _agent_summary(agent: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _list_agents(round_filter: str = "") -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    client = HubClient()
+def _list_agents(round_filter: str = "", project_root: str = "") -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    client = HubClient(project_root)
     agents = client.agents(round_filter)
     return agents, {
         "ok": True,
@@ -676,8 +739,8 @@ def _round_text_match(item: dict[str, Any], round_id: str) -> bool:
     return any(needle in str(value).lower() for value in fields if value is not None)
 
 
-def _list_round_messages(round_id: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    client = HubClient()
+def _list_round_messages(round_id: str, project_root: str = "") -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    client = HubClient(project_root)
     messages = client.messages(round_id)
     return messages, {
         "ok": True,
@@ -687,8 +750,8 @@ def _list_round_messages(round_id: str) -> tuple[list[dict[str, Any]], dict[str,
     }
 
 
-def _list_round_notifications(round_id: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    client = HubClient()
+def _list_round_notifications(round_id: str, project_root: str = "") -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    client = HubClient(project_root)
     notifications = client.notifications(round_id)
     return notifications, {
         "ok": True,
@@ -720,10 +783,10 @@ def _agent_fingerprint(agent: dict[str, Any]) -> str:
     return json.dumps(tracked, sort_keys=True, default=str)
 
 
-def _round_event_snapshot(round_id: str) -> dict[str, Any]:
-    agents, agent_result = _list_agents(round_id)
-    messages, message_result = _list_round_messages(round_id)
-    notifications, notification_result = _list_round_notifications(round_id)
+def _round_event_snapshot(round_id: str, project_root: str = "") -> dict[str, Any]:
+    agents, agent_result = _list_agents(round_id, project_root)
+    messages, message_result = _list_round_messages(round_id, project_root)
+    notifications, notification_result = _list_round_notifications(round_id, project_root)
     summaries = [_agent_summary(agent) for agent in agents]
     return {
         "round_id": round_id,
@@ -838,16 +901,17 @@ def _round_terminal_status(snapshot: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
-def _default_base_branch() -> str:
-    result = _run(["git", "branch", "--show-current"], timeout=10)
+def _default_base_branch(project_root: str = "") -> str:
+    root = _project_root(project_root) if project_root else _repo_root()
+    result = _run(["git", "branch", "--show-current"], timeout=10, cwd=root)
     current = result["output"].strip()
     return current or "HEAD"
 
 
 @mcp.tool()
-def scion_ops_hub_status() -> dict[str, Any]:
+def scion_ops_hub_status(project_root: str = "") -> dict[str, Any]:
     """Show Scion Hub API health, grove, broker providers, and agents."""
-    client = HubClient()
+    client = HubClient(project_root)
     try:
         health = client.health()
         grove = client.grove()
@@ -873,12 +937,12 @@ def scion_ops_hub_status() -> dict[str, Any]:
 
 
 @mcp.tool()
-def scion_ops_list_agents(round_filter: str = "") -> dict[str, Any]:
+def scion_ops_list_agents(round_filter: str = "", project_root: str = "") -> dict[str, Any]:
     """List Scion agents from Hub API state, optionally filtered by a round id substring."""
     if round_filter:
         _clean_name(round_filter, "round_filter")
     try:
-        agents, result = _list_agents(round_filter)
+        agents, result = _list_agents(round_filter, project_root)
     except HubAPIError as exc:
         return _hub_error_payload(exc, "list_agents")
     summaries = [_agent_summary(agent) for agent in agents]
@@ -895,21 +959,28 @@ def scion_ops_list_agents(round_filter: str = "") -> dict[str, Any]:
 
 
 @mcp.tool()
-def scion_ops_look(agent_name: str, num_lines: int = 160) -> dict[str, Any]:
+def scion_ops_look(agent_name: str, num_lines: int = 160, project_root: str = "") -> dict[str, Any]:
     """Read terminal output for a Scion agent with `scion look`."""
     agent_name = _clean_name(agent_name, "agent_name")
     num_lines = _clamp(num_lines, 20, 600)
-    return _command_result(_run(
+    args = ["scion"]
+    root = _project_root(project_root) if project_root else None
+    if root:
+        args.extend(["--grove", str(root)])
+    args.extend(
         [
-            "scion",
             "look",
             agent_name,
             "--non-interactive",
             "--plain",
             "--num-lines",
             str(num_lines),
-        ],
+        ]
+    )
+    return _command_result(_run(
+        args,
         timeout=35,
+        cwd=root,
     ))
 
 
@@ -918,13 +989,14 @@ def scion_ops_round_status(
     round_id: str = "",
     include_transcript: bool = True,
     num_lines: int = 120,
+    project_root: str = "",
 ) -> dict[str, Any]:
     """Summarize a consensus round from Hub API state and optionally include the runner tail."""
     if round_id:
         _clean_name(round_id, "round_id")
     num_lines = _clamp(num_lines, 20, 400)
     try:
-        agents, result = _list_agents(round_id)
+        agents, result = _list_agents(round_id, project_root)
     except HubAPIError as exc:
         return _hub_error_payload(exc, "round_status")
     summaries = [_agent_summary(agent) for agent in agents]
@@ -939,7 +1011,7 @@ def scion_ops_round_status(
     )
     transcript: dict[str, Any] | None = None
     if include_transcript and consensus:
-        transcript = scion_ops_look(consensus, num_lines=num_lines)
+        transcript = scion_ops_look(consensus, num_lines=num_lines, project_root=project_root)
     return {
         "ok": result["ok"],
         "source": "hub_api",
@@ -954,12 +1026,17 @@ def scion_ops_round_status(
 
 
 @mcp.tool()
-def scion_ops_round_events(round_id: str, cursor: str = "", include_existing: bool = False) -> dict[str, Any]:
+def scion_ops_round_events(
+    round_id: str,
+    cursor: str = "",
+    include_existing: bool = False,
+    project_root: str = "",
+) -> dict[str, Any]:
     """Read Hub messages/notifications and agent-state changes for a round."""
     round_id = _clean_name(round_id, "round_id")
     previous = _decode_cursor(cursor, round_id)
     try:
-        snapshot = _round_event_snapshot(round_id)
+        snapshot = _round_event_snapshot(round_id, project_root)
     except HubAPIError as exc:
         return _hub_error_payload(exc, "round_events")
     events = _round_events_since(snapshot, previous, include_existing=include_existing)
@@ -986,6 +1063,7 @@ def scion_ops_watch_round_events(
     timeout_seconds: int = 90,
     poll_interval_seconds: int = 2,
     include_existing: bool = False,
+    project_root: str = "",
 ) -> dict[str, Any]:
     """Wait inside the MCP server until a round has new state to report.
 
@@ -1001,7 +1079,7 @@ def scion_ops_watch_round_events(
     previous = _decode_cursor(cursor, round_id)
     if previous is None and not include_existing:
         try:
-            snapshot = _round_event_snapshot(round_id)
+            snapshot = _round_event_snapshot(round_id, project_root)
         except HubAPIError as exc:
             return _hub_error_payload(exc, "watch_round_events")
         previous = {
@@ -1015,7 +1093,7 @@ def scion_ops_watch_round_events(
     last_snapshot: dict[str, Any] | None = None
     while time.monotonic() <= deadline:
         try:
-            snapshot = _round_event_snapshot(round_id)
+            snapshot = _round_event_snapshot(round_id, project_root)
         except HubAPIError as exc:
             return _hub_error_payload(exc, "watch_round_events")
         last_snapshot = snapshot
@@ -1040,7 +1118,7 @@ def scion_ops_watch_round_events(
         time.sleep(poll_interval_seconds)
 
     try:
-        snapshot = last_snapshot or _round_event_snapshot(round_id)
+        snapshot = last_snapshot or _round_event_snapshot(round_id, project_root)
     except HubAPIError as exc:
         return _hub_error_payload(exc, "watch_round_events")
     return {
@@ -1068,19 +1146,24 @@ def scion_ops_start_round(
     max_review_rounds: int = 3,
     base_branch: str = "",
     final_reviewer: str = "",
+    project_root: str = "",
 ) -> dict[str, Any]:
     """Start a detached scion-ops consensus round via `task round`."""
     prompt = prompt.strip()
     if not prompt:
         raise ValueError("prompt is required")
+    target_root = _project_root(project_root) if project_root else _repo_root()
     env: dict[str, str] = {
         "MAX_MINUTES": str(_clamp(max_minutes, 1, 240)),
         "MAX_REVIEW_ROUNDS": str(_clamp(max_review_rounds, 1, 10)),
+        "SCION_OPS_PROJECT_ROOT": str(target_root),
     }
     if round_id:
         env["ROUND_ID"] = _clean_name(round_id, "round_id")
     if base_branch:
         env["BASE_BRANCH"] = _clean_name(base_branch, "base_branch")
+    else:
+        env["BASE_BRANCH"] = _default_base_branch(str(target_root))
     if final_reviewer:
         final_reviewer = final_reviewer.strip().lower()
         if final_reviewer not in {"gemini", "codex"}:
@@ -1095,11 +1178,12 @@ def scion_ops_start_round(
     event_cursor_error: dict[str, Any] | None = None
     if parsed_round_id:
         try:
-            event_cursor = _encode_cursor(_round_event_snapshot(parsed_round_id))
+            event_cursor = _encode_cursor(_round_event_snapshot(parsed_round_id, str(target_root)))
         except HubAPIError as exc:
             event_cursor_error = _hub_error_payload(exc, "start_round_event_cursor")
     return {
         **_command_result(result),
+        "project_root": str(target_root),
         "round_id": parsed_round_id,
         "consensus_agent": runner,
         "event_cursor": event_cursor,
@@ -1113,10 +1197,10 @@ def scion_ops_start_round(
 
 
 @mcp.tool()
-def scion_ops_abort_round(round_id: str, confirm: bool = False) -> dict[str, Any]:
+def scion_ops_abort_round(round_id: str, confirm: bool = False, project_root: str = "") -> dict[str, Any]:
     """Stop and delete Hub agents matching a round id. Requires confirm=true."""
     round_id = _clean_name(round_id, "round_id")
-    client = HubClient()
+    client = HubClient(project_root)
     try:
         agents = client.agents(round_id)
     except HubAPIError as exc:
@@ -1150,12 +1234,13 @@ def scion_ops_abort_round(round_id: str, confirm: bool = False) -> dict[str, Any
 
 
 @mcp.tool()
-def scion_ops_round_artifacts(round_id: str) -> dict[str, Any]:
+def scion_ops_round_artifacts(round_id: str, project_root: str = "") -> dict[str, Any]:
     """Find local branches and agent workspaces associated with a round id."""
     round_id = _clean_name(round_id, "round_id")
+    root = _project_root(project_root) if project_root else _repo_root()
     branch_patterns = sorted({f"*{round_id}*", f"*{round_id.lower()}*"})
-    branch_result = _run(["git", "branch", "--list", *branch_patterns], timeout=15)
-    agents_dir = _repo_root() / ".scion" / "agents"
+    branch_result = _run(["git", "branch", "--list", *branch_patterns], timeout=15, cwd=root)
+    agents_dir = root / ".scion" / "agents"
     workspaces: list[str] = []
     prompts: list[str] = []
     if agents_dir.exists():
@@ -1168,6 +1253,7 @@ def scion_ops_round_artifacts(round_id: str) -> dict[str, Any]:
                 prompts.append(str(prompt))
     return {
         "source": "local_git",
+        "project_root": str(root),
         "branches": [line.strip(" *+") for line in branch_result["output"].splitlines() if line.strip()],
         "workspaces": workspaces,
         "prompts": prompts,
@@ -1176,12 +1262,39 @@ def scion_ops_round_artifacts(round_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def scion_ops_git_status() -> dict[str, Any]:
+def scion_ops_project_status(project_root: str) -> dict[str, Any]:
+    """Resolve a target project path and show its git, grove, and Hub context."""
+    root = _project_root(project_root)
+    status = _run(["git", "status", "--short", "--branch"], timeout=15, cwd=root)
+    branch = _run(["git", "branch", "--show-current"], timeout=10, cwd=root)
+    remote = _run(["git", "remote", "get-url", "origin"], timeout=10, cwd=root)
+    grove_id = _read_text_file(root / ".scion" / "grove-id")
+    hub = _hub_config(root).redacted()
+    return {
+        "ok": status["ok"],
+        "source": "local_git",
+        "project_root": str(root),
+        "branch": branch["output"].strip(),
+        "origin": remote["output"].strip(),
+        "grove_id": grove_id,
+        "hub": hub,
+        "status": _command_result(status),
+        "next": {
+            "bootstrap": "Run `task bootstrap -- <project_root>` from the scion-ops repo if grove_id is empty or preflight fails.",
+            "start_round_tool": "scion_ops_start_round",
+        },
+    }
+
+
+@mcp.tool()
+def scion_ops_git_status(project_root: str = "") -> dict[str, Any]:
     """Show repo status and local round branches."""
-    status = _run(["git", "status", "--short", "--branch"], timeout=15)
-    branches = _run(["git", "branch", "--list", "round-*"], timeout=15)
+    root = _project_root(project_root) if project_root else _repo_root()
+    status = _run(["git", "status", "--short", "--branch"], timeout=15, cwd=root)
+    branches = _run(["git", "branch", "--list", "round-*"], timeout=15, cwd=root)
     return {
         "source": "local_git",
+        "project_root": str(root),
         "status": _command_result(status),
         "round_branches": branches["output"].splitlines(),
         "round_branch_result": _command_result(branches),
@@ -1195,10 +1308,12 @@ def scion_ops_git_diff(
     path_filter: str = "",
     stat_only: bool = False,
     max_output_chars: int = 20000,
+    project_root: str = "",
 ) -> dict[str, Any]:
     """Show a branch diff against a base branch, optionally limited to one path."""
     branch = _clean_name(branch, "branch")
-    base_branch = _clean_name(base_branch, "base_branch") if base_branch else _default_base_branch()
+    root = _project_root(project_root) if project_root else _repo_root()
+    base_branch = _clean_name(base_branch, "base_branch") if base_branch else _default_base_branch(str(root))
     max_output_chars = _clamp(max_output_chars, 1000, 60000)
     args = ["git", "diff"]
     if stat_only:
@@ -1206,12 +1321,13 @@ def scion_ops_git_diff(
     args.append(f"{base_branch}..{branch}")
     if path_filter:
         args.extend(["--", path_filter])
-    result = _run(args, timeout=25)
+    result = _run(args, timeout=25, cwd=root)
     output = result["output"]
     truncated = len(output) > max_output_chars
     return {
         **_command_result(result),
         "source": "local_git",
+        "project_root": str(root),
         "output": output[:max_output_chars],
         "truncated": truncated,
     }

--- a/orchestrator/round.sh
+++ b/orchestrator/round.sh
@@ -16,12 +16,18 @@ PROMPT="${*:-}"
 SCION_BIN="${SCION_BIN:-scion}"
 command -v "$SCION_BIN" >/dev/null || die "scion not on PATH"
 
+SCION_OPS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_ROOT_INPUT="${SCION_OPS_PROJECT_ROOT:-$SCION_OPS_ROOT}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" || die "target project is not a git repo: $PROJECT_ROOT"
+
 ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' "$RANDOM")}"
 MAX_REVIEW_ROUNDS="${MAX_REVIEW_ROUNDS:-${MAX_ROUNDS:-3}}"
 FINAL_REVIEWER="${FINAL_REVIEWER:-gemini}"
-BASE_BRANCH="${BASE_BRANCH:-$(git branch --show-current 2>/dev/null || true)}"
+BASE_BRANCH="${BASE_BRANCH:-$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)}"
+BROKER="${SCION_KIND_CP_BROKER:-kind-control-plane}"
 if [[ -z "$BASE_BRANCH" ]]; then
-  BASE_BRANCH="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+  BASE_BRANCH="$(git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
 fi
 BASE_BRANCH="${BASE_BRANCH:-main}"
 RUNNER_NAME="round-${ROUND_ID}-consensus"
@@ -32,6 +38,7 @@ round_id: $ROUND_ID
 max_review_rounds: $MAX_REVIEW_ROUNDS
 base_branch: $BASE_BRANCH
 final_reviewer: $FINAL_REVIEWER
+project_root: $PROJECT_ROOT
 
 original_task:
 $PROMPT
@@ -45,12 +52,15 @@ printf 'Starting consensus runner: %s\n' "$RUNNER_NAME"
 printf 'Round id: %s\n' "$ROUND_ID"
 printf 'Base branch: %s\n' "$BASE_BRANCH"
 printf 'Final reviewer: %s\n' "$FINAL_REVIEWER"
+printf 'Broker: %s\n' "$BROKER"
+printf 'Project root: %s\n' "$PROJECT_ROOT"
 
-"$SCION_BIN" start "$RUNNER_NAME" \
+"$SCION_BIN" --grove "$PROJECT_ROOT" start "$RUNNER_NAME" \
   --type consensus-runner \
   --branch "$RUNNER_BRANCH" \
-  --harness-auth auth-file \
-  --upload-template \
+  --broker "$BROKER" \
+  --no-auth \
+  --no-upload \
   --non-interactive \
   --yes \
   --notify \

--- a/orchestrator/run-round.sh
+++ b/orchestrator/run-round.sh
@@ -24,6 +24,28 @@ ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' "$RANDOM")}"
 RUNNER_NAME="round-${ROUND_ID,,}-consensus"   # scion lowercases agent slugs
 
 SCION_OPS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_ROOT_INPUT="${SCION_OPS_PROJECT_ROOT:-$SCION_OPS_ROOT}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+if git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+  PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel)"
+fi
+export SCION_OPS_PROJECT_ROOT="$PROJECT_ROOT"
+
+if [[ -z "${SCION_HUB_ENDPOINT:-}" ]]; then
+  SCION_HUB_ENDPOINT="${SCION_OPS_KIND_HUB_URL:-http://${SCION_OPS_KIND_LISTEN_ADDRESS:-192.168.122.103}:${SCION_OPS_KIND_HUB_PORT:-18090}}"
+  export SCION_HUB_ENDPOINT
+fi
+export HUB_ENDPOINT="${HUB_ENDPOINT:-$SCION_HUB_ENDPOINT}"
+
+if [[ -z "${SCION_DEV_TOKEN:-}" && -z "${SCION_DEV_TOKEN_FILE:-}" ]] && command -v task >/dev/null 2>&1; then
+  if hub_auth="$(task kind:hub:auth-export 2>/dev/null)"; then
+    eval "$hub_auth"
+  fi
+fi
+
+if [[ "${SCION_OPS_ROUND_PREFLIGHT:-1}" != "0" ]]; then
+  bash "$SCION_OPS_ROOT/scripts/kind-round-preflight.sh"
+fi
 
 # 1. Truncate log, launch round.sh detached.
 : > "$LOG_FILE"
@@ -31,6 +53,7 @@ round_env=(
   "ROUND_ID=$ROUND_ID"
   "MAX_REVIEW_ROUNDS=$MAX_REVIEW_ROUNDS"
   "FINAL_REVIEWER=$FINAL_REVIEWER"
+  "SCION_OPS_PROJECT_ROOT=$PROJECT_ROOT"
 )
 if [[ -n "$BASE_BRANCH" ]]; then
   round_env+=("BASE_BRANCH=$BASE_BRANCH")

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Bootstrap kind Hub state needed for subscription-backed consensus rounds.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_ROOT_INPUT="${1:-${SCION_OPS_PROJECT_ROOT:-$REPO_ROOT}}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+if git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+  PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel)"
+fi
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-scion-ops}"
+CONTEXT="${KIND_CONTEXT:-kind-${CLUSTER_NAME}}"
+NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
+BROKER="${SCION_KIND_CP_BROKER:-kind-control-plane}"
+HUB_IN_CLUSTER="${SCION_OPS_KIND_IN_CLUSTER_HUB_URL:-http://127.0.0.1:8090}"
+HUB_PUBLIC="${SCION_HUB_ENDPOINT:-${HUB_ENDPOINT:-${SCION_OPS_KIND_HUB_URL:-http://${SCION_OPS_KIND_LISTEN_ADDRESS:-192.168.122.103}:${SCION_OPS_KIND_HUB_PORT:-18090}}}}"
+SCION_BIN="${SCION_BIN:-scion}"
+HARNESS_CONFIG_ROOT="${SCION_OPS_HARNESS_CONFIG_ROOT:-${HOME}/.scion/harness-configs}"
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '\033[36m==> %s\033[0m\n' "$*"
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required on PATH"
+}
+
+kubectl_ctx() {
+  kubectl --context "$CONTEXT" "$@"
+}
+
+sh_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+load_hub_auth() {
+  local exports
+  exports="$(task kind:hub:auth-export)"
+  eval "$exports"
+  HUB_PUBLIC="${SCION_HUB_ENDPOINT:-$HUB_PUBLIC}"
+  export SCION_HUB_ENDPOINT="$HUB_PUBLIC"
+  export HUB_ENDPOINT="$HUB_PUBLIC"
+  [[ "${SCION_DEV_TOKEN:-}" == scion_dev_* ]] || die "could not read kind Hub dev token"
+}
+
+run_scion() {
+  (cd "$PROJECT_ROOT" && SCION_HUB_ENDPOINT="$HUB_PUBLIC" SCION_DEV_TOKEN="$SCION_DEV_TOKEN" "$SCION_BIN" "$@")
+}
+
+hub_pod() {
+  local pod
+  pod="$(kubectl_ctx -n "$NAMESPACE" get pod \
+    -l app.kubernetes.io/name=scion-hub \
+    -o jsonpath='{.items[0].metadata.name}')"
+  [[ -n "$pod" ]] || die "scion-hub pod not found in ${CONTEXT}/${NAMESPACE}; run task up"
+  printf '%s\n' "$pod"
+}
+
+run_in_hub() {
+  local pod="$1"
+  local command="$2"
+  kubectl_ctx -n "$NAMESPACE" exec "$pod" -c hub -- sh -lc "$command"
+}
+
+github_token() {
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    printf '%s' "$GITHUB_TOKEN"
+    return
+  fi
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    printf '%s' "$GH_TOKEN"
+    return
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    gh auth token 2>/dev/null | tr -d '\r\n'
+  fi
+}
+
+set_env_secret() {
+  local key="$1"
+  local value="$2"
+  [[ -n "$value" ]] || die "${key} is empty"
+  run_scion hub secret set --scope hub "$key" "$value" --non-interactive --yes >/dev/null
+  log "set Hub environment secret ${key}"
+}
+
+set_file_secret() {
+  local key="$1"
+  local source="$2"
+  local target="$3"
+  [[ -f "$source" ]] || die "required credential file not found: $source"
+  run_scion hub secret set --scope hub \
+    --type file \
+    --target "$target" \
+    "$key" "@$source" \
+    --non-interactive \
+    --yes \
+    >/dev/null
+  log "set Hub file secret ${key} -> ${target}"
+}
+
+sync_harness_configs() {
+  local pod="$1"
+  local configs=(claude codex gemini)
+  local existing=()
+
+  if [[ -d "$HARNESS_CONFIG_ROOT" ]]; then
+    for config in "${configs[@]}"; do
+      [[ -d "${HARNESS_CONFIG_ROOT}/${config}" ]] && existing+=("$config")
+    done
+  fi
+
+  if [[ "${#existing[@]}" -gt 0 ]]; then
+    log "copy host harness configs into Hub pod: ${existing[*]}"
+    tar -C "$HARNESS_CONFIG_ROOT" -cf - "${existing[@]}" |
+      kubectl_ctx -n "$NAMESPACE" exec -i "$pod" -c hub -- \
+        tar -C /home/scion/.scion/harness-configs -xf -
+  else
+    log "no host harness configs found; using Hub image defaults"
+  fi
+
+  log "sync harness configs from inside Hub pod"
+  local hub_url
+  hub_url="$(sh_quote "$HUB_IN_CLUSTER")"
+  for config in "${configs[@]}"; do
+    run_in_hub "$pod" "SCION_DEV_TOKEN=\$(cat /home/scion/.scion/dev-token) SCION_HUB_ENDPOINT=${hub_url} scion harness-config sync ${config} --hub ${hub_url} --non-interactive --yes"
+  done
+}
+
+sync_templates() {
+  local pod="$1"
+
+  [[ -d "${REPO_ROOT}/.scion/templates" ]] || die "template directory not found: ${REPO_ROOT}/.scion/templates"
+
+  log "copy checked-in templates into Hub pod global template directory"
+  run_in_hub "$pod" "mkdir -p /home/scion/.scion/templates"
+  tar -C "${REPO_ROOT}/.scion/templates" -cf - . |
+    kubectl_ctx -n "$NAMESPACE" exec -i "$pod" -c hub -- \
+      tar -C /home/scion/.scion/templates -xf -
+
+  log "sync templates from inside Hub pod"
+  local hub_url
+  hub_url="$(sh_quote "$HUB_IN_CLUSTER")"
+  run_in_hub "$pod" "SCION_DEV_TOKEN=\$(cat /home/scion/.scion/dev-token) SCION_HUB_ENDPOINT=${hub_url} scion --global templates sync --all --hub ${hub_url} --non-interactive --yes"
+}
+
+main() {
+  require task
+  require kubectl
+  require tar
+  require "$SCION_BIN"
+  [[ -d "$PROJECT_ROOT/.git" ]] || git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || die "target project is not a git repo: $PROJECT_ROOT"
+
+  log "read kind Hub auth"
+  load_hub_auth
+
+  log "wait for Hub and MCP rollouts"
+  task kind:control-plane:status >/dev/null
+
+  log "link target grove and provide broker ${BROKER}"
+  log "target project: ${PROJECT_ROOT}"
+  run_scion hub link --non-interactive --yes >/dev/null
+  run_scion broker provide --broker "$BROKER" --make-default --non-interactive --yes >/dev/null
+
+  local token pod
+  token="$(github_token)"
+  [[ -n "$token" ]] || die "GITHUB_TOKEN, GH_TOKEN, or a usable gh auth token is required"
+  set_env_secret GITHUB_TOKEN "$token"
+  unset token
+
+  set_file_secret CLAUDE_AUTH "${CLAUDE_AUTH_FILE:-${HOME}/.claude/.credentials.json}" "~/.claude/.credentials.json"
+  set_file_secret CODEX_AUTH "${CODEX_AUTH_FILE:-${HOME}/.codex/auth.json}" "~/.codex/auth.json"
+  set_file_secret GEMINI_OAUTH_CREDS "${GEMINI_OAUTH_CREDS_FILE:-${HOME}/.gemini/oauth_creds.json}" "~/.gemini/oauth_creds.json"
+  if [[ -f "${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}" ]]; then
+    set_file_secret gcloud-adc "${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}" "~/.config/gcloud/application_default_credentials.json"
+  fi
+
+  pod="$(hub_pod)"
+  sync_harness_configs "$pod"
+  sync_templates "$pod"
+
+  log "preflight round state"
+  SCION_HUB_ENDPOINT="$HUB_PUBLIC" SCION_DEV_TOKEN="$SCION_DEV_TOKEN" SCION_OPS_PROJECT_ROOT="$PROJECT_ROOT" \
+    "${REPO_ROOT}/scripts/kind-round-preflight.sh"
+
+  log "bootstrap complete"
+}
+
+main "$@"

--- a/scripts/kind-control-plane-smoke.py
+++ b/scripts/kind-control-plane-smoke.py
@@ -297,8 +297,8 @@ def bootstrap_grove(
             env=env,
             category="hub_state",
             hint=(
-                "Remote-safe harness bootstrap is not implemented yet; "
-                "use the checked-in generic smoke config or complete issue #29."
+                "The smoke path does not sync harness configs from the host. "
+                "Run task bootstrap, or keep using the checked-in generic smoke config."
             ),
             timeout=120,
         )
@@ -601,7 +601,7 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         default=os.environ.get("SCION_KIND_CP_SMOKE_SYNC_HARNESS_CONFIG", "").lower()
         in {"1", "true", "yes", "on"},
-        help="also sync the selected template's default harness config; requires a remote-safe Hub storage path",
+        help="also sync the selected template's default harness config; task bootstrap is preferred",
     )
     parser.add_argument("--skip-harness-sync", action="store_false", dest="sync_harness_config")
     parser.add_argument(
@@ -609,7 +609,7 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         default=os.environ.get("SCION_KIND_CP_SMOKE_SYNC_TEMPLATE", "").lower()
         in {"1", "true", "yes", "on"},
-        help="sync --template before dispatching; requires a Hub storage backend that supports remote uploads",
+        help="sync --template before dispatching; task bootstrap is preferred",
     )
     parser.add_argument("--skip-template-sync", action="store_false", dest="sync_template")
     parser.add_argument("--skip-mcp", action="store_true")

--- a/scripts/kind-round-preflight.sh
+++ b/scripts/kind-round-preflight.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Validate that the kind Hub has the state needed for a consensus round.
+set -euo pipefail
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+SCION_BIN="${SCION_BIN:-scion}"
+HUB_ENDPOINT="${SCION_HUB_ENDPOINT:-${HUB_ENDPOINT:-}}"
+PROJECT_ROOT_INPUT="${1:-${SCION_OPS_PROJECT_ROOT:-$(pwd -P)}}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+if git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+  PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel)"
+fi
+
+command -v "$SCION_BIN" >/dev/null 2>&1 || die "scion not on PATH"
+[[ -n "$HUB_ENDPOINT" ]] || die "SCION_HUB_ENDPOINT is not set; run task up or task bootstrap first"
+[[ -d "$PROJECT_ROOT" ]] || die "target project is not visible: $PROJECT_ROOT"
+git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || die "target project is not a git repo: $PROJECT_ROOT"
+[[ -f "${PROJECT_ROOT}/.scion/grove-id" ]] || die "target project is not linked to the Hub; run task bootstrap -- ${PROJECT_ROOT}"
+
+if [[ -z "${SCION_DEV_TOKEN:-}" && -z "${SCION_DEV_TOKEN_FILE:-}" && ! -f "${HOME}/.scion/dev-token" ]]; then
+  die "Hub dev auth is unavailable; run task bootstrap from the host or expose SCION_DEV_TOKEN_FILE"
+fi
+
+required_secrets=(
+  GITHUB_TOKEN
+  CLAUDE_AUTH
+  CODEX_AUTH
+  GEMINI_OAUTH_CREDS
+)
+
+for secret in "${required_secrets[@]}"; do
+  (cd "$PROJECT_ROOT" && "$SCION_BIN" hub secret get --scope hub "$secret" \
+    --hub "$HUB_ENDPOINT" \
+    --json \
+    --non-interactive) \
+    >/dev/null || die "Hub secret ${secret} is missing; run task bootstrap"
+done
+
+required_templates=(
+  consensus-runner
+  impl-claude
+  impl-codex
+  reviewer-claude
+  reviewer-codex
+  final-reviewer-gemini
+  final-reviewer-codex
+)
+
+for template in "${required_templates[@]}"; do
+  (cd "$PROJECT_ROOT" && SCION_HUB_ENDPOINT="$HUB_ENDPOINT" "$SCION_BIN" --global templates show "$template" \
+    --hub \
+    --non-interactive) \
+    >/dev/null || die "Hub template ${template} is missing; run task bootstrap"
+done

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -11,8 +11,27 @@ PROFILE_NAME="${SCION_K8S_PROFILE:-kind}"
 RUNTIME_NAME="${SCION_K8S_RUNTIME:-kubernetes}"
 IMAGE_REGISTRY="${SCION_IMAGE_REGISTRY:-localhost}"
 MANIFEST_DIR="${SCION_K8S_MANIFEST_DIR:-${REPO_ROOT}/deploy/kind}"
-WORKSPACE_HOST_PATH="${SCION_OPS_WORKSPACE_HOST_PATH:-$REPO_ROOT}"
-WORKSPACE_NODE_PATH="${SCION_OPS_WORKSPACE_NODE_PATH:-/workspace/scion-ops}"
+DEFAULT_WORKSPACE_HOST_PATH="${HOME}/workspace"
+case "$REPO_ROOT" in
+  "$DEFAULT_WORKSPACE_HOST_PATH"|"$DEFAULT_WORKSPACE_HOST_PATH"/*) ;;
+  *) DEFAULT_WORKSPACE_HOST_PATH="$(dirname "$REPO_ROOT")" ;;
+esac
+if [[ ! -d "$DEFAULT_WORKSPACE_HOST_PATH" ]]; then
+  DEFAULT_WORKSPACE_HOST_PATH="$(dirname "$REPO_ROOT")"
+fi
+WORKSPACE_HOST_PATH="${SCION_OPS_WORKSPACE_HOST_PATH:-$DEFAULT_WORKSPACE_HOST_PATH}"
+WORKSPACE_NODE_PATH="${SCION_OPS_WORKSPACE_NODE_PATH:-/workspace}"
+case "$REPO_ROOT" in
+  "$WORKSPACE_HOST_PATH")
+    SCION_OPS_REPO_NODE_PATH="${SCION_OPS_REPO_NODE_PATH:-$WORKSPACE_NODE_PATH}"
+    ;;
+  "$WORKSPACE_HOST_PATH"/*)
+    SCION_OPS_REPO_NODE_PATH="${SCION_OPS_REPO_NODE_PATH:-${WORKSPACE_NODE_PATH}/${REPO_ROOT#"$WORKSPACE_HOST_PATH"/}}"
+    ;;
+  *)
+    SCION_OPS_REPO_NODE_PATH="${SCION_OPS_REPO_NODE_PATH:-${WORKSPACE_NODE_PATH}/scion-ops}"
+    ;;
+esac
 KIND_PROVIDER="${KIND_EXPERIMENTAL_PROVIDER:-${SCION_OPS_KIND_PROVIDER:-podman}}"
 KIND_CLUSTER_CONFIG_TEMPLATE="${SCION_OPS_KIND_CLUSTER_CONFIG_TEMPLATE:-${REPO_ROOT}/deploy/kind/cluster.yaml.tpl}"
 KIND_LISTEN_ADDRESS="${SCION_OPS_KIND_LISTEN_ADDRESS:-192.168.122.103}"
@@ -45,10 +64,14 @@ Environment:
   SCION_K8S_PROFILE          Scion profile name (default: kind)
   SCION_K8S_RUNTIME          Scion runtime name (default: kubernetes)
   SCION_IMAGE_REGISTRY       Agent image registry/prefix (default: localhost)
-  SCION_OPS_WORKSPACE_HOST_PATH  Host scion-ops checkout mounted into kind
-                                 (default: this repo)
-  SCION_OPS_WORKSPACE_NODE_PATH  Node path used by future MCP hostPath mounts
-                                 (default: /workspace/scion-ops)
+  SCION_OPS_WORKSPACE_HOST_PATH  Host workspace tree mounted into kind
+                                 (default: ~/workspace when it contains the
+                                 scion-ops checkout, otherwise the checkout's
+                                 parent)
+  SCION_OPS_WORKSPACE_NODE_PATH  Node path for the mounted workspace tree
+                                 (default: /workspace)
+  SCION_OPS_REPO_NODE_PATH       scion-ops repo path inside the kind node
+                                 (default: derived from host/node paths)
   SCION_OPS_KIND_PROVIDER        kind provider when KIND_EXPERIMENTAL_PROVIDER
                                  is unset (default: podman)
   SCION_OPS_KIND_CLUSTER_CONFIG_TEMPLATE
@@ -84,8 +107,12 @@ kubectl_ctx() {
 ensure_workspace_host_path() {
   [[ "$WORKSPACE_HOST_PATH" = /* ]] || die "SCION_OPS_WORKSPACE_HOST_PATH must be an absolute path: $WORKSPACE_HOST_PATH"
   [[ "$WORKSPACE_NODE_PATH" = /* ]] || die "SCION_OPS_WORKSPACE_NODE_PATH must be an absolute path: $WORKSPACE_NODE_PATH"
+  [[ "$SCION_OPS_REPO_NODE_PATH" = /* ]] || die "SCION_OPS_REPO_NODE_PATH must be an absolute path: $SCION_OPS_REPO_NODE_PATH"
   [[ -d "$WORKSPACE_HOST_PATH" ]] || die "workspace host path not found: $WORKSPACE_HOST_PATH"
-  [[ -f "${WORKSPACE_HOST_PATH}/Taskfile.yml" ]] || die "workspace host path does not look like scion-ops: $WORKSPACE_HOST_PATH"
+  case "$REPO_ROOT" in
+    "$WORKSPACE_HOST_PATH"|"$WORKSPACE_HOST_PATH"/*) ;;
+    *) die "SCION_OPS_WORKSPACE_HOST_PATH must contain the scion-ops checkout: $WORKSPACE_HOST_PATH" ;;
+  esac
 }
 
 yaml_dq_escape() {
@@ -152,8 +179,8 @@ workspace_mount_present() {
   [[ -n "$node" ]] || return 1
   runtime="$(container_runtime_for_node "$node")" || return 1
 
-  "$runtime" exec "$node" test -f "${WORKSPACE_NODE_PATH}/Taskfile.yml" &&
-    "$runtime" exec "$node" test -d "${WORKSPACE_NODE_PATH}/.git"
+  "$runtime" exec "$node" test -f "${SCION_OPS_REPO_NODE_PATH}/Taskfile.yml" &&
+    "$runtime" exec "$node" test -d "${SCION_OPS_REPO_NODE_PATH}/.git"
 }
 
 kind_native_ports_present() {
@@ -178,6 +205,11 @@ warn_missing_workspace_mount() {
 Warning: workspace mount is not available inside kind node ${WORKSPACE_NODE_PATH}.
 Existing kind clusters cannot be updated with new extraMounts. Recreate this
 cluster with 'task down' and then 'task up' before deploying scion-ops.
+
+Expected:
+  host workspace path: ${WORKSPACE_HOST_PATH}
+  node workspace path: ${WORKSPACE_NODE_PATH}
+  scion-ops node path: ${SCION_OPS_REPO_NODE_PATH}
 EOF
 }
 
@@ -275,7 +307,8 @@ cmd_status() {
   printf 'namespace: %s\n' "$NAMESPACE"
   printf 'provider:  %s\n' "$KIND_PROVIDER"
   printf 'workspace host: %s\n' "$WORKSPACE_HOST_PATH"
-  printf 'workspace node: %s\n\n' "$WORKSPACE_NODE_PATH"
+  printf 'workspace node: %s\n' "$WORKSPACE_NODE_PATH"
+  printf 'scion-ops node: %s\n\n' "$SCION_OPS_REPO_NODE_PATH"
   printf 'Hub host URL: http://%s:%s\n' "$KIND_LISTEN_ADDRESS" "$HUB_HOST_PORT"
   printf 'MCP host URL: http://%s:%s/mcp\n\n' "$KIND_LISTEN_ADDRESS" "$MCP_HOST_PORT"
 
@@ -306,7 +339,8 @@ cmd_workspace_status() {
 
   printf 'cluster:        %s\n' "$CLUSTER_NAME"
   printf 'workspace host: %s\n' "$WORKSPACE_HOST_PATH"
-  printf 'workspace node: %s\n\n' "$WORKSPACE_NODE_PATH"
+  printf 'workspace node: %s\n' "$WORKSPACE_NODE_PATH"
+  printf 'scion-ops node: %s\n\n' "$SCION_OPS_REPO_NODE_PATH"
 
   if ! cluster_exists; then
     die "kind cluster $CLUSTER_NAME does not exist; run: task kind:up"


### PR DESCRIPTION
## Summary
- add default kind Hub bootstrap for shared credentials, harness configs, and global scion-ops templates
- make the round launcher and MCP tools use project_root for the selected target project
- mount the workspace tree in kind so MCP can operate from the selected project checkout
- update docs and known issues to describe the Kubernetes-only default lifecycle

Closes #29

## Verification
- task verify
- task bootstrap
- task kind:mcp:smoke
- task test -- --skip-setup

Operational note: kind extraMounts are fixed at cluster creation. To use the workspace-tree mount on an existing local kind cluster, recreate it with `task down && task up`; this deletes cluster-local Hub PVC/state, and `task bootstrap` restores Hub credentials, harness configs, and templates.