### PR TITLE
Archive accepted OpenSpec changes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,6 +96,11 @@ tasks:
     cmds:
       - python3 scripts/validate-openspec-change.py {{.CLI_ARGS}}
 
+  spec:archive:
+    desc: Archive an accepted OpenSpec change and sync accepted specs.
+    cmds:
+      - python3 scripts/archive-openspec-change.py {{.CLI_ARGS}}
+
   spec:round:
     desc: Start a spec-building Scion round for a target project.
     cmds:
@@ -342,7 +347,8 @@ tasks:
     cmds:
       - git diff --check
       - task --list
-      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-verdict-schema.py')]"
+      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/archive-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-openspec-archive.py', 'scripts/test-verdict-schema.py')]"
       - python3 scripts/test-openspec-change-validator.py
+      - python3 scripts/test-openspec-archive.py
       - python3 scripts/test-verdict-schema.py
       - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -108,9 +108,10 @@ folder by `change` name. They should not rewrite the spec intent unless
 implementation discovers a real conflict; in that case the round updates the
 artifacts and reports the reason.
 
-Archive and accepted-spec sync are a later lifecycle step. Until that is
-implemented, accepted change folders remain the implementation contract and
-`openspec/specs/` is updated only where explicitly requested.
+Archive and accepted-spec sync completes the lifecycle. Active change folders
+represent work still in progress. Archived folders represent accepted history.
+The accepted spec markers in `openspec/specs/` make completed deltas
+discoverable by future rounds without scanning active work.
 
 ## MCP Entry Points
 
@@ -122,6 +123,7 @@ Hub:
 | `scion_ops_project_status` | Confirm target project root, branch, origin, Hub link, and git status. |
 | `scion_ops_spec_status` | List OpenSpec changes and validate a selected change. |
 | `scion_ops_validate_spec_change` | Validate an OpenSpec change folder before implementation starts. |
+| `scion_ops_archive_spec_change` | Archive an accepted change and sync accepted specs. |
 | `scion_ops_start_spec_round` | Start a planning round from `project_root`, `goal`, and optional `change`. |
 | `scion_ops_start_impl_round` | Start a delivery round from `project_root` and approved `change`. |
 | `scion_ops_start_implementation_round` | Alias for `scion_ops_start_impl_round`. |
