### PR TITLE
Pin kind Hub identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ host:
 The Kubernetes resources are native Kustomize manifests under `deploy/kind`.
 They are intentionally deployable with `kubectl apply -k`; Helm packaging can
 come later only if the values and lifecycle model justify it.
+The kind Hub uses a stable `SCION_SERVER_HUB_HUBID` so Hub-scoped bootstrap
+secrets remain visible after Hub pod rollouts.
 
 ## MCP And Zed
 

--- a/deploy/kind/control-plane/hub-deployment.yaml
+++ b/deploy/kind/control-plane/hub-deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: scion
             - name: KUBECONFIG
               value: /home/scion/.kube/config
+            - name: SCION_SERVER_HUB_HUBID
+              value: scion-ops-kind
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -166,6 +166,10 @@ task kind:mcp:smoke
 Hub is available at `http://192.168.122.103:18090`; MCP is available at
 `http://192.168.122.103:8765/mcp`.
 
+The kind Hub sets `SCION_SERVER_HUB_HUBID` to `scion-ops-kind`. Scion
+namespaces Hub-scoped secrets by Hub ID, so this value must stay stable across
+Hub pod rollouts or bootstrap credentials will become invisible after restart.
+
 ## Smoke Test
 
 Run:
@@ -221,6 +225,7 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | State | Current local-kind source | Lost on cluster deletion |
 |---|---|---|
 | Hub database/state | `scion-hub-state` PVC | yes |
+| Hub ID | `SCION_SERVER_HUB_HUBID=scion-ops-kind` in `deploy/kind/control-plane/hub-deployment.yaml` | no |
 | Hub dev token | `scion-hub-state` PVC | yes |
 | Broker registration | Hub state for co-located broker | yes |
 | MCP workspace | host checkout mounted into kind node | no |


### PR DESCRIPTION
Closes #63

## Summary
- set a stable kind Hub ID with SCION_SERVER_HUB_HUBID in the Hub Deployment
- document why the Hub ID must survive pod rollouts for Hub-scoped secrets
- record the Hub ID persistence source in the kind control-plane persistence table

## Verification
- task verify
- task up
- task bootstrap
- restarted deploy/scion-hub and confirmed GITHUB_TOKEN remains visible under scopeId scion-ops-kind from the MCP pod