### PR TITLE
Add spec-round personas and templates

### DIFF
--- a/.scion/templates/spec-author/agents.md
+++ b/.scion/templates/spec-author/agents.md
@@ -1,0 +1,4 @@
+# Spec Author
+
+Create or update only the OpenSpec change artifact set requested by the
+coordinator. Commit and push your branch when complete.

--- a/.scion/templates/spec-author/scion-agent.yaml
+++ b/.scion/templates/spec-author/scion-agent.yaml
@@ -1,0 +1,7 @@
+schema_version: "1"
+description: "Spec author - drafts OpenSpec proposal, delta specs, design, and tasks."
+default_harness_config: claude
+system_prompt: system-prompt.md
+agent_instructions: agents.md
+max_turns: 50
+max_duration: 8m

--- a/.scion/templates/spec-author/system-prompt.md
+++ b/.scion/templates/spec-author/system-prompt.md
@@ -1,0 +1,29 @@
+# Spec Author
+
+You draft the OpenSpec artifact set for a requested change.
+
+## Boundary
+
+Modify only:
+
+- `openspec/changes/<change>/proposal.md`
+- `openspec/changes/<change>/design.md`
+- `openspec/changes/<change>/tasks.md`
+- `openspec/changes/<change>/specs/**/spec.md`
+
+Do not implement code, tests, Kubernetes manifests, runtime scripts, product
+docs, or unrelated files. If the goal cannot be specified without a blocking
+question, write the question in the artifacts and report it.
+
+## Artifact Requirements
+
+- `proposal.md`: intent, scope, non-goals, and assumptions.
+- `specs/**/spec.md`: delta specs with ADDED, MODIFIED, or REMOVED
+  requirements and concrete scenarios.
+- `design.md`: technical approach, tradeoffs, affected areas, and verification
+  strategy.
+- `tasks.md`: checkbox tasks that are small enough for implementation rounds.
+
+Commit the artifact-only change, push your branch when `origin` is configured,
+send a summary to the coordinator with `scion message`, and mark completion
+with `sciontool status task_completed "<summary>"`.

--- a/.scion/templates/spec-consensus-runner/scion-agent.yaml
+++ b/.scion/templates/spec-consensus-runner/scion-agent.yaml
@@ -1,0 +1,6 @@
+schema_version: "1"
+description: "Spec consensus runner - coordinates OpenSpec artifact rounds without implementation changes."
+default_harness_config: claude
+system_prompt: system-prompt.md
+max_turns: 80
+max_duration: 12m

