### PR TITLE
Make Scion runtime patches reproducible

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -140,3 +140,25 @@ Hub/Kubernetes agents work from git branches, not uncommitted editor buffers.
 
 Exit criteria: a Claude/Codex/Gemini consensus round passes through the
 Kubernetes Hub from a Zed MCP request against the selected target project.
+
+## Repo-Owned Scion Runtime Patches
+
+Issue: #67
+
+Decision: keep the Scion runtime fixes required by scion-ops as patch files
+under `patches/scion/`, and have build entry points ensure those patches are
+present in the configured local Scion checkout before building images or Hub
+dev binaries.
+
+Reason: the tested Kubernetes round path currently depends on runtime behavior
+that is not guaranteed by an arbitrary upstream Scion checkout. The user does
+not want this work pushed to public Scion repositories, so scion-ops must own a
+reproducible local build path instead of relying on hidden workstation edits.
+
+Constraint: this mutates the configured local Scion checkout. It is acceptable
+only for the local kind product path, and failures must be explicit when a
+patch cannot apply cleanly.
+
+Exit criteria: either the required behavior is available in the default Scion
+source used by scion-ops builds, or scion-ops vendors/pins a Scion source in a
+way that no longer requires patching a separate checkout.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ task dev:test              # smoke test without reapplying setup
 task storage:status        # inspect Podman storage before image work
 ```
 
+`task build` and `task dev:scion:deploy` first ensure the configured Scion
+source has the repo-owned runtime patch set from `patches/scion/`. Inspect or
+apply it directly with:
+
+```bash
+task scion:patch:status
+task scion:patch:apply
+task scion:patch:check
+```
+
+The default source remains `~/workspace/github/GoogleCloudPlatform/scion`; set
+`SCION_SRC` or pass `task build -- --src <path>` when using another checkout.
+
 For normal full rebuilds, rootless Podman should report the `overlay` storage
 driver. `vfs` is suitable only for very small experiments because it copies
 layers instead of sharing them and can consume disk quickly.
@@ -126,11 +139,13 @@ Smoke test the HTTP service with `task kind:mcp:smoke`. See `docs/zed-mcp.md`.
 - `docs/zed-mcp.md` — Kubernetes-hosted MCP registration
 - `mcp_servers/scion_ops.py` — streamable HTTP MCP server
 - `orchestrator/` — consensus round launcher and agent utilities
+- `patches/scion/` — Scion runtime patches required by this deployment
 - `rubric/` — reviewer prompt and verdict schema
 - `scripts/build-images.sh` — image build helper
 - `scripts/kind-bootstrap.sh` — Hub credential, harness, and template restore
 - `scripts/kind-scion-runtime.sh` — kind substrate helper
 - `scripts/kind-dev-scion.sh` — fast Hub/Broker Scion binary update helper
+- `scripts/scion-runtime-patches.sh` — Scion runtime patch apply/check helper
 - `scripts/storage-status.sh` — Podman storage diagnostic helper
 - `scripts/kind-control-plane-smoke.py` — Kubernetes control-plane smoke
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -136,6 +136,21 @@ tasks:
     cmds:
       - bash scripts/kind-dev-scion.sh clear
 
+  scion:patch:status:
+    desc: Show whether the configured Scion source has required runtime patches.
+    cmds:
+      - bash scripts/scion-runtime-patches.sh status {{.CLI_ARGS}}
+
+  scion:patch:check:
+    desc: Verify that required Scion runtime patches are already applied.
+    cmds:
+      - bash scripts/scion-runtime-patches.sh check {{.CLI_ARGS}}
+
+  scion:patch:apply:
+    desc: Apply required Scion runtime patches to the configured Scion source.
+    cmds:
+      - bash scripts/scion-runtime-patches.sh apply {{.CLI_ARGS}}
+
   dev:mcp:restart:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-ops-mcp
@@ -306,4 +321,4 @@ tasks:
       - git diff --check
       - task --list
       - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py')]"
-      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-dev-scion.sh scripts/kind-round-preflight.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/abort.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-dev-scion.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/abort.sh

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -118,6 +118,20 @@ with:
 task dev:scion:clear
 ```
 
