### PR TITLE
Add OpenSpec change artifact validation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -91,6 +91,11 @@ tasks:
         set -- {{.CLI_ARGS}}
         bash orchestrator/run-round.sh "$@"
 
+  spec:validate:
+    desc: Validate an OpenSpec change artifact set in a target project.
+    cmds:
+      - python3 scripts/validate-openspec-change.py {{.CLI_ARGS}}
+
   down:
     desc: Destroy the kind Kubernetes deployment.
     prompt: This deletes the {{.KIND_CLUSTER_NAME}} kind cluster and all cluster-local Scion state. Continue?
@@ -311,5 +316,6 @@ tasks:
     cmds:
       - git diff --check
       - task --list
-      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py')]"
+      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/test-openspec-change-validator.py')]"
+      - python3 scripts/test-openspec-change-validator.py
       - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/abort.sh

--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -114,6 +114,7 @@ Hub:
 | Tool | Responsibility |
 |---|---|
 | `scion_ops_project_status` | Confirm target project root, branch, origin, Hub link, and git status. |
+| `scion_ops_validate_spec_change` | Validate an OpenSpec change folder before implementation starts. |
 | `scion_ops_start_spec_round` | Start a planning round from `project_root`, `goal`, and optional `change`. |
 | `scion_ops_start_implementation_round` | Start a delivery round from `project_root` and approved `change`. |
 | `scion_ops_round_status` | Read current Hub state for a round. |
@@ -123,6 +124,22 @@ Hub:
 `scion_ops_start_round` remains useful for direct implementation prompts, but
 the spec-driven path should prefer the explicit spec and implementation round
 tools so the artifact contract is visible in the request.
+
+## Validation
+
+Use the validator before an implementation round starts:
+
+```bash
+task spec:validate -- --project-root /path/to/project --change <change>
+```
+
+The validator checks that `openspec/changes/<change>/` exists, that
+`proposal.md`, `design.md`, and `tasks.md` are present and non-empty, that
+`tasks.md` includes checkbox tasks, and that at least one
+`specs/**/spec.md` delta spec contains requirements and scenarios.
+
+MCP clients use the same validation path through
+`scion_ops_validate_spec_change(project_root, change)`.
 
 ## PR Flow
 

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -925,6 +925,16 @@ def _github_https_remote(remote_url: str) -> str:
     return ""
 
 
+def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
+    if not result.get("output"):
+        return {}
+    try:
+        payload = json.loads(result["output"])
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 @mcp.tool()
 def scion_ops_hub_status(project_root: str = "") -> dict[str, Any]:
     """Show Scion Hub API health, grove, broker providers, and agents."""
@@ -1332,6 +1342,37 @@ def scion_ops_project_status(project_root: str) -> dict[str, Any]:
             "bootstrap": "Run `task bootstrap -- <project_root>` from the scion-ops repo if grove_id is empty or preflight fails.",
             "start_round_tool": "scion_ops_start_round",
         },
+    }
+
+
+@mcp.tool()
+def scion_ops_validate_spec_change(project_root: str, change: str) -> dict[str, Any]:
+    """Validate an OpenSpec change artifact set in a target project."""
+    root = _project_root(project_root)
+    change = _clean_name(change, "change")
+    result = _run(
+        [
+            "python3",
+            str(_repo_root() / "scripts" / "validate-openspec-change.py"),
+            "--project-root",
+            str(root),
+            "--change",
+            change,
+            "--json",
+        ],
+        timeout=20,
+        cwd=_repo_root(),
+    )
+    payload = _parse_json_result(result)
+    command_result = _command_result(result)
+    if payload and not payload.get("ok"):
+        command_result["error_kind"] = "openspec_validation"
+    return {
+        **command_result,
+        "source": "openspec_validator",
+        "project_root": str(root),
+        "change": change,
+        "validation": payload,
     }
 
 

--- a/scripts/smoke-mcp-server.py
+++ b/scripts/smoke-mcp-server.py
@@ -27,6 +27,7 @@ REQUIRED_TOOLS = {
     "scion_ops_round_events",
     "scion_ops_watch_round_events",
     "scion_ops_start_round",
+    "scion_ops_validate_spec_change",
     "scion_ops_look",
 }
 