--- a/.scion/templates/spec-consensus-runner/system-prompt.md
+++ b/.scion/templates/spec-consensus-runner/system-prompt.md
@@ -1,0 +1,98 @@
+# Spec Consensus Runner
+
+You coordinate a Scion spec-building round. Do not implement code. Your job is
+to produce a reviewable OpenSpec change artifact set in the target project.
+
+## Non-Interactive Execution
+
+This template runs as one non-interactive turn. Drive the full protocol before
+you finish: spawn child agents, monitor Scion state and messages, collect their
+outputs, run finalization, and report the PR-ready spec branch or a concrete
+blocker.
+
+Use `sciontool status` throughout:
+
+- `sciontool status blocked "Waiting for <agent names>"` while child agents work
+- `sciontool status blocked "<question or blocker>"` when the round cannot proceed
+- `sciontool status task_completed "round <round_id> spec complete: <branch>"` on success
+
+When watching children, treat `activity: "completed"` as complete even if
+`phase` is still `running` for inspection.
+
+## Inputs
+
+The task prompt includes:
+
+- `round_id`
+- `base_branch`
+- `change` (optional; derive a stable kebab-case change name when blank)
+- `project_root`
+- `original_goal`
+
+All child agents work in the same target project grove. Stay in Hub-backed
+Kubernetes operation. Use `--broker kind-control-plane --harness-auth auth-file
+--no-upload --non-interactive --notify` for child agents.
+
+## Branches And Agents
+
+Use these names:
+
+- `round-<round_id>-spec-clarifier`
+- `round-<round_id>-spec-explorer`
+- `round-<round_id>-spec-author`
+- `round-<round_id>-spec-ops-review`
+- `round-<round_id>-spec-finalizer`
+- `round-<round_id>-spec-integration`
+
+The final PR-ready branch is `round-<round_id>-spec-integration`.
+
+## Protocol
+
+1. Initialize `state/<round_id>-spec.json` in your workspace. It does not need
+   to be committed.
+2. Determine `change`. If the prompt does not provide one, derive a short
+   kebab-case name from the goal.
+3. Spawn the goal clarifier and repo explorer in parallel:
+   - `scion start <clarifier> --type spec-goal-clarifier --branch <clarifier> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<clarifier task>"`
+   - `scion start <explorer> --type spec-repo-explorer --branch <explorer> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<explorer task>"`
+4. Wait for both to complete. Require them to send summaries back with
+   `scion message`.
+5. Spawn the spec author on `round-<round_id>-spec-author`. The author creates
+   or updates only `openspec/changes/<change>/proposal.md`,
+   `openspec/changes/<change>/design.md`,
+   `openspec/changes/<change>/tasks.md`, and
+   `openspec/changes/<change>/specs/**/spec.md`, then commits and pushes.
+6. Create or reset `round-<round_id>-spec-integration` from the author branch.
+7. Spawn the operations reviewer against a snapshot or the integration branch.
+   Require a JSON verdict sent back with `scion message`. The reviewer must
+   check OpenSpec structure, implementation readiness, unresolved questions,
+   `CLAUDE.md`, Kubernetes-only operation, and task simplicity.
+8. Spawn the spec finalizer on `round-<round_id>-spec-integration`. It applies
+   accepted reviewer feedback, preserves the artifact-only boundary, commits,
+   pushes, and sends a final summary with:
+   - `change`
+   - `branch`
+   - unresolved questions
+   - implementation readiness: `ready|blocked`
+   - validation notes
+9. If unresolved questions block implementation, report `blocked` with the
+   questions. Otherwise report success with the integration branch.
+
+## Child Prompt Contract
+
+Every child prompt must include:
+
+```text
+Round: <round_id>
+Change: <change>
+Base branch: <base_branch>
+Target project root: <project_root>
+Spec-only boundary: modify only openspec/changes/<change>/ artifacts when your role writes files.
+Do not implement code, tests, Kubernetes manifests, runtime scripts, or product docs outside the requested artifact set.
+Send your result to the coordinator with scion message <coordinator> --non-interactive --notify '<summary>'.
+```
+
+## Output
+
+Final output must include the PR-ready spec branch, the change name, unresolved
+questions, implementation readiness, and verification performed.

--- a/.scion/templates/spec-finalizer/agents.md
+++ b/.scion/templates/spec-finalizer/agents.md
@@ -1,0 +1,4 @@
+# Spec Finalizer
+
+Finalize the approved OpenSpec artifact set on the integration branch. Keep the
+diff artifact-only, commit, push, and report implementation readiness.

--- a/.scion/templates/spec-finalizer/scion-agent.yaml
+++ b/.scion/templates/spec-finalizer/scion-agent.yaml
@@ -1,0 +1,7 @@
+schema_version: "1"
+description: "Spec finalizer - integrates review feedback into a PR-ready spec branch."
+default_harness_config: codex
+system_prompt: system-prompt.md
+agent_instructions: agents.md
+max_turns: 50
+max_duration: 8m

--- a/.scion/templates/spec-finalizer/system-prompt.md
+++ b/.scion/templates/spec-finalizer/system-prompt.md
@@ -1,0 +1,28 @@
+# Spec Finalizer
+
+You finalize a spec integration branch after review.
+
+## Boundary
+
+Modify only `openspec/changes/<change>/` artifacts. Do not implement code,
+tests, Kubernetes manifests, runtime scripts, or unrelated docs.
+
+Apply accepted reviewer feedback. Keep unresolved questions visible in the
+artifacts. Ensure:
+
+- `proposal.md`, `design.md`, and `tasks.md` exist
+- at least one `specs/**/spec.md` delta spec exists
+- `tasks.md` uses checkbox tasks
+- requirements and scenarios are concrete enough to verify
+- implementation readiness is clearly `ready` or `blocked`
+
+Commit and push `round-<round_id>-spec-integration`. Send a final summary to
+the coordinator with `scion message`, including:
+
+- change name
+- branch name
+- unresolved questions
+- implementation readiness
+- validation notes
+
+Then mark completion with `sciontool status task_completed "<summary>"`.

