### PR TITLE
Add implementation rounds from OpenSpec changes

### DIFF
--- a/.scion/templates/consensus-runner/system-prompt.md
+++ b/.scion/templates/consensus-runner/system-prompt.md
@@ -172,6 +172,17 @@ When spawning or messaging implementers, require:
 - `git push -u origin HEAD` when `origin` is configured,
 - `sciontool status task_completed "<summary>"`.
 
+When the task prompt contains `spec_change:` or `spec_artifact_root:`, this is
+an implementation-from-spec round. In every implementer, reviewer, integrator,
+and final-review prompt, include the approved artifact paths and state that:
+
+- `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md` are the source
+  of truth,
+- agents must read those artifacts before editing,
+- `tasks.md` checkboxes should be updated for completed work,
+- scope drift from the approved spec is blocking,
+- reviewers must distinguish implementation quality from spec conformance.
+
 Claude, Codex, and Gemini child agents must be started with
 `--harness-auth auth-file --no-upload` so Scion explicitly selects the
 Hub-projected subscription credential files: `CLAUDE_AUTH`, `CLAUDE_CONFIG`,

--- a/.scion/templates/final-reviewer-codex/system-prompt.md
+++ b/.scion/templates/final-reviewer-codex/system-prompt.md
@@ -13,6 +13,9 @@ You are the *final* reviewer on a snapshot of the integrated branch after the du
    - secrets, debug prints, or commented-out code left behind;
    - dependency or schema changes without migration;
    - newly broad permissions or removed safety checks.
+4. When the task includes `spec_change:` or `spec_artifact_root:`, read the
+   approved OpenSpec artifacts and reject scope drift as a blocking issue.
+   In `summary`, include `Implementation quality:` and `Spec conformance:`.
 
 ## Output: `verdict.json`
 

--- a/.scion/templates/final-reviewer-gemini/system-prompt.md
+++ b/.scion/templates/final-reviewer-gemini/system-prompt.md
@@ -13,6 +13,9 @@ You are the *final* reviewer on a snapshot of the integrated branch after the du
    - secrets, debug prints, or commented-out code left behind;
    - dependency or schema changes without migration;
    - newly broad permissions or removed safety checks.
+4. When the task includes `spec_change:` or `spec_artifact_root:`, read the
+   approved OpenSpec artifacts and reject scope drift as a blocking issue.
+   In `summary`, include `Implementation quality:` and `Spec conformance:`.
 
 ## Output: `verdict.json`
 

--- a/.scion/templates/impl-claude/system-prompt.md
+++ b/.scion/templates/impl-claude/system-prompt.md
@@ -12,6 +12,21 @@ You are one of two parallel implementers for the same task. The other is Codex, 
 6. In Hub-backed git groves, push your branch when the remote is configured: `git push -u origin HEAD`. If pushing is unavailable, say so in your completion status.
 7. Signal completion: `sciontool status task_completed "<short summary>"` and stop.
 
+## When the task names an OpenSpec change
+
+If the prompt includes `spec_change:` or `spec_artifact_root:`, the approved
+OpenSpec artifacts are the source of truth. Before editing, read:
+
+- `openspec/changes/<change>/proposal.md`
+- `openspec/changes/<change>/design.md`
+- `openspec/changes/<change>/tasks.md`
+- `openspec/changes/<change>/specs/**/spec.md`
+
+Implement only what those artifacts require. Update `tasks.md` checkboxes for
+tasks you complete. If the artifacts conflict with the codebase, make the
+smallest necessary artifact update and call that out in your completion
+summary. Do not expand scope because the original chat prompt sounds broader.
+
 ## What you do NOT do
 
 - Do **not** review or critique the other implementer's branch. That happens in a later phase by a different agent.

--- a/.scion/templates/impl-codex/system-prompt.md
+++ b/.scion/templates/impl-codex/system-prompt.md
@@ -12,6 +12,21 @@ You are one of two parallel implementers for the same task. The other is Claude,
 6. In Hub-backed git groves, push your branch when the remote is configured: `git push -u origin HEAD`. If pushing is unavailable, say so in your completion status.
 7. Signal completion: `sciontool status task_completed "<short summary>"` and stop.
 
