### PR TITLE
Reduce kind development rebuild cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ cluster, base runtime resources, image loading, and control-plane Kustomize
 target. Hidden aliases `task deploy`, `task update`, and `task destroy` map to
 the same lifecycle operations for agents that use those words.
 
+For local iteration, use the smallest task that matches the changed asset:
+
+```bash
+task dev:scion:deploy      # rebuild Scion binaries and restart Hub only
+task dev:mcp:restart       # restart MCP after mounted Python source changes
+task build:mcp             # rebuild only the MCP image
+task update:mcp            # load the MCP image and restart MCP only
+task build:harness -- codex
+task load:image -- localhost/scion-codex:latest
+task dev:test              # smoke test without reapplying setup
+task storage:status        # inspect Podman storage before image work
+```
+
 `task bootstrap` is the default credential and template restore path. It links
 the target repo as a Hub grove, provides the kind broker, stores shared
 subscription credentials as Hub secrets, and syncs the scion-ops templates from
@@ -99,6 +112,8 @@ Smoke test the HTTP service with `task kind:mcp:smoke`. See `docs/zed-mcp.md`.
 - `scripts/build-images.sh` — image build helper
 - `scripts/kind-bootstrap.sh` — Hub credential, harness, and template restore
 - `scripts/kind-scion-runtime.sh` — kind substrate helper
+- `scripts/kind-dev-scion.sh` — fast Hub/Broker Scion binary update helper
+- `scripts/storage-status.sh` — Podman storage diagnostic helper
 - `scripts/kind-control-plane-smoke.py` — Kubernetes control-plane smoke
 
 ## Rounds

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,6 +52,18 @@ tasks:
     cmds:
       - bash scripts/build-images.sh {{.CLI_ARGS}}
 
+  build:base:
+    cmds:
+      - bash scripts/build-images.sh --only base {{.CLI_ARGS}}
+
+  build:mcp:
+    cmds:
+      - bash scripts/build-images.sh --only mcp {{.CLI_ARGS}}
+
+  build:harness:
+    cmds:
+      - bash scripts/build-images.sh --only {{.CLI_ARGS}}
+
   up:
     desc: Create or update the kind Kubernetes deployment.
     cmds:
@@ -90,6 +102,58 @@ tasks:
   update:
     cmds:
       - task: up
+
+  update:hub:
+    cmds:
+      - task kind:load-images -- localhost/scion-base:latest
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub
+      - task: kind:hub:status
+
+  update:mcp:
+    cmds:
+      - task kind:load-images -- localhost/scion-ops-mcp:latest
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-ops-mcp
+      - task: kind:mcp:status
+
+  load:image:
+    cmds:
+      - task kind:load-images -- {{.CLI_ARGS}}
+
+  dev:scion:build:
+    cmds:
+      - bash scripts/kind-dev-scion.sh build
+
+  dev:scion:deploy:
+    cmds:
+      - bash scripts/kind-dev-scion.sh deploy
+
+  dev:scion:status:
+    cmds:
+      - bash scripts/kind-dev-scion.sh status
+
+  dev:scion:clear:
+    prompt: This removes Hub dev binaries and restarts Hub. Continue?
+    cmds:
+      - bash scripts/kind-dev-scion.sh clear
+
+  dev:mcp:restart:
+    cmds:
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-ops-mcp
+      - task: kind:mcp:status
+
+  dev:test:
+    cmds:
+      - task test -- --skip-setup
+
+  storage:status:
+    cmds:
+      - bash scripts/storage-status.sh
+
+  storage:prune:
+    prompt: This prunes dangling local Podman image layers. Continue?
+    cmds:
+      - podman image prune -f
+      - task: storage:status
 
   destroy:
     cmds:
@@ -242,4 +306,4 @@ tasks:
       - git diff --check
       - task --list
       - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py')]"
