### PR TITLE
Test default Kubernetes round setup

### DIFF
--- a/.scion/templates/consensus-runner/system-prompt.md
+++ b/.scion/templates/consensus-runner/system-prompt.md
@@ -87,12 +87,12 @@ The audit file is a working artifact. It does not need to be committed.
 
 1. Initialize `state/<round_id>.json`.
 2. Spawn both implementers in parallel:
-   - Claude: `scion start <claude_impl> --type impl-claude --branch <claude_impl> --no-auth --no-upload --non-interactive --notify "<implementation task>"`
+   - Claude: `scion start <claude_impl> --type impl-claude --branch <claude_impl> --harness-auth auth-file --no-upload --non-interactive --notify "<implementation task>"`
    - Codex: `scion start <codex_impl> --type impl-codex --branch <codex_impl> --harness-auth auth-file --no-upload --non-interactive --notify "<implementation task>"`
 3. Wait for both implementers to reach `completed`. Use `sciontool status blocked` while waiting. Inspect failed or stalled agents with `scion look`.
 4. For each review round up to `max_review_rounds`:
    - Create review snapshot branches with `git branch -f <snapshot_branch> <implementation_branch>`.
-   - Spawn `reviewer-claude` on the Codex snapshot branch with `--no-auth --no-upload`.
+   - Spawn `reviewer-claude` on the Codex snapshot branch with `--harness-auth auth-file --no-upload`.
    - Spawn `reviewer-codex` on the Claude snapshot branch with `--harness-auth auth-file --no-upload`.
    - Include your coordinator agent name in each review prompt and require the reviewer to send its `verdict.json` back to you with `scion message`.
    - Collect both JSON verdicts from Scion messages or visible terminal output.
@@ -101,7 +101,7 @@ The audit file is a working artifact. It does not need to be committed.
    - If consensus is not reached, send only blocking issues back to the relevant implementer. If the implementer stopped, resume it first with `scion resume <agent> --non-interactive`, then message the feedback with `--notify`.
 5. If no consensus after the maximum review rounds, set audit status `escalate`, report the blocking issues, mark the Scion task completed as escalated, and stop.
 6. Pick the winner by highest final-round score: `correctness + completeness`. On a tie, prefer a branch whose tests passed; if still tied, choose Claude.
-7. Create or reset local branch `round-<round_id>-integration` from the winner branch. Spawn the integrator using the winner's implementation template on that integration branch. Use `--no-auth --no-upload` if the winner is Claude; use `--harness-auth auth-file --no-upload` if the winner is Codex. Instruct it to:
+7. Create or reset local branch `round-<round_id>-integration` from the winner branch. Spawn the integrator using the winner's implementation template on that integration branch with `--harness-auth auth-file --no-upload`. Instruct it to:
    - inspect the loser branch for useful ideas,
    - apply agreed reviewer feedback,
    - run tests,
@@ -142,12 +142,11 @@ When spawning or messaging implementers, require:
 - `git push -u origin HEAD` when `origin` is configured,
 - `sciontool status task_completed "<summary>"`.
 
-Claude child agents must be started with `--no-auth --no-upload` so the Claude
-CLI reads the Hub-projected `CLAUDE_AUTH` subscription file at
-`~/.claude/.credentials.json`. Codex and Gemini child agents must be started
-with `--harness-auth auth-file --no-upload` so Scion selects the Hub-projected
-`CODEX_AUTH` and `GEMINI_OAUTH_CREDS` subscription credential files. Templates
-are pre-synced by `task bootstrap`; do not upload templates during a round.
+Claude, Codex, and Gemini child agents must be started with
+`--harness-auth auth-file --no-upload` so Scion explicitly selects the
+Hub-projected subscription credential files: `CLAUDE_AUTH`, `CLAUDE_CONFIG`,
+`CODEX_AUTH`, and `GEMINI_OAUTH_CREDS`. Templates are pre-synced by
+`task bootstrap`; do not upload templates during a round.
 
 ## Final Review Requirements
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ the same lifecycle operations for agents that use those words.
 the target repo as a Hub grove, provides the kind broker, stores shared
 subscription credentials as Hub secrets, and syncs the scion-ops templates from
 inside the Hub pod so host-local upload paths are not used.
