### PR TITLE
Improve Kubernetes round diagnostics and image workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ task dev:test              # smoke test without reapplying setup
 task storage:status        # inspect Podman storage before image work
 ```
 
+For normal full rebuilds, rootless Podman should report the `overlay` storage
+driver. `vfs` is suitable only for very small experiments because it copies
+layers instead of sharing them and can consume disk quickly.
+
 `task bootstrap` is the default credential and template restore path. It links
 the target repo as a Hub grove, provides the kind broker, stores shared
 subscription credentials as Hub secrets, and syncs the scion-ops templates from
@@ -65,7 +69,7 @@ kind cluster:
 host:
   repo checkout and target project checkouts
   container image build source
-  kind native host ports for Hub and Zed
+  kind native host ports for Hub and MCP
 ```
 
 The Kubernetes resources are native Kustomize manifests under `deploy/kind`.
@@ -130,3 +134,8 @@ SCION_OPS_PROJECT_ROOT=/home/david/workspace/github/example/project task round -
 The MCP tool `scion_ops_start_round` accepts the same target as `project_root`.
 Agents work from the target repo's Hub grove and branch context; uncommitted
 local work is not included unless it is committed or pushed before the round.
+
+If a round reaches its watchdog limit, scion-ops stops the round agents and
+keeps their Hub records for inspection. Use `task abort -- <round_id>` when the
+diagnostics are no longer needed. Set `SCION_OPS_WATCHDOG_DELETE=1` only when
+automatic timeout cleanup is preferred over post-run inspection.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -306,4 +306,4 @@ tasks:
       - git diff --check
       - task --list
       - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py')]"
-      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-dev-scion.sh scripts/kind-round-preflight.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-dev-scion.sh scripts/kind-round-preflight.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/abort.sh

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -145,7 +145,9 @@ task storage:status
 The build helper warns when Podman uses `vfs` and fails early when available
 space in the Podman graph root is under 40 GiB. Set
 `SCION_OPS_SKIP_STORAGE_CHECK=1` only when the storage state has been checked
-another way.
+another way. Normal full rebuilds should use rootless Podman with the `overlay`
+storage driver so base layers are shared across `core-base`, `scion-base`, MCP,
+and harness images.
 
 ## Local Access
 
@@ -190,6 +192,7 @@ Useful overrides:
 | `SCION_KIND_CP_SMOKE_KEEP_AGENT` | unset, deletes on success |
 | `SCION_KIND_CP_SMOKE_SKIP_SETUP` | unset, applies kind resources |
 | `SCION_KIND_CP_SMOKE_TIMEOUT` | `90` |
+| `SCION_OPS_WATCHDOG_DELETE` | unset, timeout stops agents and keeps Hub records |
 
 ## Project Targeting
 
@@ -221,7 +224,7 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Hub dev token | `scion-hub-state` PVC | yes |
 | Broker registration | Hub state for co-located broker | yes |
 | MCP workspace | host checkout mounted into kind node | no |
-| Agent artifacts | agent workspaces and pushed git branches | pod-local state is ephemeral |
+| Agent artifacts | Hub agent records and pushed git branches | pod-local state is ephemeral |
 | Subscription credentials | Hub-scoped Claude, Codex, and Gemini secrets restored by `task bootstrap` | yes |
 | Vertex ADC credentials | optional Hub-scoped secrets restored only when `SCION_OPS_BOOTSTRAP_VERTEX_ADC=1`; cleared by default bootstrap | yes |
 | Templates/harness configs | Hub global templates and Hub harness configs restored by `task bootstrap` | yes |

--- a/image-build/gemini/Dockerfile
+++ b/image-build/gemini/Dockerfile
@@ -3,10 +3,8 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG GEMINI_CLI_VERSION=0.11.3
-ARG TASK_VERSION=v3.44.0
 
-RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION} \
-  && npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} \
+RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} \
   && npm cache clean --force
 
 CMD ["gemini"]

--- a/image-build/scion-ops-mcp/Dockerfile
+++ b/image-build/scion-ops-mcp/Dockerfile
@@ -4,11 +4,9 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG TASK_VERSION=v3.44.0
 ENV VIRTUAL_ENV=/opt/scion-ops-mcp/venv
 
-RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION} \
-  && python3 -m venv "${VIRTUAL_ENV}" \
+RUN python3 -m venv "${VIRTUAL_ENV}" \
   && "${VIRTUAL_ENV}/bin/pip" install --no-cache-dir "mcp>=1.13,<2" "PyYAML>=6,<7"
 
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \

--- a/image-build/task-runtime/Dockerfile
+++ b/image-build/task-runtime/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG TASK_VERSION=v3.44.0
+
+USER root
+RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION}

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -1235,11 +1235,25 @@ def scion_ops_abort_round(round_id: str, confirm: bool = False, project_root: st
 
 @mcp.tool()
 def scion_ops_round_artifacts(round_id: str, project_root: str = "") -> dict[str, Any]:
-    """Find local branches and agent workspaces associated with a round id."""
+    """Find local/remote branches and agent workspaces associated with a round id."""
     round_id = _clean_name(round_id, "round_id")
     root = _project_root(project_root) if project_root else _repo_root()
     branch_patterns = sorted({f"*{round_id}*", f"*{round_id.lower()}*"})
     branch_result = _run(["git", "branch", "--list", *branch_patterns], timeout=15, cwd=root)
+    remote_result = _run(
+        ["git", "ls-remote", "--heads", "origin", *branch_patterns],
+        timeout=25,
+        cwd=root,
+    )
+    remote_branches: list[dict[str, str]] = []
+    if remote_result["ok"]:
+        for line in remote_result["output"].splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+                remote_branches.append({
+                    "sha": parts[0],
+                    "branch": parts[1].removeprefix("refs/heads/"),
+                })
     agents_dir = root / ".scion" / "agents"
     workspaces: list[str] = []
     prompts: list[str] = []
@@ -1255,9 +1269,11 @@ def scion_ops_round_artifacts(round_id: str, project_root: str = "") -> dict[str
         "source": "local_git",
         "project_root": str(root),
         "branches": [line.strip(" *+") for line in branch_result["output"].splitlines() if line.strip()],
+        "remote_branches": remote_branches,
         "workspaces": workspaces,
         "prompts": prompts,
         "branch_result": _command_result(branch_result),
+        "remote_branch_result": _command_result(remote_result),
     }
 
 

--- a/orchestrator/abort.sh
+++ b/orchestrator/abort.sh
@@ -6,6 +6,12 @@ set -eo pipefail
 
 ROUND_FILTER="${1:-}"
 SCION_BIN="${SCION_BIN:-scion}"
+DELETE_AGENTS="${SCION_OPS_ABORT_DELETE:-1}"
+
+case "$DELETE_AGENTS" in
+  1|true|TRUE|yes|YES|on|ON) DELETE_AGENTS=1 ;;
+  *) DELETE_AGENTS=0 ;;
+esac
 
 names=$("$SCION_BIN" list --format json 2>/dev/null \
   | sed -n '/^\[/,/^\]/p' \
@@ -25,10 +31,14 @@ done <<<"$names"
 
 sleep 2
 
-while IFS= read -r n; do
-  [[ -n "$n" ]] || continue
-  echo "deleting  $n"
-  "$SCION_BIN" delete "$n" --non-interactive --yes 2>/dev/null | tail -1 || true
-done <<<"$names"
+if [[ "$DELETE_AGENTS" == "1" ]]; then
+  while IFS= read -r n; do
+    [[ -n "$n" ]] || continue
+    echo "deleting  $n"
+    "$SCION_BIN" delete "$n" --non-interactive --yes 2>/dev/null | tail -1 || true
+  done <<<"$names"
+else
+  echo "kept stopped agents for inspection."
+fi
 
 echo "done."

--- a/orchestrator/round.sh
+++ b/orchestrator/round.sh
@@ -20,6 +20,7 @@ SCION_OPS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_ROOT_INPUT="${SCION_OPS_PROJECT_ROOT:-$SCION_OPS_ROOT}"
 PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
 PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" || die "target project is not a git repo: $PROJECT_ROOT"
+AGENT_PROJECT_ROOT="${SCION_OPS_AGENT_PROJECT_ROOT:-/workspace}"
 
 ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' "$RANDOM")}"
 MAX_REVIEW_ROUNDS="${MAX_REVIEW_ROUNDS:-${MAX_ROUNDS:-3}}"
@@ -38,7 +39,7 @@ round_id: $ROUND_ID
 max_review_rounds: $MAX_REVIEW_ROUNDS
 base_branch: $BASE_BRANCH
 final_reviewer: $FINAL_REVIEWER
-project_root: $PROJECT_ROOT
+project_root: $AGENT_PROJECT_ROOT
 
 original_task:
 $PROMPT
@@ -53,7 +54,8 @@ printf 'Round id: %s\n' "$ROUND_ID"
 printf 'Base branch: %s\n' "$BASE_BRANCH"
 printf 'Final reviewer: %s\n' "$FINAL_REVIEWER"
 printf 'Broker: %s\n' "$BROKER"
-printf 'Project root: %s\n' "$PROJECT_ROOT"
+printf 'Grove root: %s\n' "$PROJECT_ROOT"
+printf 'Agent project root: %s\n' "$AGENT_PROJECT_ROOT"
 
 "$SCION_BIN" --grove "$PROJECT_ROOT" start "$RUNNER_NAME" \
   --type consensus-runner \

--- a/orchestrator/run-round.sh
+++ b/orchestrator/run-round.sh
@@ -19,6 +19,11 @@ BASE_BRANCH="${BASE_BRANCH:-}"
 LOG_FILE="${LOG_FILE:-/tmp/scion-round.log}"
 PID_FILE="${PID_FILE:-/tmp/scion-round.pid}"
 WATCHDOG_PID_FILE="${WATCHDOG_PID_FILE:-/tmp/scion-round-watchdog.pid}"
+WATCHDOG_DELETE="${SCION_OPS_WATCHDOG_DELETE:-0}"
+case "$WATCHDOG_DELETE" in
+  1|true|TRUE|yes|YES|on|ON) WATCHDOG_DELETE=1 ;;
+  *) WATCHDOG_DELETE=0 ;;
+esac
 
 ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' "$RANDOM")}"
 RUNNER_NAME="round-${ROUND_ID,,}-consensus"   # scion lowercases agent slugs