-      - bash -n scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh orchestrator/run-round.sh orchestrator/round.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-dev-scion.sh scripts/kind-round-preflight.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh

--- a/deploy/kind/control-plane/hub-deployment.yaml
+++ b/deploy/kind/control-plane/hub-deployment.yaml
@@ -28,17 +28,16 @@ spec:
           image: localhost/scion-base:latest
           imagePullPolicy: IfNotPresent
           command:
-            - scion
-          env:
-            - name: HOME
-              value: /home/scion
-            - name: USER
-              value: scion
-            - name: LOGNAME
-              value: scion
-            - name: KUBECONFIG
-              value: /home/scion/.kube/config
+            - /bin/sh
+            - -ec
           args:
+            - |
+              scion_bin=scion
+              if [ -x /home/scion/.scion/dev-bin/scion ]; then
+                scion_bin=/home/scion/.scion/dev-bin/scion
+              fi
+              exec "$scion_bin" "$@"
+            - --
             - --global
             - server
             - start
@@ -56,6 +55,15 @@ spec:
             - /home/scion/.scion/hub.db
             - --storage-dir
             - /home/scion/.scion/storage
+          env:
+            - name: HOME
+              value: /home/scion
+            - name: USER
+              value: scion
+            - name: LOGNAME
+              value: scion
+            - name: KUBECONFIG
+              value: /home/scion/.kube/config
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -25,6 +25,22 @@ workspace mount, loads local images, applies the control-plane Kustomize target,
 restarts the control-plane deployments so mutable local image tags are picked
 up, and waits for rollout.
 
+Use focused tasks for iteration:
+
+```bash
+task dev:scion:deploy
+task dev:mcp:restart
+task build:mcp
+task update:mcp
+task build:harness -- claude
+task load:image -- localhost/scion-claude:latest
+task dev:test
+task storage:status
+```
+
+These tasks keep the lifecycle defaults intact while avoiding unnecessary image
+builds, kind image loads, and control-plane restarts.
+
 ## Kubernetes Resources
 
 Resources are native manifests managed by Kustomize:
@@ -81,6 +97,55 @@ tools operate on the mounted git checkout selected by `project_root`.
 
 The broker creates agent pods in `scion-agents` using in-cluster Kubernetes API
 access. It does not use host Podman or Docker sockets.
+
+## Development Loop
+
+Scion Hub/Broker changes can be tested without rebuilding `scion-base`.
+
+```bash
+task dev:scion:deploy
+task dev:scion:status
+task dev:test
+```
+
+`task dev:scion:deploy` builds `scion` and `sciontool` from the upstream Scion
+checkout, copies them into the Hub PVC at `/home/scion/.scion/dev-bin`, and
+restarts only the Hub deployment. The Hub manifest selects that PVC-backed
+binary when it exists; otherwise it runs the image binary. Remove the override
+with:
+
+```bash
+task dev:scion:clear
+```
+
+MCP source changes are mounted from the workspace, so they usually need only:
+
+```bash
+task dev:mcp:restart
+task kind:mcp:smoke
+```
+
+Image-level changes stay explicit:
+
+```bash
+task build:base
+task update:hub
+task build:mcp
+task update:mcp
+task build:harness -- codex
+task load:image -- localhost/scion-codex:latest
+```
+
+Before full image work, check storage:
+
+```bash
+task storage:status
+```
+
+The build helper warns when Podman uses `vfs` and fails early when available
+space in the Podman graph root is under 40 GiB. Set
+`SCION_OPS_SKIP_STORAGE_CHECK=1` only when the storage state has been checked
+another way.
 
 ## Local Access
 

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -1009,7 +1009,7 @@ def scion_ops_round_status(
         ),
         "",
     )