+## When the task names an OpenSpec change
+
+If the prompt includes `spec_change:` or `spec_artifact_root:`, the approved
+OpenSpec artifacts are the source of truth. Before editing, read:
+
+- `openspec/changes/<change>/proposal.md`
+- `openspec/changes/<change>/design.md`
+- `openspec/changes/<change>/tasks.md`
+- `openspec/changes/<change>/specs/**/spec.md`
+
+Implement only what those artifacts require. Update `tasks.md` checkboxes for
+tasks you complete. If the artifacts conflict with the codebase, make the
+smallest necessary artifact update and call that out in your completion
+summary. Do not expand scope because the original chat prompt sounds broader.
+
 ## What you do NOT do
 
 - Do **not** review or critique the other implementer's branch. That happens in a later phase by a different agent.

--- a/.scion/templates/reviewer-claude/system-prompt.md
+++ b/.scion/templates/reviewer-claude/system-prompt.md
@@ -15,6 +15,12 @@ You review a peer agent's diff. **You do not modify the code.** You produce one 
 - **completeness** — are all parts of the task addressed? Missing tests count against this.
 - **style** — readability, naming, idiom for the language, adherence to project conventions.
 
+When the task includes `spec_change:` or `spec_artifact_root:`, also review
+spec conformance. Read the approved proposal, design, tasks, and delta specs.
+Scope drift from those artifacts is a blocking correctness issue. In
+`summary`, include two labeled sentences: `Implementation quality:` and
+`Spec conformance:`. Keep the JSON schema unchanged.
+
 A score of **4 or 5 on correctness** means consensus-passing. **3 or below on correctness** means `verdict: request_changes` and `blocking_issues` must be populated.
 
 ## Output: `verdict.json`

--- a/.scion/templates/reviewer-codex/system-prompt.md
+++ b/.scion/templates/reviewer-codex/system-prompt.md
@@ -15,6 +15,12 @@ You review a peer agent's diff. **You do not modify the code.** You produce one 
 - **completeness** — are all parts of the task addressed? Missing tests count against this.
 - **style** — readability, naming, idiom for the language, adherence to project conventions.
 
+When the task includes `spec_change:` or `spec_artifact_root:`, also review
+spec conformance. Read the approved proposal, design, tasks, and delta specs.
+Scope drift from those artifacts is a blocking correctness issue. In
+`summary`, include two labeled sentences: `Implementation quality:` and
+`Spec conformance:`. Keep the JSON schema unchanged.
+
 A score of **4 or 5 on correctness** means consensus-passing. **3 or below on correctness** means `verdict: request_changes` and `blocking_issues` must be populated.
 
 ## Output: `verdict.json`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -109,6 +109,19 @@ tasks:
         set -- {{.CLI_ARGS}}
         SCION_OPS_DRY_RUN=1 bash orchestrator/spec-round.sh "$@"
 
+  spec:implement:
+    desc: Start an implementation round from an approved OpenSpec change.
+    cmds:
+      - |
+        set -- {{.CLI_ARGS}}
+        bash orchestrator/spec-implementation-round.sh "$@"
+
+  spec:implement:dry-run:
+    cmds:
+      - |
+        set -- {{.CLI_ARGS}}
+        SCION_OPS_DRY_RUN=1 bash orchestrator/spec-implementation-round.sh "$@"
+
   down:
     desc: Destroy the kind Kubernetes deployment.
     prompt: This deletes the {{.KIND_CLUSTER_NAME}} kind cluster and all cluster-local Scion state. Continue?
@@ -331,4 +344,4 @@ tasks:
       - task --list
       - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/test-openspec-change-validator.py')]"
       - python3 scripts/test-openspec-change-validator.py
-      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/abort.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -176,6 +176,30 @@ The spec round uses these templates:
 | `spec-ops-reviewer` | Checks OpenSpec structure and operational fit. |
 | `spec-finalizer` | Produces the PR-ready spec integration branch. |
 
+## Implementation From Spec
+
+After the spec PR is merged, start implementation from the approved change
+folder:
+
+```bash
+task bootstrap -- /path/to/project
+SCION_OPS_PROJECT_ROOT=/path/to/project \
+task spec:implement -- --change <change> "implement the approved change"
+```
+
+`task spec:implement` validates `openspec/changes/<change>/` before it starts
+the round. Missing or invalid artifacts fail before any agent is launched. The
+implementation prompt names the approved artifact paths and requires agents to
+read them before editing, update `tasks.md` checkboxes, and treat spec drift as
+a blocking review issue.
+
+For a no-model prompt rendering check against a valid artifact tree:
+
+```bash
+SCION_OPS_PROJECT_ROOT=/path/to/project \
+task spec:implement:dry-run -- --change <change> "implement the approved change"
+```
+
 ## PR Flow
 
 Spec PR:

--- a/orchestrator/spec-implementation-round.sh
+++ b/orchestrator/spec-implementation-round.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Start an implementation round from an approved OpenSpec change.
+set -euo pipefail
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+CHANGE=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --change)
+      [[ $# -ge 2 ]] || die "--change requires a value"
+      CHANGE="$2"
+      shift 2
+      ;;
+    --change=*)
+      CHANGE="${1#--change=}"
+      shift
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$CHANGE" ]] || die "Usage: $(basename "$0") --change <change> \"<optional implementation goal>\""
+GOAL="${ARGS[*]:-Implement the approved OpenSpec change.}"
+
+SCION_OPS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_ROOT_INPUT="${SCION_OPS_PROJECT_ROOT:-$SCION_OPS_ROOT}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" || die "target project is not a git repo: $PROJECT_ROOT"
+AGENT_PROJECT_ROOT="${SCION_OPS_AGENT_PROJECT_ROOT:-/workspace}"
+BASE_BRANCH="${BASE_BRANCH:-$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)}"
+if [[ -z "$BASE_BRANCH" ]]; then
+  BASE_BRANCH="$(git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+fi
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+VALIDATION_JSON="$(python3 "$SCION_OPS_ROOT/scripts/validate-openspec-change.py" \
+  --project-root "$PROJECT_ROOT" \
+  --change "$CHANGE" \
+  --json)" || {
+  printf '%s\n' "$VALIDATION_JSON"
+  die "OpenSpec change is missing or invalid: $CHANGE"
+}
+
+IMPLEMENTATION_PROMPT=$(cat <<EOF
+spec_change: $CHANGE
+spec_artifact_root: openspec/changes/$CHANGE
+base_branch: $BASE_BRANCH
+project_root: $AGENT_PROJECT_ROOT
+
+approved_spec_artifacts:
+- openspec/changes/$CHANGE/proposal.md
+- openspec/changes/$CHANGE/design.md
+- openspec/changes/$CHANGE/tasks.md
+- openspec/changes/$CHANGE/specs/
+
+validation:
+$VALIDATION_JSON
+
+implementation_goal:
+$GOAL
+
+Implement the approved OpenSpec change. Before editing, read proposal.md,
+design.md, tasks.md, and all delta specs under specs/. Treat those artifacts as
+the implementation contract. Do not expand scope beyond the approved artifacts.
+Update tasks.md checkboxes for tasks you complete. If implementation reveals a
+real spec conflict, update the artifact text and report why in your completion
+summary.
+
+Reviewers must distinguish implementation quality from spec conformance. Spec
+drift is a blocking issue even when the code works.
+EOF
+)
+
+if [[ "${SCION_OPS_DRY_RUN:-0}" == "1" ]]; then
+  cat <<EOF
+Spec implementation dry run:
+project_root: $PROJECT_ROOT
+change: $CHANGE
+base_branch: $BASE_BRANCH
+
+Rendered prompt:
+$IMPLEMENTATION_PROMPT
+EOF
+  exit 0
+fi
+
+env \
+  "SCION_OPS_PROJECT_ROOT=$PROJECT_ROOT" \
+  "BASE_BRANCH=$BASE_BRANCH" \
+  bash "$SCION_OPS_ROOT/orchestrator/run-round.sh" "$IMPLEMENTATION_PROMPT"


### PR DESCRIPTION
Closes #47.

## Summary
- add `task spec:implement` and dry-run support for implementation rounds from approved OpenSpec changes
- validate the requested change before launching agents so missing or invalid artifact sets fail clearly
- update consensus, implementer, reviewer, and final-review prompts to treat spec artifacts as the source of truth
- document the implementation-from-spec workflow

## Verification
- `task verify`
- `task spec:implement -- --change missing-change "implement missing change"` fails before agent launch with validator JSON
- dry-run against a temporary valid OpenSpec artifact tree renders the spec-bound implementation prompt
- `task bootstrap` synced the modified templates into the kind Hub

## Notes
- This PR keeps the existing verdict JSON schema unchanged. #49 owns schema expansion for explicit spec-conformance fields.