### PR TITLE
Preserve Task CLI argument quoting

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -87,7 +87,9 @@ tasks:
   round:
     desc: Start a Scion consensus round after Kubernetes Hub credential bootstrap.
     cmds:
-      - bash orchestrator/run-round.sh "{{.CLI_ARGS}}"
+      - |
+        set -- {{.CLI_ARGS}}
+        bash orchestrator/run-round.sh "$@"
 
   down:
     desc: Destroy the kind Kubernetes deployment.
@@ -285,15 +287,21 @@ tasks:
 
   watch:
     cmds:
-      - bash orchestrator/watch.sh "{{.CLI_ARGS}}"
+      - |
+        set -- {{.CLI_ARGS}}
+        bash orchestrator/watch.sh "$@"
 
   abort:
     cmds:
-      - bash orchestrator/abort.sh "{{.CLI_ARGS}}"
+      - |
+        set -- {{.CLI_ARGS}}
+        bash orchestrator/abort.sh "$@"
 
   look:
     cmds:
-      - '{{.SCION_BIN}} look "{{.CLI_ARGS}}"'
+      - |
+        set -- {{.CLI_ARGS}}
+        '{{.SCION_BIN}}' look "$@"
 
   tail:
     cmds:


### PR DESCRIPTION
Closes #77.

## Summary
- forward Task CLI args through set -- before invoking shell scripts
- fix task round so prompts containing backticks stay literal
- apply the same forwarding pattern to watch, abort, and look helpers

## Verification
- task --dry round -- 'prompt `printf TASK_ROUND_EXPANDED >&2` /home/david'
- task verify