-    transcript: dict[str, Any] | None = None
+    transcript: dict[str, Any] = {}
     if include_transcript and consensus:
         transcript = scion_ops_look(consensus, num_lines=num_lines, project_root=project_root)
     return {
@@ -1048,7 +1048,7 @@ def scion_ops_round_events(
         "changed": bool(events),
         "events": events,
         "cursor": _encode_cursor(snapshot),
-        "terminal": _round_terminal_status(snapshot),
+        "terminal": _round_terminal_status(snapshot) or {},
         "agent_count": len(snapshot["agents"]),
         "message_count": len(snapshot["messages"]),
         "notification_count": len(snapshot["notifications"]),
@@ -1108,7 +1108,7 @@ def scion_ops_watch_round_events(
                 "changed": bool(events),
                 "events": events,
                 "cursor": _encode_cursor(snapshot),
-                "terminal": terminal,
+                "terminal": terminal or {},
                 "timed_out": False,
                 "agent_count": len(snapshot["agents"]),
                 "message_count": len(snapshot["messages"]),
@@ -1129,7 +1129,7 @@ def scion_ops_watch_round_events(
         "changed": False,
         "events": [],
         "cursor": _encode_cursor(snapshot),
-        "terminal": _round_terminal_status(snapshot),
+        "terminal": _round_terminal_status(snapshot) or {},
         "timed_out": True,
         "agent_count": len(snapshot["agents"]),
         "message_count": len(snapshot["messages"]),
@@ -1175,7 +1175,7 @@ def scion_ops_start_round(
     parsed_round_id = match.group(1) if match else env.get("ROUND_ID", "")
     runner = f"round-{parsed_round_id.lower()}-consensus" if parsed_round_id else ""
     event_cursor = ""
-    event_cursor_error: dict[str, Any] | None = None
+    event_cursor_error: dict[str, Any] = {}
     if parsed_round_id:
         try:
             event_cursor = _encode_cursor(_round_event_snapshot(parsed_round_id, str(target_root)))

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -23,6 +23,9 @@ TAG="latest"
 REGISTRY="localhost"
 HARNESSES=(claude codex gemini)   # skip opencode by default to save time/disk
 BUILD_MCP=1
+BUILD_CORE=1
+BUILD_BASE=1
+BUILD_HARNESSES=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOCAL_IMG_BUILD="$REPO_ROOT/image-build"
@@ -35,6 +38,33 @@ while [[ $# -gt 0 ]]; do
     --harness)   HARNESSES=("$2"); shift 2 ;;
     --all-harnesses) HARNESSES=(claude codex gemini opencode); shift ;;
     --skip-mcp)  BUILD_MCP=0; shift ;;
+    --skip-core) BUILD_CORE=0; shift ;;
+    --skip-base) BUILD_BASE=0; shift ;;
+    --skip-harnesses) BUILD_HARNESSES=0; shift ;;
+    --only)
+      BUILD_CORE=0
+      BUILD_BASE=0
+      BUILD_HARNESSES=0
+      BUILD_MCP=0
+      case "$2" in
+        core) BUILD_CORE=1 ;;
+        base) BUILD_BASE=1 ;;
+        harnesses) BUILD_HARNESSES=1 ;;
+        mcp) BUILD_MCP=1 ;;
+        claude|codex|gemini|opencode)
+          BUILD_HARNESSES=1
+          HARNESSES=("$2")
+          ;;
+        all)
+          BUILD_CORE=1
+          BUILD_BASE=1
+          BUILD_HARNESSES=1
+          BUILD_MCP=1
+          ;;
+        *) red "Unknown --only target: $2"; exit 1 ;;
+      esac
+      shift 2
+      ;;
     -h|--help)
       cat <<EOF
 Usage: $(basename "$0") [options]
@@ -44,6 +74,10 @@ Usage: $(basename "$0") [options]
   --harness <name>   Build only this harness (repeatable)
   --all-harnesses    Build claude codex gemini opencode (default: claude codex gemini)
   --skip-mcp         Do not build the scion-ops MCP image