@@ -67,9 +72,14 @@ echo "$ROUND_PID" > "$PID_FILE"
 # 2. Watchdog: after MAX_MINUTES, kill everything related to this round.
 (
   sleep $((MAX_MINUTES * 60))
-  if "$SCION_OPS_ROOT/orchestrator/abort.sh" "$ROUND_ID" >/dev/null 2>&1; then
-    printf '\n[watchdog %s] aborted round %s after %s minutes\n' \
-      "$(date +%H:%M:%S)" "$ROUND_ID" "$MAX_MINUTES" >> "$LOG_FILE"
+  if SCION_OPS_ABORT_DELETE="$WATCHDOG_DELETE" "$SCION_OPS_ROOT/orchestrator/abort.sh" "$ROUND_ID" >/dev/null 2>&1; then
+    if [[ "$WATCHDOG_DELETE" == "1" ]]; then
+      action="aborted and deleted"
+    else
+      action="stopped for inspection"
+    fi
+    printf '\n[watchdog %s] %s round %s after %s minutes\n' \
+      "$(date +%H:%M:%S)" "$action" "$ROUND_ID" "$MAX_MINUTES" >> "$LOG_FILE"
   fi
   kill "$ROUND_PID" 2>/dev/null || true
 ) >> "$LOG_FILE" 2>&1 &

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -29,6 +29,7 @@ BUILD_HARNESSES=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOCAL_IMG_BUILD="$REPO_ROOT/image-build"
+TASK_VERSION="${TASK_VERSION:-v3.44.0}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -140,6 +141,11 @@ if [[ "$BUILD_BASE" == "1" ]]; then
         "$SCION_SRC" \
         --build-arg "BASE_IMAGE=${REGISTRY}/core-base:${TAG}" \
         --build-arg "GIT_COMMIT=$(git -C "$SCION_SRC" rev-parse HEAD 2>/dev/null || echo unknown)"
+  build "scion-base" \
+        "$LOCAL_IMG_BUILD/task-runtime/Dockerfile" \
+        "$LOCAL_IMG_BUILD/task-runtime" \
+        --build-arg "BASE_IMAGE=${REGISTRY}/scion-base:${TAG}" \
+        --build-arg "TASK_VERSION=${TASK_VERSION}"
 fi
 
 # 3. harness images

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -41,6 +41,7 @@ HUB_NODE_PORT="30090"
 MCP_NODE_PORT="30876"
 CONTEXT="kind-${CLUSTER_NAME}"
 SCION_SETTINGS_TEMPLATE="${SCION_SETTINGS_TEMPLATE:-${REPO_ROOT}/deploy/kind/scion-settings.base.yaml}"
+KIND_IMAGE_PLATFORM="${SCION_OPS_KIND_IMAGE_PLATFORM:-linux/amd64}"
 export KIND_EXPERIMENTAL_PROVIDER="$KIND_PROVIDER"
 
 usage() {
@@ -80,6 +81,8 @@ Environment:
                                  (default: 192.168.122.103)
   SCION_OPS_KIND_HUB_PORT        Host port for the Hub service (default: 18090)
   SCION_OPS_MCP_PORT             Host port for the MCP service (default: 8765)
+  SCION_OPS_KIND_IMAGE_PLATFORM  Platform for direct kind image imports
+                                 (default: linux/amd64)
 EOF
 }
 