+The default LLM auth path uses provider subscription credential files:
+`CLAUDE_AUTH`, `CLAUDE_CONFIG`, `CODEX_AUTH`, and `GEMINI_OAUTH_CREDS`,
+selected through Scion's `auth-file` harness auth. Vertex ADC is not restored
+by default; enable it deliberately with `SCION_OPS_BOOTSTRAP_VERTEX_ADC=1` and
+provide `GOOGLE_CLOUD_PROJECT` plus a Google Cloud region variable.
 
 ## Kubernetes Shape
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,7 +35,7 @@ vars:
   HOME:
     sh: echo "$HOME"
   GOPATH:
-    sh: go env GOPATH
+    sh: command -v go >/dev/null 2>&1 && go env GOPATH || printf '%s/go' "$HOME"
   SCION_BIN: scion
 
 tasks:
@@ -59,6 +59,7 @@ tasks:
       - task: kind:workspace:status
       - task kind:load-images -- localhost/scion-base:latest localhost/scion-ops-mcp:latest localhost/scion-claude:latest localhost/scion-codex:latest localhost/scion-gemini:latest
       - task: kind:control-plane:apply
+      - task: kind:control-plane:restart
       - task: kind:control-plane:status
 
   test:
@@ -130,6 +131,10 @@ tasks:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' apply -f deploy/kind/namespace.yaml
       - kubectl --context '{{.KIND_CONTEXT}}' apply -k deploy/kind/control-plane
+
+  kind:control-plane:restart:
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub deploy/scion-ops-mcp
 
   kind:control-plane:status:
     cmds:

--- a/deploy/kind/control-plane/broker-rbac.yaml
+++ b/deploy/kind/control-plane/broker-rbac.yaml
@@ -47,3 +47,33 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: scion-control-plane-broker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scion-control-plane-broker-namespaces
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scion-control-plane-broker-namespaces
+  labels:
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: scion-control-plane
+    namespace: scion-agents
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scion-control-plane-broker-namespaces

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -22,7 +22,8 @@ task down
 run the bootstrap and smoke test. `task up` is both deploy and update. It
 creates or reuses the kind cluster, applies base runtime resources, verifies the
 workspace mount, loads local images, applies the control-plane Kustomize target,
-and waits for rollout.
+restarts the control-plane deployments so mutable local image tags are picked
+up, and waits for rollout.
 
 ## Kubernetes Resources
 
