### PR TITLE
Extend verdict schema for spec conformance

### DIFF
--- a/.scion/templates/final-reviewer-codex/agents.md
+++ b/.scion/templates/final-reviewer-codex/agents.md
@@ -25,13 +25,26 @@ The verdict JSON must have this shape:
 
 ```json
 {
+  "review_type": "final",
   "scores": { "correctness": 5, "completeness": 5, "style": 5 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": [],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 5,
+    "operational_verification": 5,
+    "checked_artifacts": [],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "Tests green, no critical issues."
 }
 ```
+
+For non-spec reviews, omit `review_type` and `spec`.
 
 ## Scion CLI Use
 

--- a/.scion/templates/final-reviewer-codex/system-prompt.md
+++ b/.scion/templates/final-reviewer-codex/system-prompt.md
@@ -15,7 +15,8 @@ You are the *final* reviewer on a snapshot of the integrated branch after the du
    - newly broad permissions or removed safety checks.
 4. When the task includes `spec_change:` or `spec_artifact_root:`, read the
    approved OpenSpec artifacts and reject scope drift as a blocking issue.
-   In `summary`, include `Implementation quality:` and `Spec conformance:`.
+   Include the `spec` object in `verdict.json`. In `summary`, include
+   `Implementation quality:` and `Spec conformance:`.
 
 ## Output: `verdict.json`
 
@@ -23,10 +24,21 @@ Write *exactly* one file named `verdict.json` in the current workspace root:
 
 ```json
 {
+  "review_type": "final",
   "scores":  { "correctness": 5, "completeness": 5, "style": 5 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": ["log message at foo.go:42 leaks the request id"],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 5,
+    "operational_verification": 5,
+    "checked_artifacts": ["openspec/changes/add-widget/tasks.md"],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "Tests green, no critical issues."
 }
 ```
@@ -35,6 +47,7 @@ Rules — different from peer review, narrower:
 - `blocking_issues` is reserved for things that would break production or fail compliance review. Style and naming go in `nits`. If you find none, leave `blocking_issues` empty and set `verdict: accept`.
 - `verdict == "request_changes"` ONLY when there is at least one blocking issue.
 - Tests failing → `blocking_issues` must include `"tests failing on integrated branch"` and `verdict: request_changes`.
+- Existing non-spec verdicts may omit `review_type` and `spec`. Spec-driven verdicts must include both.
 - If the task names a coordinator agent, send the exact JSON to that coordinator with `scion message` after writing the file.
 
 ## Don't

--- a/.scion/templates/final-reviewer-gemini/agents.md
+++ b/.scion/templates/final-reviewer-gemini/agents.md
@@ -25,13 +25,26 @@ The verdict JSON must have this shape:
 
 ```json
 {
+  "review_type": "final",
   "scores": { "correctness": 5, "completeness": 5, "style": 5 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": [],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 5,
+    "operational_verification": 5,
+    "checked_artifacts": [],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "Tests green, no critical issues."
 }
 ```
+
+For non-spec reviews, omit `review_type` and `spec`.
 
 ## Scion CLI Use
 

--- a/.scion/templates/final-reviewer-gemini/system-prompt.md
+++ b/.scion/templates/final-reviewer-gemini/system-prompt.md
@@ -15,7 +15,8 @@ You are the *final* reviewer on a snapshot of the integrated branch after the du
    - newly broad permissions or removed safety checks.
 4. When the task includes `spec_change:` or `spec_artifact_root:`, read the
    approved OpenSpec artifacts and reject scope drift as a blocking issue.
-   In `summary`, include `Implementation quality:` and `Spec conformance:`.
+   Include the `spec` object in `verdict.json`. In `summary`, include
+   `Implementation quality:` and `Spec conformance:`.
 
 ## Output: `verdict.json`
 
