### PR TITLE
Add uv to Kubernetes agent runtime image

### DIFF
--- a/image-build/task-runtime/Dockerfile
+++ b/image-build/task-runtime/Dockerfile
@@ -3,6 +3,12 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG TASK_VERSION=v3.44.0
+ARG UV_VERSION=0.9.16
 
 USER root
-RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION}
+RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION} \
+  && python3 -m venv /opt/scion-ops-uv \
+  && /opt/scion-ops-uv/bin/pip install --no-cache-dir "uv==${UV_VERSION}" \
+  && ln -sf /opt/scion-ops-uv/bin/uv /usr/local/bin/uv \
+  && task --version \
+  && uv --version


### PR DESCRIPTION
Closes #79.

## Summary

- install pinned `uv` into the local `scion-base` task-runtime overlay
- expose `uv` on `/usr/local/bin` so inherited Claude, Codex, Gemini, and MCP images can run repo task verification
- keep the fix in the existing image layer that already provides `task`

## Verification

- `task build:base`
- `task build -- --skip-core --skip-base`
- `podman run --rm --entrypoint uv localhost/scion-base:latest --version`
- `podman run --rm --entrypoint uv localhost/scion-codex:latest --version`
- `podman run --rm --entrypoint uv localhost/scion-claude:latest --version`
- `podman run --rm --entrypoint uv localhost/scion-gemini:latest --version`
- `task up`
- `kubectl --context kind-scion-ops -n scion-agents run scion-uv-smoke --rm -i --restart=Never --image=localhost/scion-codex:latest --image-pull-policy=IfNotPresent --command -- uv --version`
- `task test`
- `task verify`