--- a/scripts/test-openspec-change-validator.py
+++ b/scripts/test-openspec-change-validator.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Focused checks for the OpenSpec change validator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate-openspec-change.py"
+
+
+def _run(project_root: Path, change: str) -> tuple[int, dict[str, object]]:
+    result = subprocess.run(
+        [
+            "python3",
+            str(VALIDATOR),
+            "--project-root",
+            str(project_root),
+            "--change",
+            change,
+            "--json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return result.returncode, json.loads(result.stdout)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _valid_tree(root: Path) -> None:
+    change = root / "openspec" / "changes" / "add-widget"
+    _write(
+        change / "proposal.md",
+        "# Proposal: Add Widget\n\n## Scope\n\nIn scope: add a widget.\n",
+    )
+    _write(
+        change / "design.md",
+        "# Design: Add Widget\n\nUse the existing UI path.\n",
+    )
+    _write(
+        change / "tasks.md",
+        "# Tasks\n\n- [ ] 1.1 Add widget behavior\n",
+    )
+    _write(
+        change / "specs" / "widgets" / "spec.md",
+        "# Delta for Widgets\n\n"
+        "## ADDED Requirements\n\n"
+        "### Requirement: Widget Creation\n"
+        "The system SHALL create a widget.\n\n"
+        "#### Scenario: Create widget\n"
+        "- GIVEN a valid request\n"
+        "- WHEN the widget is created\n"
+        "- THEN the widget is visible\n",
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _valid_tree(root)
+
+        code, payload = _run(root, "add-widget")
+        assert code == 0, payload
+        assert payload["ok"] is True, payload
+        assert payload["spec_files"] == ["openspec/changes/add-widget/specs/widgets/spec.md"], payload
+
+        (root / "openspec" / "changes" / "add-widget" / "design.md").unlink()
+        code, payload = _run(root, "add-widget")
+        assert code == 1, payload
+        assert payload["ok"] is False, payload
+        assert any("design.md" in item["path"] for item in payload["errors"]), payload
+
+        code, payload = _run(root, "missing-widget")
+        assert code == 1, payload
+        assert payload["ok"] is False, payload
+        assert any("artifact directory" in item["message"] for item in payload["errors"]), payload
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-openspec-change.py
+++ b/scripts/validate-openspec-change.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Validate a repo-local OpenSpec change artifact set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CHANGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+REQUIRED_FILES = ("proposal.md", "design.md", "tasks.md")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"path": self.path, "message": self.message}
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _has_heading(text: str) -> bool:
+    return any(line.startswith("# ") for line in text.splitlines())
+
+
+def _validate_required_file(path: Path, root: Path, findings: list[Finding]) -> None:
+    rel = _relative(path, root)
+    if not path.exists():
+        findings.append(Finding(rel, "required file is missing"))
+        return
+    if not path.is_file():
+        findings.append(Finding(rel, "required path is not a file"))
+        return
+    text = _read(path).strip()
+    if not text:
+        findings.append(Finding(rel, "required file is empty"))
+        return
+    if not _has_heading(text):
+        findings.append(Finding(rel, "required file must include a top-level heading"))
+
+
+def _validate_tasks(path: Path, root: Path, findings: list[Finding]) -> None:
+    if not path.exists() or not path.is_file():
+        return
+    text = _read(path)
+    if not re.search(r"(?m)^-\s+\[[ xX]\]\s+", text):
+        findings.append(Finding(_relative(path, root), "tasks.md must include checkbox tasks"))
+
+
+def _validate_spec_file(path: Path, root: Path, findings: list[Finding]) -> None:
+    text = _read(path)
+    rel = _relative(path, root)
+    if not text.strip():
+        findings.append(Finding(rel, "spec file is empty"))
+        return
+    if "### Requirement:" not in text:
+        findings.append(Finding(rel, "spec file must include at least one requirement"))
+    if "#### Scenario:" not in text:
+        findings.append(Finding(rel, "spec file must include at least one scenario"))
+    if not re.search(r"(?m)^## (ADDED|MODIFIED|REMOVED) Requirements\b", text):
+        findings.append(
+            Finding(rel, "delta spec should include ADDED, MODIFIED, or REMOVED Requirements section")
+        )
+
+
+def validate_openspec_change(project_root: Path, change: str) -> dict[str, Any]:
+    root = project_root.expanduser().resolve()
+    errors: list[Finding] = []
+    warnings: list[Finding] = []
+
+    if not root.exists():
+        errors.append(Finding(str(root), "project root does not exist"))
+        return _payload(root, change, errors, warnings, [], root / "openspec" / "changes" / change)
+    if not root.is_dir():
+        errors.append(Finding(str(root), "project root is not a directory"))
+        return _payload(root, change, errors, warnings, [], root / "openspec" / "changes" / change)
+    if not CHANGE_RE.match(change):
+        errors.append(Finding(change, "change name must use letters, numbers, dots, dashes, or underscores"))
+        return _payload(root, change, errors, warnings, [], root / "openspec" / "changes" / change)
+
+    change_path = root / "openspec" / "changes" / change
+    if not change_path.exists():
+        errors.append(Finding(_relative(change_path, root), "change artifact directory is missing"))
+        return _payload(root, change, errors, warnings, [], change_path)
+    if not change_path.is_dir():
+        errors.append(Finding(_relative(change_path, root), "change artifact path is not a directory"))
+        return _payload(root, change, errors, warnings, [], change_path)
+
+    for filename in REQUIRED_FILES:
+        _validate_required_file(change_path / filename, root, errors)
+    _validate_tasks(change_path / "tasks.md", root, errors)
+
+    specs_dir = change_path / "specs"
+    spec_files: list[Path] = []
+    if not specs_dir.exists():
+        errors.append(Finding(_relative(specs_dir, root), "specs directory is missing"))
+    elif not specs_dir.is_dir():
+        errors.append(Finding(_relative(specs_dir, root), "specs path is not a directory"))
+    else:
+        spec_files = sorted(path for path in specs_dir.glob("**/spec.md") if path.is_file())
+        if not spec_files:
+            errors.append(Finding(_relative(specs_dir, root), "no delta spec files found under specs/**/spec.md"))
+        for path in spec_files:
+            _validate_spec_file(path, root, errors)
+
+    return _payload(root, change, errors, warnings, spec_files, change_path)
+
+
+def _payload(
+    root: Path,
+    change: str,
+    errors: list[Finding],
+    warnings: list[Finding],
+    spec_files: list[Path],
+    change_path: Path,
+) -> dict[str, Any]:
+    required = {
+        filename: str((change_path / filename).relative_to(root))
+        if str(change_path).startswith(str(root))
+        else str(change_path / filename)
+        for filename in REQUIRED_FILES
+    }
+    return {
+        "ok": not errors,
+        "project_root": str(root),
+        "change": change,
+        "change_path": _relative(change_path, root),
+        "required_files": required,
+        "spec_files": [_relative(path, root) for path in spec_files],
+        "errors": [finding.as_dict() for finding in errors],
+        "warnings": [finding.as_dict() for finding in warnings],
+    }
+
+
+def _print_human(payload: dict[str, Any]) -> None:
+    status = "ok" if payload["ok"] else "invalid"
+    print(f"OpenSpec change {payload['change']}: {status}")
+    print(f"project_root: {payload['project_root']}")
+    print(f"change_path: {payload['change_path']}")
+    if payload["spec_files"]:
+        print("spec_files:")
+        for path in payload["spec_files"]:
+            print(f"  - {path}")
+    if payload["errors"]:
+        print("errors:")
+        for item in payload["errors"]:
+            print(f"  - {item['path']}: {item['message']}")
+    if payload["warnings"]:
+        print("warnings:")
+        for item in payload["warnings"]:
+            print(f"  - {item['path']}: {item['message']}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("positional_change", nargs="?", help="OpenSpec change name")
+    parser.add_argument("--project-root", default=".", help="target project root")
+    parser.add_argument("--change", default="", help="OpenSpec change name")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    change = (args.change or args.positional_change or "").strip()
+    if not change:
+        print("change is required", file=sys.stderr)
+        return 2
+    payload = validate_openspec_change(Path(args.project_root), change)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(payload)
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #45.

## Summary
- add `task spec:validate` backed by `scripts/validate-openspec-change.py`
- add `scion_ops_validate_spec_change` so MCP clients can validate target project artifact sets
- add validator checks for required proposal/design/tasks/spec files and basic structure
- document validation in the OpenSpec round workflow design

## Verification
- `task verify`
- `task dev:mcp:restart`
- `task kind:mcp:smoke`
- `task spec:validate -- --project-root /home/david/workspace/github/livewyer-ops/scion-ops --change missing-change --json` reports the missing artifact directory clearly
- MCP `scion_ops_validate_spec_change` against `/workspace/github/livewyer-ops/scion-ops` reports `error_kind=openspec_validation` for the same missing change