+Before building Scion binaries or images, scion-ops ensures the configured
+Scion checkout has the required runtime patch set from `patches/scion/`.
+The default source is `~/workspace/github/GoogleCloudPlatform/scion`; override
+it with `SCION_SRC` or `task build -- --src <path>`.
+
+```bash
+task scion:patch:status
+task scion:patch:apply
+task scion:patch:check
+```
+
+`task build` and `task dev:scion:deploy` run the same patch ensure step, so a
+clean checkout fails or converges before images or Hub dev binaries are built.
+
 MCP source changes are mounted from the workspace, so they usually need only:
 
 ```bash

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -11,8 +11,9 @@ task x
 ```
 
 `task x` expands to `task build`, `task up`, `task bootstrap`, and `task test`.
-The bootstrap step restores shared Hub credentials, harness configs, and
-templates before a round is started.
+The build step ensures the configured Scion checkout has the repo-owned runtime
+patches before building images. The bootstrap step restores shared Hub
+credentials, harness configs, and templates before a round is started.
 
 `task test` runs `scripts/kind-control-plane-smoke.py`. It verifies:
 
@@ -38,6 +39,7 @@ When changing one layer, run the closest check first:
 
 ```bash
 task kind:workspace:status
+task scion:patch:status
 task kind:control-plane:status
 task kind:mcp:smoke
 task kind:broker:status

--- a/patches/scion/noninteractive-auth-file-k8s.patch
+++ b/patches/scion/noninteractive-auth-file-k8s.patch
@@ -1,0 +1,231 @@
+diff --git a/cmd/sciontool/commands/init.go b/cmd/sciontool/commands/init.go
+index ebd8740e..9c11c60b 100644
+--- a/cmd/sciontool/commands/init.go
++++ b/cmd/sciontool/commands/init.go
+@@ -1076,14 +1076,16 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
+ 	}
+ 
+ 	// fetchBranch attempts a shallow fetch of a single branch from origin.
+-	// Returns sanitized stderr and whether the fetch succeeded.
++	// Use an explicit remote-tracking refspec so origin/<branch> exists for
++	// the checkout step, including branch names with slashes.
+ 	fetchBranch := func(branchToFetch string) (string, bool) {
+-		fetchCmd := exec.Command("git", "-C", workspacePath, "fetch", "--depth", depthStr, "origin", branchToFetch)
++		fetchCmd := exec.Command("git", "-C", workspacePath, "fetch", "--depth", depthStr, "origin", remoteBranchRefspec(branchToFetch))
+ 		setupGitCmd(fetchCmd)
+-		var stderr bytes.Buffer
+-		fetchCmd.Stderr = &stderr
++		var output bytes.Buffer
++		fetchCmd.Stdout = &output
++		fetchCmd.Stderr = &output
+ 		if err := fetchCmd.Run(); err != nil {
+-			return sanitizeGitOutput(stderr.String(), token), false
++			return strings.TrimSpace(sanitizeGitOutput(output.String(), token)), false
+ 		}
+ 		return "", true
+ 	}
+@@ -1205,7 +1207,7 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
+ 
+ 		// 2. Try fetching the branch from origin (shallow clone may not have it)
+ 		if !checked {
+-			fetchCmd := exec.Command("git", "-C", workspacePath, "fetch", "origin", branchName)
++			fetchCmd := exec.Command("git", "-C", workspacePath, "fetch", "origin", remoteBranchRefspec(branchName))
+ 			setupGitCmd(fetchCmd)
+ 			if err := fetchCmd.Run(); err == nil {
+ 				// Branch exists on remote — check it out tracking origin
+@@ -1286,6 +1288,10 @@ func isAuthError(sanitizedStderr string) bool {
+ // When no GITHUB_TOKEN is set, the message calls that out specifically.
+ // Also includes user-facing guidance from the error classification.
+ func formatCloneError(sanitizedStderr, token string) error {
++	sanitizedStderr = strings.TrimSpace(sanitizedStderr)
++	if sanitizedStderr == "" {
++		sanitizedStderr = "no git error output"
++	}
+ 	gitErr := util.ClassifyGitError(sanitizedStderr)
+ 	if token == "" {
+ 		return fmt.Errorf("git clone failed (no GITHUB_TOKEN secret configured — the repository may require authentication): %s", sanitizedStderr)
+@@ -1293,7 +1299,11 @@ func formatCloneError(sanitizedStderr, token string) error {
+ 	if guidance := gitErr.UserGuidance(); guidance != "" {
+ 		return fmt.Errorf("git clone failed (%s): %s", guidance, sanitizedStderr)
+ 	}
+-	return fmt.Errorf("git clone failed (GITHUB_TOKEN may be invalid or lack Contents read access): %s", sanitizedStderr)
++	return fmt.Errorf("git clone failed: %s", sanitizedStderr)
++}
++
++func remoteBranchRefspec(branch string) string {
++	return fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch)
+ }
+ 
+ // detectDefaultBranch uses `git ls-remote --symref origin HEAD` to discover
+diff --git a/cmd/sciontool/commands/init_test.go b/cmd/sciontool/commands/init_test.go
+index 95c3bf01..15a4ddc4 100644
+--- a/cmd/sciontool/commands/init_test.go
++++ b/cmd/sciontool/commands/init_test.go
+@@ -711,6 +711,28 @@ func TestGitCloneWorkspace_DefaultEnvValues(t *testing.T) {
+ 	}
+ }
+ 
++func TestRemoteBranchRefspecSupportsSlashBranches(t *testing.T) {
++	got := remoteBranchRefspec("scion/agent-branch")
++	want := "+refs/heads/scion/agent-branch:refs/remotes/origin/scion/agent-branch"
++	if got != want {
++		t.Fatalf("unexpected refspec: got %q, want %q", got, want)
++	}
++}
++
++func TestFormatCloneErrorUnknownDoesNotBlameToken(t *testing.T) {
++	err := formatCloneError("From https://github.com/example/repo\n * branch main -> FETCH_HEAD", "ghp_test")
++	if err == nil {
++		t.Fatal("expected error")
++	}
++	msg := err.Error()
++	if strings.Contains(msg, "GITHUB_TOKEN may be invalid") {
++		t.Fatalf("unknown git failure should not be reported as token failure: %s", msg)
++	}
++	if !strings.Contains(msg, "git clone failed:") {
++		t.Fatalf("expected generic clone failure, got: %s", msg)
++	}
++}
++
+ func TestGitCloneWorkspace_NonZeroUIDChownsWorkspace(t *testing.T) {
+ 	// Verify that gitCloneWorkspace chowns /workspace before cloning when
+ 	// a non-zero uid is provided. We use a temp dir as the workspace and
+diff --git a/pkg/harness/gemini_cli.go b/pkg/harness/gemini_cli.go
+index 8423a86b..212c04a7 100644
+--- a/pkg/harness/gemini_cli.go
++++ b/pkg/harness/gemini_cli.go
+@@ -80,7 +80,7 @@ func (g *GeminiCLI) GetCommand(task string, resume bool, baseArgs []string) []st
+ 	}
+ 	args = append(args, baseArgs...)
+ 	if task != "" {
+-		args = append(args, "--prompt-interactive", task)
++		args = append(args, "--prompt", task)
+ 	}
+ 	return args
+ }
+diff --git a/pkg/harness/gemini_cli_test.go b/pkg/harness/gemini_cli_test.go
+index 755ff3f5..e1bb50a4 100644
+--- a/pkg/harness/gemini_cli_test.go
++++ b/pkg/harness/gemini_cli_test.go
+@@ -113,6 +113,22 @@ func TestGeminiInjectAgentInstructions_RemovesLowercaseFile(t *testing.T) {
+ 	}
+ }
+ 
++func TestGeminiGetCommand(t *testing.T) {
++	g := &GeminiCLI{}
++
++	cmd := g.GetCommand("do something", false, []string{"--model", "gemini-2.5-flash"})
++	want := []string{"gemini", "--yolo", "--model", "gemini-2.5-flash", "--prompt", "do something"}
++	if strings.Join(cmd, "\x00") != strings.Join(want, "\x00") {
++		t.Fatalf("unexpected command: got %v, want %v", cmd, want)
++	}
++
++	cmd = g.GetCommand("", true, nil)
++	want = []string{"gemini", "--yolo", "--resume"}
++	if strings.Join(cmd, "\x00") != strings.Join(want, "\x00") {
++		t.Fatalf("unexpected resume command: got %v, want %v", cmd, want)
++	}
++}
++
+ func TestGeminiResolveAuth_ExplicitAPIKey(t *testing.T) {
+ 	g := &GeminiCLI{}
+ 	auth := api.AuthConfig{
+diff --git a/pkg/runtime/common_test.go b/pkg/runtime/common_test.go
+index 79935ae9..bc6eac80 100644
+--- a/pkg/runtime/common_test.go
++++ b/pkg/runtime/common_test.go
+@@ -89,7 +89,7 @@ func TestBuildCommonRunArgs(t *testing.T) {
+ 				Image: "scion-agent:latest",
+ 			},
+ 			wantIn:  []string{"-e", "GEMINI_API_KEY=sk-123", "-e", "GEMINI_DEFAULT_AUTH_TYPE=gemini-api-key"},
+-			wantOut: []string{"--prompt-interactive"},
++			wantOut: []string{"--prompt"},
+ 		},
+ 		{
+ 			name: "labels",
+@@ -183,7 +183,7 @@ func TestBuildCommonRunArgs(t *testing.T) {
+ 			},
+ 			wantIn: []string{
+ 				"-e FOO=BAR",
+-				"tmux new-session -d -s scion -n agent gemini --yolo --resume --prompt-interactive hello",
++				"tmux new-session -d -s scion -n agent gemini --yolo --resume --prompt hello",
+ 			},
+ 		},
+ 		{
+@@ -196,7 +196,7 @@ func TestBuildCommonRunArgs(t *testing.T) {
+ 				Resume:  true,
+ 			},
+ 			wantIn: []string{
+-				"tmux new-session -d -s scion -n agent gemini --yolo --resume --prompt-interactive hello",
++				"tmux new-session -d -s scion -n agent gemini --yolo --resume --prompt hello",
+ 			},
+ 		},
+ 		{
+@@ -323,7 +323,7 @@ func TestBuildCommonRunArgs(t *testing.T) {
+ 				Task:         "",
+ 			},
+ 			wantIn:  []string{"gemini", "--yolo"},
+-			wantOut: []string{"--prompt-interactive"},
++			wantOut: []string{"--prompt"},
+ 		},
+ 		{
+ 			name: "workspace from volumes",
+diff --git a/pkg/runtime/k8s_runtime.go b/pkg/runtime/k8s_runtime.go
+index a939b0b8..afc67402 100644
+--- a/pkg/runtime/k8s_runtime.go
++++ b/pkg/runtime/k8s_runtime.go
+@@ -380,7 +380,11 @@ func (r *KubernetesRuntime) createAgentSecret(ctx context.Context, namespace, ag
+ 		case "environment":
+ 			data[s.Name] = []byte(s.Value)
+ 		case "file":
+-			data[s.Name] = []byte(s.Value)
++			decoded, err := base64.StdEncoding.DecodeString(s.Value)
++			if err != nil {
++				decoded = []byte(s.Value)
++			}
++			data[s.Name] = decoded
+ 		case "variable":
+ 			varSecrets[s.Target] = s.Value
+ 		}
+@@ -1364,7 +1368,7 @@ func (r *KubernetesRuntime) syncToPod(ctx context.Context, namespace, podName, s
+ 
+ 	// Use sh -c to allow us to ignore certain exit codes if needed, or just to be more flexible.
+ 	// We use -m to avoid utime errors on the mount point.
+-	remoteCmd := fmt.Sprintf("tar -xz -m --no-same-owner --no-same-permissions -C '%s'", destPath)
++	remoteCmd := fmt.Sprintf("tar -xz -m --skip-old-files --no-same-owner --no-same-permissions -C '%s'", destPath)
+ 	cmd := []string{"sh", "-c", remoteCmd}
+ 
+ 	req := r.Client.Clientset.CoreV1().RESTClient().Post().
+diff --git a/pkg/runtime/k8s_secrets_test.go b/pkg/runtime/k8s_secrets_test.go
+index 6c139ebd..6494207e 100644
+--- a/pkg/runtime/k8s_secrets_test.go
++++ b/pkg/runtime/k8s_secrets_test.go
+@@ -403,6 +403,28 @@ func TestCreateAgentSecret(t *testing.T) {
+ 	}
+ }
+ 
++func TestCreateAgentSecret_DecodesBase64FileSecret(t *testing.T) {
++	rt, clientset, _ := newTestK8sRuntime()
++	ctx := context.Background()
++
++	secrets := []api.ResolvedSecret{
++		{Name: "CLAUDE_CONFIG", Type: "file", Target: "/home/scion/.claude.json", Value: "eyJrZXkiOiJ2YWwifQ==", Source: "hub"},
++	}
++
++	name, err := rt.createAgentSecret(ctx, "default", "test-agent", secrets, nil)
++	if err != nil {
++		t.Fatalf("createAgentSecret failed: %v", err)
++	}
++
++	secret, err := clientset.CoreV1().Secrets("default").Get(ctx, name, metav1.GetOptions{})
++	if err != nil {
++		t.Fatalf("failed to get created secret: %v", err)
++	}
++	if string(secret.Data["CLAUDE_CONFIG"]) != `{"key":"val"}` {
++		t.Errorf("expected decoded CLAUDE_CONFIG, got %s", string(secret.Data["CLAUDE_CONFIG"]))
++	}
++}
++
+ func TestCreateAgentSecret_NoSecrets(t *testing.T) {
+ 	rt, _, _ := newTestK8sRuntime()
+ 	ctx := context.Background()

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -89,6 +89,8 @@ done
 [[ -d "$SCION_SRC/image-build" ]] || { red "scion source not found at $SCION_SRC"; exit 1; }
 command -v podman >/dev/null || { red "podman not on PATH"; exit 1; }
 
+"$REPO_ROOT/scripts/scion-runtime-patches.sh" ensure --src "$SCION_SRC"
+
 IMG_BUILD="$SCION_SRC/image-build"
 
 storage_preflight() {

--- a/scripts/kind-dev-scion.sh
+++ b/scripts/kind-dev-scion.sh
@@ -56,6 +56,8 @@ cmd_build() {
   [[ -d "$SCION_SRC" ]] || die "SCION_SRC does not exist: $SCION_SRC"
   [[ -f "$SCION_SRC/go.mod" ]] || die "SCION_SRC is not a Go module: $SCION_SRC"
 
+  "$REPO_ROOT/scripts/scion-runtime-patches.sh" ensure --src "$SCION_SRC"
+
   log "build Scion binaries from $SCION_SRC"
   mkdir -p "$BIN_DIR"
   (

--- a/scripts/scion-runtime-patches.sh
+++ b/scripts/scion-runtime-patches.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Apply or verify the Scion runtime patches required by scion-ops.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCION_SRC="${SCION_SRC:-${HOME}/workspace/github/GoogleCloudPlatform/scion}"
+PATCH_DIR="${SCION_OPS_SCION_PATCH_DIR:-$REPO_ROOT/patches/scion}"
+COMMAND="${1:-status}"
+
+if [[ "$COMMAND" == "-h" || "$COMMAND" == "--help" ]]; then
+  COMMAND="help"
+else
+  shift || true
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src)
+      SCION_SRC="$2"
+      shift 2
+      ;;
+    --patch-dir)
+      PATCH_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      COMMAND="help"
+      shift
+      ;;
+    *)
+      printf 'unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <status|check|apply|ensure> [--src PATH] [--patch-dir PATH]
+
+Commands:
+  status   Print whether each scion-ops patch is applied, pending, or blocked.
+  check    Exit successfully only when every patch is already applied.
+  apply    Apply pending patches and leave already-applied patches unchanged.
+  ensure   Alias for apply; used by build entry points.
+
+Environment:
+  SCION_SRC                 Scion source checkout
+                            (default: ${SCION_SRC})
+  SCION_OPS_SCION_PATCH_DIR Patch directory
+                            (default: ${PATCH_DIR})
+EOF
+}
+
+log() {
+  printf '\033[36m==> %s\033[0m\n' "$*"
+}
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+require_source() {
+  command -v git >/dev/null 2>&1 || die "git is required on PATH"
+  [[ -d "$SCION_SRC/.git" ]] || die "SCION_SRC is not a git checkout: $SCION_SRC"
+  [[ -f "$SCION_SRC/go.mod" ]] || die "SCION_SRC is not the Scion Go module: $SCION_SRC"
+}
+
+load_patches() {
+  shopt -s nullglob
+  PATCHES=("$PATCH_DIR"/*.patch)
+  shopt -u nullglob
+  [[ "${#PATCHES[@]}" -gt 0 ]] || die "no Scion patches found in $PATCH_DIR"
+}
+
+patch_state() {
+  local patch="$1"
+  if git -C "$SCION_SRC" apply --reverse --check "$patch" >/dev/null 2>&1; then
+    printf 'applied'
+    return 0
+  fi
+  if git -C "$SCION_SRC" apply --check "$patch" >/dev/null 2>&1; then
+    printf 'pending'
+    return 0
+  fi
+  printf 'blocked'
+  return 1
+}
+
+run_status() {
+  local patch state failed=0
+  for patch in "${PATCHES[@]}"; do
+    state="$(patch_state "$patch")" || failed=1
+    printf '%-8s %s\n' "$state" "$(basename "$patch")"
+  done
+  return "$failed"
+}
+
+run_check() {
+  local patch state failed=0
+  for patch in "${PATCHES[@]}"; do
+    state="$(patch_state "$patch")" || state="blocked"
+    case "$state" in
+      applied)
+        printf 'applied %s\n' "$(basename "$patch")"
+        ;;
+      pending)
+        printf 'pending %s; run task scion:patch:apply or let task build apply it\n' "$(basename "$patch")" >&2
+        failed=1
+        ;;
+      *)
+        printf 'blocked %s; patch does not apply cleanly to %s\n' "$(basename "$patch")" "$SCION_SRC" >&2
+        git -C "$SCION_SRC" apply --check "$patch" >&2 || true
+        failed=1
+        ;;
+    esac
+  done
+  return "$failed"
+}
+
+run_apply() {
+  local patch state
+  for patch in "${PATCHES[@]}"; do
+    state="$(patch_state "$patch")" || state="blocked"
+    case "$state" in
+      applied)
+        printf 'already applied %s\n' "$(basename "$patch")"
+        ;;
+      pending)
+        log "apply $(basename "$patch")"
+        git -C "$SCION_SRC" apply "$patch"
+        ;;
+      *)
+        printf 'blocked %s; patch does not apply cleanly to %s\n' "$(basename "$patch")" "$SCION_SRC" >&2
+        git -C "$SCION_SRC" apply --check "$patch" >&2 || true
+        exit 1
+        ;;
+    esac
+  done
+}
+
+case "$COMMAND" in
+  help)
+    usage
+    exit 0
+    ;;
+  status|check|apply|ensure)
+    require_source
+    load_patches
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+case "$COMMAND" in
+  status) run_status ;;
+  check) run_check ;;
+  apply|ensure) run_apply ;;
+esac


### PR DESCRIPTION
## Summary
- add a repo-owned Scion runtime patch under patches/scion for the Kubernetes auth-file round fixes
- add task-visible patch status/check/apply commands and a shared patch helper
- run the patch ensure step before image builds and Hub dev binary builds
- document the patch path and known issue/exit criteria

## Verification
- task verify
- task scion:patch:status
- temporary clean Scion source from the parent commit: task scion:patch:status -> pending, task scion:patch:apply, task scion:patch:check -> applied
- patched temporary source: go test ./pkg/runtime ./pkg/harness passed
- patched temporary source: go test ./cmd/sciontool/commands -run 'TestRemoteBranchRefspecSupportsSlashBranches|TestFormatCloneErrorUnknownDoesNotBlameToken' passed

Note: full cmd/sciontool/commands package test in the temporary source hit an unrelated sandbox UID mapping expectation, so the two patch-added command tests were run directly.

Closes #67