### PR TITLE
Add Kubernetes CLIs to agent runtime image

### DIFF
--- a/image-build/task-runtime/Dockerfile
+++ b/image-build/task-runtime/Dockerfile
@@ -4,11 +4,24 @@ FROM ${BASE_IMAGE}
 
 ARG TASK_VERSION=v3.44.0
 ARG UV_VERSION=0.9.16
+ARG KIND_VERSION=v0.30.0
+ARG KUBECTL_VERSION=v1.33.1
 
 USER root
-RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION} \
-  && python3 -m venv /opt/scion-ops-uv \
-  && /opt/scion-ops-uv/bin/pip install --no-cache-dir "uv==${UV_VERSION}" \
-  && ln -sf /opt/scion-ops-uv/bin/uv /usr/local/bin/uv \
-  && task --version \
-  && uv --version
+RUN set -eux; \
+  arch="$(dpkg --print-architecture)"; \
+  case "${arch}" in \
+    amd64|arm64) tool_arch="${arch}" ;; \
+    *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+  esac; \
+  GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@${TASK_VERSION}; \
+  curl -fsSL -o /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${tool_arch}"; \
+  curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${tool_arch}/kubectl"; \
+  chmod 0755 /usr/local/bin/kind /usr/local/bin/kubectl; \
+  python3 -m venv /opt/scion-ops-uv; \
+  /opt/scion-ops-uv/bin/pip install --no-cache-dir "uv==${UV_VERSION}"; \
+  ln -sf /opt/scion-ops-uv/bin/uv /usr/local/bin/uv; \
+  task --version; \
+  uv --version; \
+  kind --version; \
+  kubectl version --client=true


### PR DESCRIPTION
Closes #81.

## Summary

- add pinned `kind` and `kubectl` binaries to the shared task runtime image layer
- verify `task`, `uv`, `kind`, and `kubectl` during the image build
- keep provider images inheriting the same runtime tooling contract

## Verification

- `task build:base`
- `task build -- --skip-core --skip-base`
- `podman run --rm --entrypoint sh localhost/scion-base:latest -lc "task --version; uv --version; kind --version; kubectl version --client=true"`
- `podman run --rm --entrypoint sh localhost/scion-codex:latest -lc "kind --version; kubectl version --client=true; uv --version"`
- `podman run --rm --entrypoint sh localhost/scion-claude:latest -lc "kind --version; kubectl version --client=true; uv --version"`
- `podman run --rm --entrypoint sh localhost/scion-gemini:latest -lc "kind --version; kubectl version --client=true; uv --version"`
- `task up`
- `kubectl --context kind-scion-ops -n scion-agents run scion-kind-smoke --rm -i --restart=Never --image=localhost/scion-codex:latest --image-pull-policy=IfNotPresent --command -- sh -lc "command -v kind; kind version; kind --version; command -v kubectl"`
- `task test`
- `task verify`