@@ -23,10 +24,21 @@ Write *exactly* one file named `verdict.json` in the current workspace root:
 
 ```json
 {
+  "review_type": "final",
   "scores":  { "correctness": 5, "completeness": 5, "style": 5 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": ["log message at foo.go:42 leaks the request id"],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 5,
+    "operational_verification": 5,
+    "checked_artifacts": ["openspec/changes/add-widget/tasks.md"],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "Tests green, no critical issues."
 }
 ```
@@ -35,6 +47,7 @@ Rules - different from peer review, narrower:
 - `blocking_issues` is reserved for things that would break production or fail compliance review. Style and naming go in `nits`. If you find none, leave `blocking_issues` empty and set `verdict: accept`.
 - `verdict == "request_changes"` ONLY when there is at least one blocking issue.
 - Tests failing -> `blocking_issues` must include `"tests failing on integrated branch"` and `verdict: request_changes`.
+- Existing non-spec verdicts may omit `review_type` and `spec`. Spec-driven verdicts must include both.
 - If the task names a coordinator agent, send the exact JSON to that coordinator with `scion message` after writing the file.
 
 ## Don't

--- a/.scion/templates/reviewer-claude/agents.md
+++ b/.scion/templates/reviewer-claude/agents.md
@@ -25,13 +25,26 @@ The verdict JSON must have this shape:
 
 ```json
 {
+  "review_type": "implementation",
   "scores": { "correctness": 4, "completeness": 5, "style": 3 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": [],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 4,
+    "operational_verification": 4,
+    "checked_artifacts": [],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "One paragraph."
 }
 ```
+
+For non-spec reviews, omit `review_type` and `spec`.
 
 ## Scion CLI Use
 

--- a/.scion/templates/reviewer-claude/system-prompt.md
+++ b/.scion/templates/reviewer-claude/system-prompt.md
@@ -17,9 +17,9 @@ You review a peer agent's diff. **You do not modify the code.** You produce one 
 
 When the task includes `spec_change:` or `spec_artifact_root:`, also review
 spec conformance. Read the approved proposal, design, tasks, and delta specs.
-Scope drift from those artifacts is a blocking correctness issue. In
-`summary`, include two labeled sentences: `Implementation quality:` and
-`Spec conformance:`. Keep the JSON schema unchanged.
+Scope drift from those artifacts is a blocking correctness issue. Include the
+`spec` object in `verdict.json`. In `summary`, include two labeled sentences:
+`Implementation quality:` and `Spec conformance:`.
 
 A score of **4 or 5 on correctness** means consensus-passing. **3 or below on correctness** means `verdict: request_changes` and `blocking_issues` must be populated.
 
@@ -29,10 +29,21 @@ Write *exactly* one file named `verdict.json` in the current workspace root:
 
 ```json
 {
+  "review_type": "implementation",
   "scores":  { "correctness": 4, "completeness": 5, "style": 3 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": ["function name `calc` is vague — consider `compute_total`"],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 4,
+    "operational_verification": 4,
+    "checked_artifacts": ["openspec/changes/add-widget/proposal.md"],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "One paragraph."
 }
 ```
@@ -41,6 +52,7 @@ Rules:
 - `verdict == "accept"` iff `scores.correctness >= 4`.
 - `blocking_issues` non-empty iff `verdict == "request_changes"`. Each entry is concrete and actionable; fixing it should raise correctness to ≥ 4.
 - `nits` are non-blocking. They never gate consensus.
+- Existing non-spec verdicts may omit `review_type` and `spec`. Spec-driven verdicts must include both.
 - If the task names a coordinator agent, send the exact JSON to that coordinator with `scion message` after writing the file.
 - Do **not** commit `verdict.json` — keep it as a working-tree file.
 - Do **not** edit code under review.

--- a/.scion/templates/reviewer-codex/agents.md
+++ b/.scion/templates/reviewer-codex/agents.md
@@ -25,13 +25,26 @@ The verdict JSON must have this shape:
 
 ```json
 {
+  "review_type": "implementation",
   "scores": { "correctness": 4, "completeness": 5, "style": 3 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": [],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 4,
+    "operational_verification": 4,
+    "checked_artifacts": [],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "One paragraph."
 }
 ```