@@ -207,6 +209,25 @@ For a no-model prompt rendering check against a valid artifact tree:
 SCION_OPS_PROJECT_ROOT=/path/to/project \
 task spec:implement:dry-run -- --change <change> "implement the approved change"
 ```
+
+## Archive Lifecycle
+
+After the implementation PR is accepted, archive the completed change:
+
+```bash
+task spec:archive -- --project-root /path/to/project --change <change>
+task spec:archive -- --project-root /path/to/project --change <change> --yes
+```
+
+The first command is a dry run. The `--yes` command validates the active change,
+syncs each accepted delta spec into `openspec/specs/**/spec.md` under a
+`scion-ops:accepted-change` marker, then moves the change folder to
+`openspec/changes/archive/YYYY-MM-DD-<change>/`.
+
+MCP clients use the same flow with
+`scion_ops_archive_spec_change(project_root, change, confirm=false)` for a plan
+and `confirm=true` to apply. `scion_ops_spec_status` reports active and
+archived changes.
 
 ## PR Flow
 

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -164,3 +164,15 @@ scion_ops_round_artifacts(project_root, round_id)
 
 `scion_ops_start_impl_round` validates the artifact set before launching
 agents. Missing or invalid specs fail before model work starts.
+
+After the implementation PR is merged, ask for archive cleanup:
+
+```text
+Use scion-ops on project_root=/home/david/workspace/github/example/project.
+Archive accepted OpenSpec change=add-widget, sync accepted specs, and report the archive path.
+```
+
+The external agent should first call
+`scion_ops_archive_spec_change(project_root, change, confirm=false)` and show
+the plan. After confirmation, it calls the same tool with `confirm=true`, then
+uses `scion_ops_spec_status(project_root, change)` to show the archived state.

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -990,6 +990,26 @@ def _validate_spec_change_result(root: Path, change: str) -> tuple[dict[str, Any
     return command_result, payload
 
 
+def _archive_spec_change_result(root: Path, change: str, confirm: bool) -> tuple[dict[str, Any], dict[str, Any]]:
+    args = [
+        "python3",
+        str(_repo_root() / "scripts" / "archive-openspec-change.py"),
+        "--project-root",
+        str(root),
+        "--change",
+        change,
+        "--json",
+    ]
+    if confirm:
+        args.append("--yes")
+    result = _run(args, timeout=30, cwd=_repo_root())
+    payload = _parse_json_result(result)
+    command_result = _command_result(result)
+    if payload and not payload.get("ok"):
+        command_result["error_kind"] = "openspec_archive"
+    return command_result, payload
+
+
 @mcp.tool()
 def scion_ops_hub_status(project_root: str = "") -> dict[str, Any]:
     """Show Scion Hub API health, grove, broker providers, and agents."""
@@ -1412,6 +1432,7 @@ def scion_ops_spec_status(project_root: str, change: str = "") -> dict[str, Any]
     """List OpenSpec changes in a target project and optionally validate one change."""
     root = _project_root(project_root)
     changes_dir = root / "openspec" / "changes"
+    archive_dir = changes_dir / "archive"
     changes: list[dict[str, Any]] = []
     if changes_dir.exists():
         for path in sorted(item for item in changes_dir.iterdir() if item.is_dir() and item.name != "archive"):
@@ -1423,6 +1444,10 @@ def scion_ops_spec_status(project_root: str, change: str = "") -> dict[str, Any]
                 "has_tasks": (path / "tasks.md").exists(),
                 "spec_file_count": len(list((path / "specs").glob("**/spec.md"))) if (path / "specs").exists() else 0,
             })
+    archived_changes: list[dict[str, str]] = []
+    if archive_dir.exists():
+        for path in sorted(item for item in archive_dir.iterdir() if item.is_dir()):
+            archived_changes.append({"archive": path.name, "path": str(path.relative_to(root))})
     validation: dict[str, Any] = {}
     validation_result: dict[str, Any] = {}
     ok = True
@@ -1436,6 +1461,8 @@ def scion_ops_spec_status(project_root: str, change: str = "") -> dict[str, Any]
         "project_root": str(root),
         "changes_path": str(changes_dir.relative_to(root)),
         "changes": changes,
+        "archive_path": str(archive_dir.relative_to(root)),
+        "archived_changes": archived_changes,
         "change": change,
         "validation": validation,
         "validation_result": validation_result,
@@ -1443,7 +1470,27 @@ def scion_ops_spec_status(project_root: str, change: str = "") -> dict[str, Any]
             "draft_spec_tool": "scion_ops_start_spec_round",
             "validate_tool": "scion_ops_validate_spec_change",
             "start_implementation_tool": "scion_ops_start_impl_round",
+            "archive_tool": "scion_ops_archive_spec_change",
             "watch_tool": "scion_ops_watch_round_events",
+        },
+    }
+
+
+@mcp.tool()
+def scion_ops_archive_spec_change(project_root: str, change: str, confirm: bool = False) -> dict[str, Any]:
+    """Archive an accepted OpenSpec change and sync accepted specs. Requires confirm=true to apply."""
+    root = _project_root(project_root)
+    change = _clean_name(change, "change")
+    command_result, payload = _archive_spec_change_result(root, change, confirm)
+    return {
+        **command_result,
+        "source": "openspec_archive",
+        "project_root": str(root),
+        "change": change,
+        "archive": payload,
+        "next": {
+            "apply": "Call again with confirm=true to apply the archive." if not confirm else "",
+            "status_tool": "scion_ops_spec_status",
         },
     }
 

--- a/scripts/archive-openspec-change.py
+++ b/scripts/archive-openspec-change.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Archive an accepted OpenSpec change and sync its delta specs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate-openspec-change.py"
+
+
+def _run_validator(project_root: Path, change: str) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            "python3",
+            str(VALIDATOR),
+            "--project-root",
+            str(project_root),
+            "--change",
+            change,
+            "--json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        payload = {
+            "ok": False,
+            "errors": [{"path": str(project_root), "message": result.stdout.strip()}],
+        }
+    payload["validator_returncode"] = result.returncode
+    return payload
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _archive_path(root: Path, change: str) -> Path:
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    archive_root = root / "openspec" / "changes" / "archive"
+    candidate = archive_root / f"{date}-{change}"
+    if not candidate.exists():
+        return candidate
+    suffix = datetime.now(timezone.utc).strftime("%H%M%S")
+    return archive_root / f"{date}-{change}-{suffix}"
+
+
+def _spec_title(path: Path) -> str:
+    domain = path.parent.name.replace("-", " ").replace("_", " ").strip()
+    return f"{domain.title()} Specification" if domain else "Specification"
+
+
+def _sync_spec(source: Path, target: Path, root: Path, change: str) -> dict[str, str]:
+    source_rel = _relative(source, root)
+    target_rel = _relative(target, root)
+    marker_start = f"<!-- scion-ops:accepted-change {change} source={source_rel} -->"
+    marker_end = f"<!-- /scion-ops:accepted-change {change} -->"
+    source_text = source.read_text(errors="replace").strip()
+    block = f"\n\n{marker_start}\n{source_text}\n{marker_end}\n"
+
+    if target.exists():
+        existing = target.read_text(errors="replace")
+        if marker_start in existing:
+            return {"source": source_rel, "target": target_rel, "action": "already_synced"}
+        target.write_text(existing.rstrip() + block)
+        return {"source": source_rel, "target": target_rel, "action": "appended"}
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"# {_spec_title(target)}\n\n## Accepted Changes{block}")
+    return {"source": source_rel, "target": target_rel, "action": "created"}
+
+
+def archive_change(project_root: Path, change: str, apply: bool) -> dict[str, Any]:
+    root = project_root.expanduser().resolve()
+    validation = _run_validator(root, change)
+    change_path = root / "openspec" / "changes" / change
+    archive_path = _archive_path(root, change)
+    spec_sources = [root / path for path in validation.get("spec_files", [])]
+
+    plan = {
+        "ok": bool(validation.get("ok")),
+        "dry_run": not apply,
+        "project_root": str(root),
+        "change": change,
+        "change_path": _relative(change_path, root),
+        "archive_path": _relative(archive_path, root),
+        "validation": validation,
+        "synced_specs": [],
+    }
+    if not validation.get("ok"):
+        plan["ok"] = False
+        return plan
+
+    if not apply:
+        plan["synced_specs"] = [
+            {
+                "source": _relative(source, root),
+                "target": _relative(root / "openspec" / "specs" / source.relative_to(change_path / "specs"), root),
+                "action": "would_sync",
+            }
+            for source in spec_sources
+        ]
+        return plan
+
+    synced_specs = []
+    try:
+        for source in spec_sources:
+            target = root / "openspec" / "specs" / source.relative_to(change_path / "specs")
+            synced_specs.append(_sync_spec(source, target, root, change))
+
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(change_path), str(archive_path))
+    except OSError as exc:
+        plan["ok"] = False
+        plan["errors"] = [{"path": _relative(root, root), "message": f"{type(exc).__name__}: {exc}"}]
+        plan["synced_specs"] = synced_specs
+        return plan
+    plan["synced_specs"] = synced_specs
+    plan["dry_run"] = False
+    plan["ok"] = True
+    return plan
+
+
+def _print_human(payload: dict[str, Any]) -> None:
+    action = "planned" if payload["dry_run"] else "archived"
+    print(f"OpenSpec change {payload['change']}: {action}")
+    print(f"project_root: {payload['project_root']}")
+    print(f"archive_path: {payload['archive_path']}")
+    if not payload["ok"]:
+        print("errors:")
+        for item in payload.get("errors", []):
+            print(f"  - {item.get('path')}: {item.get('message')}")
+        for item in payload.get("validation", {}).get("errors", []):
+            print(f"  - {item.get('path')}: {item.get('message')}")
+    if payload["synced_specs"]:
+        print("synced_specs:")
+        for item in payload["synced_specs"]:
+            print(f"  - {item['source']} -> {item['target']} ({item['action']})")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-root", default=".", help="target project root")
+    parser.add_argument("--change", required=True, help="OpenSpec change name")
+    parser.add_argument("--yes", action="store_true", help="apply the archive and spec sync")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    payload = archive_change(Path(args.project_root), args.change, apply=args.yes)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(payload)
+        if not args.yes and payload["ok"]:
+            print("Re-run with --yes to apply.")
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-mcp-server.py
+++ b/scripts/smoke-mcp-server.py
@@ -29,6 +29,7 @@ REQUIRED_TOOLS = {
     "scion_ops_start_round",
     "scion_ops_validate_spec_change",
     "scion_ops_spec_status",
+    "scion_ops_archive_spec_change",
     "scion_ops_start_spec_round",
     "scion_ops_start_impl_round",
     "scion_ops_look",

--- a/scripts/test-openspec-archive.py
+++ b/scripts/test-openspec-archive.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Exercise the OpenSpec archive lifecycle on a sample project."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCHIVER = ROOT / "scripts" / "archive-openspec-change.py"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _sample(root: Path) -> None:
+    change = root / "openspec" / "changes" / "add-widget"
+    _write(change / "proposal.md", "# Proposal: Add Widget\n\n## Scope\n\nAdd widget behavior.\n")
+    _write(change / "design.md", "# Design: Add Widget\n\nUse the existing widget path.\n")
+    _write(change / "tasks.md", "# Tasks\n\n- [x] 1.1 Add widget behavior\n")
+    _write(
+        change / "specs" / "widgets" / "spec.md",
+        "# Delta for Widgets\n\n"
+        "## ADDED Requirements\n\n"
+        "### Requirement: Widget Creation\n"
+        "The system SHALL create a widget.\n\n"
+        "#### Scenario: Create widget\n"
+        "- GIVEN a valid request\n"
+        "- WHEN the widget is created\n"
+        "- THEN the widget is visible\n",
+    )
+
+
+def _run(root: Path, *extra: str) -> tuple[int, dict[str, object]]:
+    result = subprocess.run(
+        [
+            "python3",
+            str(ARCHIVER),
+            "--project-root",
+            str(root),
+            "--change",
+            "add-widget",
+            "--json",
+            *extra,
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return result.returncode, json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _sample(root)
+
+        code, payload = _run(root)
+        assert code == 0, payload
+        assert payload["dry_run"] is True, payload
+        assert payload["synced_specs"][0]["action"] == "would_sync", payload
+        assert (root / "openspec" / "changes" / "add-widget").exists()
+
+        code, payload = _run(root, "--yes")
+        assert code == 0, payload
+        assert payload["dry_run"] is False, payload
+        assert not (root / "openspec" / "changes" / "add-widget").exists()
+        assert payload["archive_path"].startswith("openspec/changes/archive/"), payload
+        archived = root / payload["archive_path"]
+        assert (archived / "proposal.md").exists()
+        accepted = root / "openspec" / "specs" / "widgets" / "spec.md"
+        text = accepted.read_text()
+        assert "scion-ops:accepted-change add-widget" in text
+        assert "Requirement: Widget Creation" in text
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #50.

## Summary
- add `task spec:archive` to validate, sync accepted delta specs, and archive completed changes
- add `scion_ops_archive_spec_change` and archived-change reporting in `scion_ops_spec_status`
- document the archive lifecycle in the workflow and Zed MCP docs
- add a sample lifecycle test for dry-run, archive, accepted spec sync, and archive inspection

## Verification
- `task verify`
- `task dev:mcp:restart`
- `task kind:mcp:smoke` reports 20 tools and requires the archive tool
- MCP `scion_ops_archive_spec_change(confirm=true)` succeeded against a temporary mounted target repo; follow-up `scion_ops_spec_status` showed no active changes and one archive entry

## Notes
- The archive sync preserves accepted deltas under `openspec/specs/**/spec.md` with `scion-ops:accepted-change` markers.