@@ -132,6 +133,14 @@ The codebase being changed is always the target project. `task bootstrap --
 Shared credentials are stored as Hub-scoped secrets, and scion-ops templates are
 synced as Hub global templates.
 
+Default model authentication uses subscription credential files restored by
+`task bootstrap`: `CLAUDE_AUTH`, `CLAUDE_CONFIG`, `CODEX_AUTH`, and
+`GEMINI_OAUTH_CREDS`.
+The default round personas use Scion's `--harness-auth auth-file` path for
+Claude, Codex, and Gemini. Vertex ADC is deliberately opt-in. To use it, set
+`SCION_OPS_BOOTSTRAP_VERTEX_ADC=1` and provide `GOOGLE_CLOUD_PROJECT` plus
+`GOOGLE_CLOUD_REGION`, `CLOUD_ML_REGION`, or `GOOGLE_CLOUD_LOCATION`.
+
 The MCP tool contract mirrors that shape: pass `project_root` to
 `scion_ops_project_status`, `scion_ops_start_round`, `scion_ops_round_status`,
 `scion_ops_watch_round_events`, and git diff/status tools when operating on a
@@ -148,5 +157,6 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Broker registration | Hub state for co-located broker | yes |
 | MCP workspace | host checkout mounted into kind node | no |
 | Agent artifacts | agent workspaces and pushed git branches | pod-local state is ephemeral |
-| Subscription credentials | Hub-scoped secrets restored by `task bootstrap` | yes |
+| Subscription credentials | Hub-scoped Claude, Codex, and Gemini secrets restored by `task bootstrap` | yes |
+| Vertex ADC credentials | optional Hub-scoped secrets restored only when `SCION_OPS_BOOTSTRAP_VERTEX_ADC=1`; cleared by default bootstrap | yes |
 | Templates/harness configs | Hub global templates and Hub harness configs restored by `task bootstrap` | yes |

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -66,4 +66,6 @@ recreate the Kubernetes cluster.
 The Kubernetes smoke still uses the checked-in generic no-auth smoke config, so
 it proves broker dispatch and MCP readiness without spending subscription model
 usage. The next full validation is a short `scion_ops_start_round` call against
-a clean target branch after `task bootstrap` passes.
+a clean target branch after `task bootstrap` passes. That round should use
+Scion's explicit `auth-file` harness authentication path for Claude, Codex,
+and Gemini, including Claude's companion `CLAUDE_CONFIG` state file.

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -25,13 +25,41 @@ task kind:mcp:smoke
 
 ## Register In Zed
 
-Add this to `.zed/settings.json` or your Zed user settings:
+If Zed can reach the remote host address directly, add this to
+`.zed/settings.json` or your Zed user settings:
 
 ```json
 {
   "context_servers": {
     "scion-ops": {
       "url": "http://192.168.122.103:8765/mcp"
+    }
+  }
+}
+```
+
+If Zed is running locally and should reach MCP through the Zed SSH connection,
+forward the remote MCP port and point the context server at the local forwarded
+port:
+
+```json
+{
+  "ssh_connections": [
+    {
+      "host": "192.168.122.103",
+      "username": "david",
+      "port_forwards": [
+        {
+          "local_port": 8765,
+          "remote_host": "192.168.122.103",
+          "remote_port": 8765
+        }
+      ]
+    }
+  ],
+  "context_servers": {
+    "scion-ops": {
+      "url": "http://127.0.0.1:8765/mcp"
     }
   }
 }
@@ -50,7 +78,8 @@ cd /home/david/workspace/github/livewyer-ops/scion-ops
 task up
 ```
 
-Then use the same remote-host URL in Zed:
+Then use the same remote-host URL in Zed, or the SSH-forwarded local URL when
+using the forwarded configuration above:
 
 ```json
 {

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -624,7 +624,7 @@ class HubClient:
             "/api/v1/messages",
             query={"grove": self.cfg.grove_id, "limit": str(limit)},
         )
-        messages = data.get("items", []) if isinstance(data, dict) else []
+        messages = (data.get("items") or []) if isinstance(data, dict) else []
         result = [item for item in messages if isinstance(item, dict)]
         if round_id:
             result = [item for item in result if _round_text_match(item, round_id)]

--- a/orchestrator/round.sh
+++ b/orchestrator/round.sh
@@ -59,7 +59,7 @@ printf 'Project root: %s\n' "$PROJECT_ROOT"
   --type consensus-runner \
   --branch "$RUNNER_BRANCH" \
   --broker "$BROKER" \
-  --no-auth \
+  --harness-auth auth-file \
   --no-upload \
   --non-interactive \
   --yes \

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -107,6 +107,21 @@ set_file_secret() {
   log "set Hub file secret ${key} -> ${target}"
 }
 