--- a/.scion/templates/spec-goal-clarifier/agents.md
+++ b/.scion/templates/spec-goal-clarifier/agents.md
@@ -1,0 +1,4 @@
+# Spec Goal Clarifier
+
+Clarify intent, scope, non-goals, and unresolved questions. Do not write files.
+Send a concise summary to the coordinator with `scion message`.

--- a/.scion/templates/spec-goal-clarifier/scion-agent.yaml
+++ b/.scion/templates/spec-goal-clarifier/scion-agent.yaml
@@ -1,0 +1,7 @@
+schema_version: "1"
+description: "Spec goal clarifier - narrows the user goal before spec drafting."
+default_harness_config: claude
+system_prompt: system-prompt.md
+agent_instructions: agents.md
+max_turns: 30
+max_duration: 6m

--- a/.scion/templates/spec-goal-clarifier/system-prompt.md
+++ b/.scion/templates/spec-goal-clarifier/system-prompt.md
@@ -1,0 +1,16 @@
+# Spec Goal Clarifier
+
+You clarify a user's goal before an OpenSpec change is drafted.
+
+Do not modify files. Inspect the target project only enough to avoid guessing.
+Focus on:
+
+- smallest useful change
+- user-visible outcome
+- non-goals
+- likely change name
+- unresolved questions that would block implementation
+
+If a question is not blocking, convert it into an assumption. Send your result
+to the coordinator with `scion message`, then mark completion with
+`sciontool status task_completed "<summary>"`.

--- a/.scion/templates/spec-ops-reviewer/agents.md
+++ b/.scion/templates/spec-ops-reviewer/agents.md
@@ -1,0 +1,4 @@
+# Spec Operations Reviewer
+
+Review the OpenSpec artifact branch. Do not modify files. Return a JSON verdict
+to the coordinator.

--- a/.scion/templates/spec-ops-reviewer/scion-agent.yaml
+++ b/.scion/templates/spec-ops-reviewer/scion-agent.yaml
@@ -1,0 +1,7 @@
+schema_version: "1"
+description: "Spec operations reviewer - checks artifact quality and operational fit."
+default_harness_config: codex
+system_prompt: system-prompt.md
+agent_instructions: agents.md
+max_turns: 40
+max_duration: 7m

--- a/.scion/templates/spec-ops-reviewer/system-prompt.md
+++ b/.scion/templates/spec-ops-reviewer/system-prompt.md
@@ -1,0 +1,29 @@
+# Spec Operations Reviewer
+
+You review a spec artifact branch for implementation readiness.
+
+Do not modify files. Review only. Check:
+
+- OpenSpec layout and required artifact structure
+- clear requirements and scenarios
+- tasks are small, ordered, and verifiable
+- design follows `CLAUDE.md`
+- Kubernetes-only operation remains the default
+- task commands remain simple and sane
+- unresolved questions are explicit
+- no implementation files changed outside `openspec/changes/<change>/`
+
+Send this JSON to the coordinator with `scion message`:
+
+```json
+{
+  "reviewer": "spec-ops-reviewer",
+  "verdict": "accept|revise|blocked",
+  "readiness": "ready|blocked",
+  "issues": [],
+  "unresolved_questions": [],
+  "summary": ""
+}
+```
+
+Then mark completion with `sciontool status task_completed "<verdict>"`.

--- a/.scion/templates/spec-repo-explorer/agents.md
+++ b/.scion/templates/spec-repo-explorer/agents.md
@@ -1,0 +1,4 @@
+# Spec Repo Explorer
+
+Inspect the target project and report the existing structures relevant to the
+spec. Do not write files or implement changes.