@@ -362,6 +365,11 @@ cmd_load_images() {
 
   for image in "$@"; do
     log "load image $image into $CLUSTER_NAME"
+    if command -v podman >/dev/null 2>&1 && podman image exists "$image" && image_loaded_in_kind "$image"; then
+      log "image $image already loaded in $CLUSTER_NAME"
+      continue
+    fi
+
     local load_output
     if load_output="$(kind load docker-image --name "$CLUSTER_NAME" "$image" 2>&1)"; then
       [[ -n "$load_output" ]] && printf '%s\n' "$load_output"
@@ -380,11 +388,59 @@ cmd_load_images() {
       rm -f "$archive"
       die "failed to export podman image $image"
     fi
-    if ! kind load image-archive --name "$CLUSTER_NAME" "$archive"; then
+    if ! import_image_archive "$archive"; then
       rm -f "$archive"
       die "failed to load podman archive for $image into $CLUSTER_NAME"
     fi
     rm -f "$archive"
+  done
+}
+
+image_loaded_in_kind() {
+  local image="$1"
+  local image_id node runtime
+  local nodes=()
+
+  image_id="$(podman image inspect "$image" --format '{{.Id}}' 2>/dev/null || true)"
+  image_id="${image_id#sha256:}"
+  [[ -n "$image_id" ]] || return 1
+
+  mapfile -t nodes < <(kind get nodes --name "$CLUSTER_NAME" 2>/dev/null)
+  [[ "${#nodes[@]}" -gt 0 ]] || return 1
+
+  for node in "${nodes[@]}"; do
+    [[ -n "$node" ]] || continue
+    runtime="$(container_runtime_for_node "$node")" || return 1
+    "$runtime" exec "$node" ctr --namespace=k8s.io images inspect "$image" 2>/dev/null \
+      | grep -Fq "@sha256:${image_id}" || return 1
+  done
+}
+
+import_image_archive() {
+  local archive="$1"
+  local node runtime snapshotter
+  local nodes=()
+  local import_cmd
+
+  mapfile -t nodes < <(kind get nodes --name "$CLUSTER_NAME" 2>/dev/null)
+  [[ "${#nodes[@]}" -gt 0 ]] || return 1
+
+  for node in "${nodes[@]}"; do
+    [[ -n "$node" ]] || continue
+    runtime="$(container_runtime_for_node "$node")" || return 1
+    snapshotter="${SCION_OPS_KIND_IMAGE_SNAPSHOTTER:-}"
+    if [[ -z "$snapshotter" && "$runtime" == "podman" ]]; then
+      snapshotter="fuse-overlayfs"
+    fi
+
+    import_cmd=(ctr --namespace=k8s.io images import --local --digests --platform "$KIND_IMAGE_PLATFORM")
+    if [[ -n "$snapshotter" ]]; then
+      import_cmd+=(--snapshotter "$snapshotter")
+    fi
+    import_cmd+=(-)
+
+    log "import image archive into $node for $KIND_IMAGE_PLATFORM"
+    "$runtime" exec --privileged -i "$node" "${import_cmd[@]}" < "$archive"
   done
 }
 
@@ -396,7 +452,7 @@ cmd_load_archive() {
   for archive in "$@"; do
     [[ -f "$archive" ]] || die "image archive not found: $archive"
     log "load image archive $archive into $CLUSTER_NAME"
-    kind load image-archive --name "$CLUSTER_NAME" "$archive"
+    import_image_archive "$archive"
   done
 }
 

--- a/scripts/storage-status.sh
+++ b/scripts/storage-status.sh
@@ -25,12 +25,17 @@ printf '  tmp:      %s\n\n' "${image_tmp:-unknown}"
 if [[ "$driver" == "vfs" ]]; then
   warn "Warning: vfs copies layers instead of sharing them efficiently."
   warn "         Full Scion image rebuilds can consume hundreds of GiB."
+  warn "         Rootless Podman should use overlay storage for normal work."
   warn "         Prefer task dev:* or targeted task build:* commands for iteration."
   printf '\n'
 fi
 
 if [[ -n "$graph_root" && -d "$graph_root" ]]; then
   df -h "$graph_root"
+  physical_usage="$( { du -sh "$graph_root" 2>/dev/null || true; } | awk 'NR == 1 {print $1}')"
+  if [[ -n "$physical_usage" ]]; then
+    printf 'Physical graph usage: %s\n' "$physical_usage"
+  fi
   printf '\n'
 fi
 


### PR DESCRIPTION
Closes #61.

Changes:
- keep timed-out round records by default for inspection, with opt-in delete-on-timeout
- add task to scion-base so all agent images inherit it
- remove duplicate task installs from Gemini and MCP images
- make kind image loading work with Podman/containerd local imports and skip already-loaded images
- report physical Podman graph usage and document overlay storage expectations
- include remote round branches in MCP artifact lookup

Verification:
- task verify
- task build
- task up
- task bootstrap
- task test
- task kind:load-images -- localhost/scion-base:latest localhost/scion-ops-mcp:latest localhost/scion-claude:latest localhost/scion-codex:latest localhost/scion-gemini:latest