+
+For non-spec reviews, omit `review_type` and `spec`.
 
 ## Scion CLI Use
 

--- a/.scion/templates/reviewer-codex/system-prompt.md
+++ b/.scion/templates/reviewer-codex/system-prompt.md
@@ -17,9 +17,9 @@ You review a peer agent's diff. **You do not modify the code.** You produce one 
 
 When the task includes `spec_change:` or `spec_artifact_root:`, also review
 spec conformance. Read the approved proposal, design, tasks, and delta specs.
-Scope drift from those artifacts is a blocking correctness issue. In
-`summary`, include two labeled sentences: `Implementation quality:` and
-`Spec conformance:`. Keep the JSON schema unchanged.
+Scope drift from those artifacts is a blocking correctness issue. Include the
+`spec` object in `verdict.json`. In `summary`, include two labeled sentences:
+`Implementation quality:` and `Spec conformance:`.
 
 A score of **4 or 5 on correctness** means consensus-passing. **3 or below on correctness** means `verdict: request_changes` and `blocking_issues` must be populated.
 
@@ -29,10 +29,21 @@ Write *exactly* one file named `verdict.json` in the current workspace root:
 
 ```json
 {
+  "review_type": "implementation",
   "scores":  { "correctness": 4, "completeness": 5, "style": 3 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": ["function name `calc` is vague — consider `compute_total`"],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 4,
+    "operational_verification": 4,
+    "checked_artifacts": ["openspec/changes/add-widget/proposal.md"],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "One paragraph."
 }
 ```
@@ -41,6 +52,7 @@ Rules:
 - `verdict == "accept"` iff `scores.correctness >= 4`.
 - `blocking_issues` non-empty iff `verdict == "request_changes"`. Each entry is concrete and actionable; fixing it should raise correctness to ≥ 4.
 - `nits` are non-blocking. They never gate consensus.
+- Existing non-spec verdicts may omit `review_type` and `spec`. Spec-driven verdicts must include both.
 - If the task names a coordinator agent, send the exact JSON to that coordinator with `scion message` after writing the file.
 - Do **not** commit `verdict.json` — keep it as a working-tree file.
 - Do **not** edit code under review.

--- a/.scion/templates/spec-ops-reviewer/system-prompt.md
+++ b/.scion/templates/spec-ops-reviewer/system-prompt.md
@@ -17,13 +17,25 @@ Send this JSON to the coordinator with `scion message`:
 
 ```json
 {
-  "reviewer": "spec-ops-reviewer",
-  "verdict": "accept|revise|blocked",
-  "readiness": "ready|blocked",
-  "issues": [],
-  "unresolved_questions": [],
-  "summary": ""
+  "review_type": "spec",
+  "scores": { "correctness": 4, "completeness": 4, "style": 4 },
+  "verdict": "accept",
+  "blocking_issues": [],
+  "nits": [],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 4,
+    "spec_completeness": 4,
+    "task_coverage": 4,
+    "operational_verification": 4,
+    "checked_artifacts": ["openspec/changes/add-widget/proposal.md"],
+    "unresolved_questions": [],
+    "gaps": []
+  },
+  "summary": "Spec review summary."
 }
 ```
 
-Then mark completion with `sciontool status task_completed "<verdict>"`.
+Use `verdict: "request_changes"` when unresolved questions or gaps block
+implementation. Then mark completion with
+`sciontool status task_completed "<verdict>"`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -342,6 +342,7 @@ tasks:
     cmds:
       - git diff --check
       - task --list
-      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/test-openspec-change-validator.py')]"
+      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-verdict-schema.py')]"
       - python3 scripts/test-openspec-change-validator.py