--- a/.scion/templates/spec-repo-explorer/scion-agent.yaml
+++ b/.scion/templates/spec-repo-explorer/scion-agent.yaml
@@ -1,0 +1,7 @@
+schema_version: "1"
+description: "Spec repo explorer - inspects the target repo to ground the spec."
+default_harness_config: codex
+system_prompt: system-prompt.md
+agent_instructions: agents.md
+max_turns: 30
+max_duration: 6m

--- a/.scion/templates/spec-repo-explorer/system-prompt.md
+++ b/.scion/templates/spec-repo-explorer/system-prompt.md
@@ -1,0 +1,16 @@
+# Spec Repo Explorer
+
+You inspect the target repository so the spec author can work with the grain of
+the project.
+
+Do not modify files. Look for existing docs, tests, task commands, deployment
+shape, and any existing `openspec/` tree. Report:
+
+- relevant files and directories
+- likely spec domains under `openspec/specs/`
+- the nearest cheap verification command
+- constraints from `CLAUDE.md`, README, and Kubernetes lifecycle docs
+- risks or ambiguity the spec author should address
+
+Send your summary to the coordinator with `scion message`, then mark completion
+with `sciontool status task_completed "<summary>"`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,6 +96,19 @@ tasks:
     cmds:
       - python3 scripts/validate-openspec-change.py {{.CLI_ARGS}}
 
+  spec:round:
+    desc: Start a spec-building Scion round for a target project.
+    cmds:
+      - |
+        set -- {{.CLI_ARGS}}
+        bash orchestrator/spec-round.sh "$@"
+
+  spec:round:dry-run:
+    cmds:
+      - |
+        set -- {{.CLI_ARGS}}
+        SCION_OPS_DRY_RUN=1 bash orchestrator/spec-round.sh "$@"
+
   down:
     desc: Destroy the kind Kubernetes deployment.
     prompt: This deletes the {{.KIND_CLUSTER_NAME}} kind cluster and all cluster-local Scion state. Continue?
@@ -318,4 +331,4 @@ tasks:
       - task --list
       - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/test-openspec-change-validator.py')]"
       - python3 scripts/test-openspec-change-validator.py
-      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/abort.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/abort.sh

--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -141,6 +141,41 @@ The validator checks that `openspec/changes/<change>/` exists, that
 MCP clients use the same validation path through
 `scion_ops_validate_spec_change(project_root, change)`.
 
+## Spec Round Launch
+
+Use `task spec:round` to launch the spec-building personas against the selected
+target project:
+
+```bash
+task bootstrap -- /path/to/project
+SCION_OPS_PROJECT_ROOT=/path/to/project task spec:round -- "draft the spec goal"
+```
+
+Optionally provide a stable change name:
+
+```bash
+SCION_OPS_PROJECT_ROOT=/path/to/project \
+SCION_OPS_SPEC_CHANGE=add-widget \
+task spec:round -- "draft the spec goal"
+```
+
+For a no-model prompt rendering check:
+
+```bash
+task spec:round:dry-run -- "draft the spec goal"
+```
+
+The spec round uses these templates:
+
+| Template | Role |
+|---|---|
+| `spec-consensus-runner` | Coordinates the spec protocol and final branch. |
+| `spec-goal-clarifier` | Narrows scope, assumptions, and blocking questions. |
+| `spec-repo-explorer` | Inspects the target repo so the spec follows local patterns. |
+| `spec-author` | Writes only `openspec/changes/<change>/` artifacts. |
+| `spec-ops-reviewer` | Checks OpenSpec structure and operational fit. |
+| `spec-finalizer` | Produces the PR-ready spec integration branch. |
+
 ## PR Flow
 
 Spec PR:

--- a/orchestrator/spec-round.sh
+++ b/orchestrator/spec-round.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Start a Scion-native spec-building round.
+set -euo pipefail
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+GOAL="${*:-}"
+[[ -n "$GOAL" ]] || die "Usage: $(basename "$0") \"<spec goal>\""
+
+SCION_BIN="${SCION_BIN:-scion}"
+command -v "$SCION_BIN" >/dev/null || die "scion not on PATH"
+
+SCION_OPS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_ROOT_INPUT="${SCION_OPS_PROJECT_ROOT:-$SCION_OPS_ROOT}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" || die "target project is not a git repo: $PROJECT_ROOT"
+AGENT_PROJECT_ROOT="${SCION_OPS_AGENT_PROJECT_ROOT:-/workspace}"
+
+ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' "$RANDOM")}"
+CHANGE="${SCION_OPS_SPEC_CHANGE:-}"
+BASE_BRANCH="${BASE_BRANCH:-$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)}"
+BROKER="${SCION_KIND_CP_BROKER:-kind-control-plane}"
+if [[ -z "$BASE_BRANCH" ]]; then
+  BASE_BRANCH="$(git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+fi
+BASE_BRANCH="${BASE_BRANCH:-main}"
+RUNNER_NAME="round-${ROUND_ID}-spec-consensus"
+RUNNER_BRANCH="$RUNNER_NAME"
+
+if [[ "${SCION_OPS_ROUND_PREFLIGHT:-1}" != "0" && "${SCION_OPS_DRY_RUN:-0}" != "1" ]]; then
+  bash "$SCION_OPS_ROOT/scripts/kind-round-preflight.sh"
+fi
+
+TASK_PROMPT=$(cat <<EOF
+round_id: $ROUND_ID
+base_branch: $BASE_BRANCH
+change: $CHANGE
+project_root: $AGENT_PROJECT_ROOT
+
+original_goal:
+$GOAL
+
+Start the spec-building protocol described in your system prompt. Produce only
+OpenSpec artifacts under openspec/changes/<change>/ in the target project. Do
+not implement code, tests, manifests, or runtime changes during this round.
+EOF
+)
+
+printf 'Starting spec consensus runner: %s\n' "$RUNNER_NAME"
+printf 'Round id: %s\n' "$ROUND_ID"
+printf 'Base branch: %s\n' "$BASE_BRANCH"
+printf 'Change: %s\n' "${CHANGE:-<derive in round>}"
+printf 'Broker: %s\n' "$BROKER"
+printf 'Grove root: %s\n' "$PROJECT_ROOT"
+printf 'Agent project root: %s\n' "$AGENT_PROJECT_ROOT"
+
+if [[ "${SCION_OPS_DRY_RUN:-0}" == "1" ]]; then
+  cat <<EOF
+
+Dry run command:
+  $SCION_BIN --grove "$PROJECT_ROOT" start "$RUNNER_NAME" --type spec-consensus-runner --branch "$RUNNER_BRANCH" --broker "$BROKER" --harness-auth auth-file --no-upload --non-interactive --yes --notify "<prompt>"
+
+Rendered prompt:
+$TASK_PROMPT
+EOF
+  exit 0
+fi
+
+"$SCION_BIN" --grove "$PROJECT_ROOT" start "$RUNNER_NAME" \
+  --type spec-consensus-runner \
+  --branch "$RUNNER_BRANCH" \
+  --broker "$BROKER" \
+  --harness-auth auth-file \
+  --no-upload \
+  --non-interactive \
+  --yes \
+  --notify \
+  "$TASK_PROMPT"
+
+printf '\nWatch progress:\n'
+printf '  scion look %s\n' "$RUNNER_NAME"
+printf '  scion messages --agent %s\n' "$RUNNER_NAME"


### PR DESCRIPTION
Closes #46.

## Summary
- add spec-focused Scion templates for clarifier, explorer, author, operations reviewer, finalizer, and spec consensus runner
- add `task spec:round` plus `task spec:round:dry-run` for launch and no-model prompt rendering
- document spec round launch and template roles in `docs/openspec-round-workflow.md`

## Verification
- `task verify`
- `task spec:round:dry-run -- "draft a spec for README search improvements"`
- `task bootstrap` synced 14 templates to the kind Hub, including all six new spec templates

## Notes
- This PR intentionally does not add MCP start tools; #48 owns MCP entry points for spec and implementation rounds.