+clear_secret_if_present() {
+  local key="$1"
+  if run_scion hub secret get --scope hub "$key" --json --non-interactive >/dev/null 2>&1; then
+    run_scion hub secret clear --scope hub "$key" --non-interactive --yes >/dev/null
+    log "cleared Hub secret ${key}"
+  fi
+}
+
+truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 sync_harness_configs() {
   local pod="$1"
   local configs=(claude codex gemini)
@@ -177,10 +192,22 @@ main() {
   unset token
 
   set_file_secret CLAUDE_AUTH "${CLAUDE_AUTH_FILE:-${HOME}/.claude/.credentials.json}" "~/.claude/.credentials.json"
+  set_file_secret CLAUDE_CONFIG "${CLAUDE_CONFIG_FILE:-${HOME}/.claude.json}" "~/.claude.json"
   set_file_secret CODEX_AUTH "${CODEX_AUTH_FILE:-${HOME}/.codex/auth.json}" "~/.codex/auth.json"
   set_file_secret GEMINI_OAUTH_CREDS "${GEMINI_OAUTH_CREDS_FILE:-${HOME}/.gemini/oauth_creds.json}" "~/.gemini/oauth_creds.json"
-  if [[ -f "${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}" ]]; then
+  if truthy "${SCION_OPS_BOOTSTRAP_VERTEX_ADC:-}"; then
+    [[ -n "${GOOGLE_CLOUD_PROJECT:-}" ]] || die "GOOGLE_CLOUD_PROJECT is required when SCION_OPS_BOOTSTRAP_VERTEX_ADC is enabled"
+    [[ -n "${GOOGLE_CLOUD_REGION:-${CLOUD_ML_REGION:-${GOOGLE_CLOUD_LOCATION:-}}}" ]] || die "GOOGLE_CLOUD_REGION, CLOUD_ML_REGION, or GOOGLE_CLOUD_LOCATION is required when SCION_OPS_BOOTSTRAP_VERTEX_ADC is enabled"
     set_file_secret gcloud-adc "${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}" "~/.config/gcloud/application_default_credentials.json"
+    set_env_secret GOOGLE_CLOUD_PROJECT "$GOOGLE_CLOUD_PROJECT"
+    set_env_secret GOOGLE_CLOUD_REGION "${GOOGLE_CLOUD_REGION:-${CLOUD_ML_REGION:-${GOOGLE_CLOUD_LOCATION:-}}}"
+  else
+    clear_secret_if_present gcloud-adc
+    clear_secret_if_present GOOGLE_CLOUD_PROJECT
+    clear_secret_if_present GOOGLE_CLOUD_REGION
+    clear_secret_if_present CLOUD_ML_REGION
+    clear_secret_if_present GOOGLE_CLOUD_LOCATION
+    log "skip Vertex ADC restore; set SCION_OPS_BOOTSTRAP_VERTEX_ADC=1 to enable"
   fi
 
   pod="$(hub_pod)"

--- a/scripts/kind-round-preflight.sh
+++ b/scripts/kind-round-preflight.sh
@@ -28,6 +28,7 @@ fi
 required_secrets=(
   GITHUB_TOKEN
   CLAUDE_AUTH
+  CLAUDE_CONFIG
   CODEX_AUTH
   GEMINI_OAUTH_CREDS
 )


### PR DESCRIPTION
## Summary
- restore Claude, Codex, and Gemini subscription credentials through default bootstrap, including Claude's companion config file
- make the default round templates and runner use Scion auth-file harness auth
- refresh control-plane deployments on task up, add broker namespace RBAC, and document direct/SSH-forwarded Zed MCP config
- make MCP message polling tolerate null Hub message lists

## Verification
- task up
- task bootstrap
- task test -- --skip-setup
- scion-ops MCP hub status: healthy Hub, one connected kind-control-plane broker, zero leftover agents
- Scion targeted tests for the sibling patch passed: pkg/harness, pkg/agent, pkg/runtimebroker with isolated HOME, targeted pkg/hub file-secret/control-channel tests, pkg/wsprotocol

## Dependency
- Depends on the sibling Scion patch now committed locally as /home/david/workspace/github/GoogleCloudPlatform/scion branch issue-43-claude-auth-file-support at 3da72eed.
- Without that Scion patch, bootstrap can reject CLAUDE_CONFIG or dispatch can fail with websocket message-too-big.

Refs #43