+  --skip-core        Do not build core-base
+  --skip-base        Do not build scion-base
+  --skip-harnesses   Do not build harness images
+  --only <target>    Build only core, base, mcp, harnesses, all, or one harness
 EOF
       exit 0
       ;;
@@ -55,6 +89,28 @@ done
 command -v podman >/dev/null || { red "podman not on PATH"; exit 1; }
 
 IMG_BUILD="$SCION_SRC/image-build"
+
+storage_preflight() {
+  [[ "${SCION_OPS_SKIP_STORAGE_CHECK:-}" == "1" ]] && return
+
+  local driver graph_root available_kb
+  driver="$(podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || true)"
+  graph_root="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || true)"
+
+  if [[ "$driver" == "vfs" ]]; then
+    printf '\033[33m%s\033[0m\n' "Warning: Podman is using the vfs storage driver; image rebuilds will consume much more disk than overlay-backed storage."
+    printf '\033[33m%s\033[0m\n' "         Use targeted build tasks, or run 'task storage:status' and 'task storage:prune' before a full build."
+  fi
+
+  if [[ -n "$graph_root" && -d "$graph_root" ]]; then
+    available_kb="$(df -Pk "$graph_root" | awk 'NR == 2 {print $4}')"
+    if [[ -n "$available_kb" && "$available_kb" -lt 41943040 ]]; then
+      red "Podman storage has less than 40GiB available at $graph_root."
+      red "Run 'task storage:status' and prune old images before building."
+      exit 1
+    fi
+  fi
+}
 
 build() {
   local name="$1" dockerfile="$2" context="$3"; shift 3
@@ -68,29 +124,37 @@ build() {
   green "    ok  $tag"
 }
 
+storage_preflight
+
 # 1. core-base
-build "core-base" \
-      "$IMG_BUILD/core-base/Dockerfile" \
-      "$IMG_BUILD/core-base"
+if [[ "$BUILD_CORE" == "1" ]]; then
+  build "core-base" \
+        "$IMG_BUILD/core-base/Dockerfile" \
+        "$IMG_BUILD/core-base"
+fi
 
 # 2. scion-base (needs scion source root as context to copy go.mod, cmd/, pkg/, web/)
-build "scion-base" \
-      "$IMG_BUILD/scion-base/Dockerfile" \
-      "$SCION_SRC" \
-      --build-arg "BASE_IMAGE=${REGISTRY}/core-base:${TAG}" \
-      --build-arg "GIT_COMMIT=$(git -C "$SCION_SRC" rev-parse HEAD 2>/dev/null || echo unknown)"
+if [[ "$BUILD_BASE" == "1" ]]; then
+  build "scion-base" \
+        "$IMG_BUILD/scion-base/Dockerfile" \
+        "$SCION_SRC" \
+        --build-arg "BASE_IMAGE=${REGISTRY}/core-base:${TAG}" \
+        --build-arg "GIT_COMMIT=$(git -C "$SCION_SRC" rev-parse HEAD 2>/dev/null || echo unknown)"
+fi
 
 # 3. harness images
-for h in "${HARNESSES[@]}"; do
-  harness_dir="$IMG_BUILD/${h}"
-  if [[ -d "$LOCAL_IMG_BUILD/${h}" ]]; then
-    harness_dir="$LOCAL_IMG_BUILD/${h}"
-  fi
-  build "scion-${h}" \
-        "$harness_dir/Dockerfile" \
-        "$harness_dir" \
-        --build-arg "BASE_IMAGE=${REGISTRY}/scion-base:${TAG}"
-done
+if [[ "$BUILD_HARNESSES" == "1" ]]; then
+  for h in "${HARNESSES[@]}"; do
+    harness_dir="$IMG_BUILD/${h}"
+    if [[ -d "$LOCAL_IMG_BUILD/${h}" ]]; then
+      harness_dir="$LOCAL_IMG_BUILD/${h}"
+    fi
+    build "scion-${h}" \
+          "$harness_dir/Dockerfile" \
+          "$harness_dir" \
+          --build-arg "BASE_IMAGE=${REGISTRY}/scion-base:${TAG}"
+  done
+fi
 
 if [[ "$BUILD_MCP" == "1" ]]; then
   build "scion-ops-mcp" \

--- a/scripts/kind-dev-scion.sh
+++ b/scripts/kind-dev-scion.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Fast Scion binary iteration for the kind-hosted Hub/Broker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCION_SRC="${SCION_SRC:-${HOME}/workspace/github/GoogleCloudPlatform/scion}"
+BIN_DIR="${SCION_DEV_BIN_DIR:-${SCION_SRC}/.scion-dev/bin}"
+KIND_CONTEXT="${KIND_CONTEXT:-kind-${KIND_CLUSTER_NAME:-scion-ops}}"
+NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
+DEV_BIN_TARGET="/home/scion/.scion/dev-bin"
+
+log() {
+  printf '\033[36m==> %s\033[0m\n' "$*"
+}
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <build|deploy|status|clear>
+
+Commands:
+  build    Build scion and sciontool into ${BIN_DIR}
+  deploy   Build, copy binaries into the Hub PVC dev-bin path, and restart Hub
+  status   Show whether Hub is using dev binaries
+  clear    Remove dev binaries from the Hub PVC and restart Hub
+
+Environment:
+  SCION_SRC          Upstream Scion source checkout
+                     (default: ${SCION_SRC})
+  SCION_DEV_BIN_DIR  Local output directory
+                     (default: ${BIN_DIR})
+  KIND_CONTEXT       Kubernetes context
+                     (default: ${KIND_CONTEXT})
+  SCION_K8S_NAMESPACE Namespace
+                     (default: ${NAMESPACE})
+EOF
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required on PATH"
+}
+
+hub_pod() {
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" get pod \
+    -l app.kubernetes.io/name=scion-hub,app.kubernetes.io/component=hub \
+    -o jsonpath='{.items[0].metadata.name}'
+}
+
+cmd_build() {
+  require go
+  [[ -d "$SCION_SRC" ]] || die "SCION_SRC does not exist: $SCION_SRC"
+  [[ -f "$SCION_SRC/go.mod" ]] || die "SCION_SRC is not a Go module: $SCION_SRC"
+
+  log "build Scion binaries from $SCION_SRC"
+  mkdir -p "$BIN_DIR"
+  (
+    cd "$SCION_SRC"
+    go build -buildvcs=false -tags no_embed_web -o "$BIN_DIR/scion" ./cmd/scion/
+    go build -buildvcs=false -tags no_embed_web -o "$BIN_DIR/sciontool" ./cmd/sciontool/
+  )
+  chmod +x "$BIN_DIR/scion" "$BIN_DIR/sciontool"
+  ls -lh "$BIN_DIR/scion" "$BIN_DIR/sciontool"
+}
+
+cmd_deploy() {
+  require kubectl
+  cmd_build
+
+  local pod
+  pod="$(hub_pod)"
+  [[ -n "$pod" ]] || die "scion-hub pod not found in $KIND_CONTEXT/$NAMESPACE"
+
+  log "copy dev binaries into Hub PVC"
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" exec "$pod" -c hub -- mkdir -p "$DEV_BIN_TARGET"
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" cp "$BIN_DIR/scion" "$pod:${DEV_BIN_TARGET}/scion" -c hub
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" cp "$BIN_DIR/sciontool" "$pod:${DEV_BIN_TARGET}/sciontool" -c hub
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" exec "$pod" -c hub -- chmod +x "${DEV_BIN_TARGET}/scion" "${DEV_BIN_TARGET}/sciontool"
+
+  log "restart Hub to run dev scion binary"
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" rollout restart deploy/scion-hub
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" rollout status deploy/scion-hub --timeout=120s
+}
+
+cmd_status() {
+  require kubectl
+  local pod
+  pod="$(hub_pod)"
+  [[ -n "$pod" ]] || die "scion-hub pod not found in $KIND_CONTEXT/$NAMESPACE"
+
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" exec "$pod" -c hub -- sh -lc "
+    set -e
+    printf 'dev-bin: %s\n' '${DEV_BIN_TARGET}'
+    ls -lh '${DEV_BIN_TARGET}' 2>/dev/null || true
+    printf '\nselected scion: '
+    if [ -x '${DEV_BIN_TARGET}/scion' ]; then
+      printf '%s\n' '${DEV_BIN_TARGET}/scion'
+    else
+      command -v scion
+    fi
+  "
+}
+
+cmd_clear() {
+  require kubectl
+  local pod
+  pod="$(hub_pod)"
+  [[ -n "$pod" ]] || die "scion-hub pod not found in $KIND_CONTEXT/$NAMESPACE"
+
+  log "remove dev binaries from Hub PVC"
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" exec "$pod" -c hub -- rm -f "${DEV_BIN_TARGET}/scion" "${DEV_BIN_TARGET}/sciontool"
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" rollout restart deploy/scion-hub
+  kubectl --context "$KIND_CONTEXT" -n "$NAMESPACE" rollout status deploy/scion-hub --timeout=120s
+}
+
+case "${1:-}" in
+  build)
+    cmd_build
+    ;;
+  deploy)
+    cmd_deploy
+    ;;
+  status)
+    cmd_status
+    ;;
+  clear)
+    cmd_clear
+    ;;
+  -h|--help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/storage-status.sh
+++ b/scripts/storage-status.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Show the local container storage state used by kind and image builds.
+set -euo pipefail
+
+warn() {
+  printf '\033[33m%s\033[0m\n' "$*"
+}
+
+if ! command -v podman >/dev/null 2>&1; then
+  echo "podman is not on PATH"
+  exit 1
+fi
+
+driver="$(podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || true)"
+graph_root="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || true)"
+run_root="$(podman info --format '{{.Store.RunRoot}}' 2>/dev/null || true)"
+image_tmp="$(podman info --format '{{.Store.ImageCopyTmpDir}}' 2>/dev/null || true)"
+
+printf 'Podman storage\n'
+printf '  driver:   %s\n' "${driver:-unknown}"
+printf '  graph:    %s\n' "${graph_root:-unknown}"
+printf '  run:      %s\n' "${run_root:-unknown}"
+printf '  tmp:      %s\n\n' "${image_tmp:-unknown}"
+
+if [[ "$driver" == "vfs" ]]; then
+  warn "Warning: vfs copies layers instead of sharing them efficiently."
+  warn "         Full Scion image rebuilds can consume hundreds of GiB."
+  warn "         Prefer task dev:* or targeted task build:* commands for iteration."
+  printf '\n'
+fi
+
+if [[ -n "$graph_root" && -d "$graph_root" ]]; then
+  df -h "$graph_root"
+  printf '\n'
+fi
+
+podman system df
+
+printf '\nLargest scion images\n'
+podman images --format 'table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}' |
+  awk 'NR == 1 || /localhost\/(core-base|scion-)/'


### PR DESCRIPTION
Closes #59.

## Summary
- keep the default task list focused on lifecycle commands while adding hidden targeted helpers for narrow image loads, MCP restarts, and fast Scion Hub/Broker binary iteration
- add Podman storage diagnostics and build preflight warnings for vfs / low free space
- let the Hub select PVC-backed dev Scion binaries when present, otherwise use the image binary
- make optional MCP round status fields object-shaped so event watching does not fail response serialization
- document the intended default and iteration loops

## Verification
- task verify
- kubectl --context kind-scion-ops apply -k deploy/kind/control-plane --dry-run=client
- task storage:status