+      - python3 scripts/test-verdict-schema.py
       - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -77,6 +77,12 @@ The same model providers can fill these roles, but their prompts differ:
 planning roles must avoid code changes unless requested; implementation roles
 must treat the approved artifact set as the contract.
 
+Spec-driven reviewer verdicts use the same base `verdict.json` shape as direct
+implementation rounds, with optional `review_type` and `spec` fields. Existing
+non-spec verdicts may omit those fields. Spec-driven verdicts include
+conformance, spec completeness, task coverage, operational verification,
+checked artifacts, unresolved questions, and gaps.
+
 ## State Transitions
 
 ```text

--- a/rubric/reviewer-prompt.md
+++ b/rubric/reviewer-prompt.md
@@ -14,6 +14,13 @@ You are reviewing a peer agent's diff. **You do not modify the code.** You produ
 - **completeness** — are all parts of the task addressed? Missing tests count against this.
 - **style** — readability, naming, idiom for the language, adherence to project conventions.
 
+For spec-driven rounds, also score the `spec` object:
+
+- **conformance** — does the implementation match the approved proposal, design, tasks, and delta specs?
+- **spec_completeness** — are the approved spec artifacts internally complete enough to guide implementation?
+- **task_coverage** — are the implementation tasks represented and checked off accurately?
+- **operational_verification** — does the verification match the operational risk and project lifecycle?
+
 A score of **4 or 5 on correctness** means *consensus-passing* — the orchestrator stops looping when both reviewers reach this. A score of **3 or below on correctness** means `verdict: request_changes` and you must populate `blocking_issues`.
 
 ## Output
@@ -22,10 +29,21 @@ Write *exactly* one file at the root of your workspace, named `verdict.json`, ma
 
 ```json
 {
+  "review_type": "implementation",
   "scores": { "correctness": 4, "completeness": 5, "style": 3 },
   "verdict": "accept",
   "blocking_issues": [],
   "nits": ["function name `calc` is vague — consider `compute_total`"],
+  "spec": {
+    "change": "add-widget",
+    "conformance": 5,
+    "spec_completeness": 5,
+    "task_coverage": 4,
+    "operational_verification": 4,
+    "checked_artifacts": ["openspec/changes/add-widget/proposal.md"],
+    "unresolved_questions": [],
+    "gaps": []
+  },
   "summary": "One paragraph."
 }
 ```
@@ -34,6 +52,7 @@ Rules:
 - `verdict` must be `"accept"` if and only if `scores.correctness >= 4`.
 - `blocking_issues` must be non-empty if `verdict == "request_changes"`. Each entry is a concrete, actionable problem that, if fixed, would raise correctness to ≥ 4.
 - `nits` are non-blocking style/readability suggestions. They never gate consensus.
+- Existing non-spec verdicts may omit `review_type` and `spec`. Spec-driven verdicts must include both.
 - Do not commit `verdict.json` to git — it must remain a working-tree file the orchestrator reads directly.
 - Do not write any other artifacts; do not edit code under review.
 

--- a/rubric/verdict.schema.json
+++ b/rubric/verdict.schema.json
@@ -6,6 +6,11 @@
   "additionalProperties": false,
   "required": ["scores", "verdict"],
   "properties": {
+    "review_type": {
+      "type": "string",
+      "enum": ["implementation", "spec", "final", "unknown"],
+      "default": "implementation"
+    },
     "scores": {
       "type": "object",
       "additionalProperties": false,
@@ -29,6 +34,32 @@
       "type": "array",
       "items": { "type": "string" },
       "default": []
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change": { "type": "string" },
+        "conformance": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "spec_completeness": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "task_coverage": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "operational_verification": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "checked_artifacts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "unresolved_questions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "gaps": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        }
+      }
     },
     "summary": {
       "type": "string",

--- a/scripts/test-verdict-schema.py
+++ b/scripts/test-verdict-schema.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Validate representative verdict payloads against rubric/verdict.schema.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "rubric" / "verdict.schema.json"
+
+
+def _type_ok(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    return True
+
+
+def _validate(value: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+    expected_type = schema.get("type")
+    if isinstance(expected_type, str) and not _type_ok(value, expected_type):
+        return [f"{path}: expected {expected_type}"]
+
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: value {value!r} is not in enum")
+
+    if expected_type == "integer":
+        minimum = schema.get("minimum")
+        maximum = schema.get("maximum")
+        if minimum is not None and value < minimum:
+            errors.append(f"{path}: value below minimum")
+        if maximum is not None and value > maximum:
+            errors.append(f"{path}: value above maximum")
+
+    if expected_type == "object":
+        required = set(schema.get("required", []))
+        missing = sorted(required - set(value))
+        errors.extend(f"{path}.{key}: required property missing" for key in missing)
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(value) - set(properties))
+            errors.extend(f"{path}.{key}: additional property not allowed" for key in extra)
+        for key, item in value.items():
+            if key in properties:
+                errors.extend(_validate(item, properties[key], f"{path}.{key}"))
+
+    if expected_type == "array":
+        item_schema = schema.get("items", {})
+        for index, item in enumerate(value):
+            errors.extend(_validate(item, item_schema, f"{path}[{index}]"))
+
+    return errors
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    samples = [
+        {
+            "scores": {"correctness": 4, "completeness": 5, "style": 4},
+            "verdict": "accept",
+            "blocking_issues": [],
+            "nits": [],
+            "summary": "Legacy implementation verdict remains valid.",
+        },
+        {
+            "review_type": "implementation",
+            "scores": {"correctness": 5, "completeness": 4, "style": 4},
+            "verdict": "accept",
+            "blocking_issues": [],
+            "nits": [],
+            "spec": {
+                "change": "add-widget",
+                "conformance": 5,
+                "spec_completeness": 4,
+                "task_coverage": 4,
+                "operational_verification": 5,
+                "checked_artifacts": [
+                    "openspec/changes/add-widget/proposal.md",
+                    "openspec/changes/add-widget/tasks.md",
+                ],
+                "unresolved_questions": [],
+                "gaps": [],
+            },
+            "summary": "Implementation quality: tests pass. Spec conformance: matches the approved change.",
+        },
+        {
+            "review_type": "spec",
+            "scores": {"correctness": 3, "completeness": 3, "style": 4},
+            "verdict": "request_changes",
+            "blocking_issues": ["tasks.md does not cover rollback verification"],
+            "nits": [],
+            "spec": {
+                "change": "add-widget",
+                "conformance": 3,
+                "spec_completeness": 3,
+                "task_coverage": 2,
+                "operational_verification": 2,
+                "checked_artifacts": [
+                    "openspec/changes/add-widget/proposal.md",
+                    "openspec/changes/add-widget/design.md",
+                    "openspec/changes/add-widget/tasks.md",
+                    "openspec/changes/add-widget/specs/widgets/spec.md",
+                ],
+                "unresolved_questions": ["Which verification command is authoritative?"],
+                "gaps": ["No operational rollback task."],
+            },
+            "summary": "Spec review found blocking operational gaps.",
+        },
+    ]
+    failures: list[str] = []
+    for index, sample in enumerate(samples):
+        failures.extend(f"sample {index}: {error}" for error in _validate(sample, schema))
+    if failures:
+        raise SystemExit("\n".join(failures))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #49.

## Summary
- extend `rubric/verdict.schema.json` with optional `review_type` and `spec` fields
- keep legacy verdicts valid while allowing spec, implementation, and final reviews to record conformance details
- update reviewer/final/spec-review prompts to emit spec conformance fields when reviewing spec-driven rounds
- add sample schema validation for legacy, implementation-from-spec, and spec-review verdicts

## Verification
- `task verify`
- `scripts/test-verdict-schema.py` validates representative verdict payloads
- `task bootstrap` synced updated reviewer templates into the kind Hub

## Compatibility
- Existing non-spec verdicts may omit `review_type` and `spec`.