### PR TITLE
Define smoke test tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ task build      # build all Scion and scion-ops images
 task up         # create/update kind and apply the Kubernetes control plane
 task bootstrap  # restore Hub credentials, harness configs, and templates
 task test       # smoke test Hub, broker, MCP, and Kubernetes agent dispatch
+task release:smoke  # opt-in subscription-backed round smoke
 task down       # destroy the local kind deployment
 ```
 
@@ -166,6 +167,13 @@ SCION_OPS_PROJECT_ROOT=/home/david/workspace/github/example/project task round -
 The MCP tool `scion_ops_start_round` accepts the same target as `project_root`.
 Agents work from the target repo's Hub grove and branch context; uncommitted
 local work is not included unless it is committed or pushed before the round.
+
+Use `task test` for frequent no-spend health checks. Use `task release:smoke`
+only when you want release confidence from a bounded subscription-backed round:
+it bootstraps the target repo, starts a short Claude/Codex round, and defaults
+to Gemini final review. Override with
+`SCION_OPS_RELEASE_SMOKE_FINAL_REVIEWER=codex` when Gemini capacity or auth is
+not part of the check.
 
 If a round reaches its watchdog limit, scion-ops stops the round agents and
 keeps their Hub records for inspection. Use `task abort -- <round_id>` when the

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,6 +79,11 @@ tasks:
     cmds:
       - task kind:control-plane:smoke -- {{.CLI_ARGS}}
 
+  release:smoke:
+    desc: Start an opt-in subscription-backed release smoke round.
+    cmds:
+      - bash scripts/release-smoke-round.sh {{.CLI_ARGS}}
+
   bootstrap:
     desc: Restore Hub secrets, harness configs, and templates for rounds.
     cmds:
@@ -351,4 +356,4 @@ tasks:
       - python3 scripts/test-openspec-change-validator.py
       - python3 scripts/test-openspec-archive.py
       - python3 scripts/test-verdict-schema.py
-      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/release-smoke-round.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -179,6 +179,17 @@ This dispatches the checked-in no-auth generic smoke config through the Kubernet
 Hub and co-located broker, verifies that an agent pod appears in kind, checks
 MCP Hub status through HTTP, and deletes the smoke agent after success.
 
+`task test` is deliberately no-auth and no-spend. For release confidence, run
+the opt-in model-backed tier:
+
+```bash
+task release:smoke
+```
+
+That command bootstraps the selected target, starts a short Claude/Codex round,
+and defaults to Gemini final review. It is intended for release checks or model
+credential changes, not every local edit.
+
 Useful overrides:
 
 | Variable | Default |

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -2,6 +2,30 @@
 
 The supported verification path is Kubernetes-only.
 
+## Smoke Tiers
+
+| Tier | Command | Model spend | Purpose |
+|---|---|---:|---|
+| Static | `task verify` | no | Check task surface, syntax, and repo-local validators. |
+| Cheap control plane | `task test` | no | Prove kind, Hub, broker, MCP, and Kubernetes no-auth agent dispatch. |
+| Release round | `task release:smoke` | yes | Prove subscription-backed Claude, Codex, and final reviewer credentials in Kubernetes. |
+
+Keep `task test` as the frequent local health check. It must stay no-auth and
+no-spend so it is safe to run during normal iteration. Run
+`task release:smoke` only before a release, after credential changes, or when
+debugging model-backed round dispatch.
+
+`task release:smoke` defaults to:
+
+- `SCION_OPS_RELEASE_SMOKE_MAX_MINUTES=8`
+- `SCION_OPS_RELEASE_SMOKE_MAX_REVIEW_ROUNDS=1`
+- `SCION_OPS_RELEASE_SMOKE_FINAL_REVIEWER=gemini`
+
+The command bootstraps the selected target repo unless
+`SCION_OPS_RELEASE_SMOKE_BOOTSTRAP=0` is set. Use
+`SCION_OPS_RELEASE_SMOKE_FINAL_REVIEWER=codex` when the release check should
+avoid Gemini capacity or auth.
+
 ## Lifecycle Check
 
 Use this sequence for a full local validation:
@@ -63,18 +87,20 @@ task verify
 This checks whitespace, task listing, and Python syntax without trying to
 recreate the Kubernetes cluster.
 
-## Known Test Gap
+## Failure Classes
 
-The Kubernetes smoke still uses the checked-in generic no-auth smoke config, so
-it proves broker dispatch and MCP readiness without spending subscription model
-usage. The next full validation is a short `scion_ops_start_round` call against
-a clean target branch after `task bootstrap` passes. That round should use
-Scion's explicit `auth-file` harness authentication path for Claude, Codex,
-and optional Gemini final review, including Claude's companion `CLAUDE_CONFIG`
-state file with Scion's `/workspace` checkout marked trusted and
-bypass-permissions startup accepted for the Kubernetes agent sandbox. The
-bootstrapped Claude config should not carry host-local MCP server registrations
-into agent pods, and the Claude round templates should use native Scion
-`command_args` to pass `--print` so the prompt is submitted immediately. Codex
-is the default final reviewer; Gemini is an explicit option with Codex fallback
-when capacity or auth prevents a verdict.
+Use the nearest failing tier to classify problems:
+
+| Class | Signals | First check |
+|---|---|---|
+| Setup | missing tools, broken task surface, invalid manifests or scripts | `task verify` |
+| Hub | unhealthy Hub, missing dev auth, missing grove link, missing Hub secrets | `task kind:hub:status` and `task bootstrap` |
+| Broker | no broker provider, broker auth failure, dispatch rejected before pod creation | `task kind:broker:status` |
+| Kubernetes runtime | no agent pod, pod stuck, image pull, RBAC, or namespace errors | `kubectl --context kind-scion-ops -n scion-agents get pods` |
+| MCP | HTTP service unavailable or missing tool surface | `task kind:mcp:smoke` |
+| Model credentials | Claude, Codex, or Gemini agent starts but cannot authenticate or produce output | `task release:smoke` plus `scion_ops_watch_round_events` |
+
+The release tier uses Scion's explicit `auth-file` harness authentication path
+for Claude, Codex, and optional Gemini final review. It validates that
+`CLAUDE_AUTH`, `CLAUDE_CONFIG`, `CODEX_AUTH`, and `GEMINI_OAUTH_CREDS` have
+been restored as Hub secrets by `task bootstrap`.

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -129,6 +129,19 @@ The external agent should call `scion_ops_project_status` first, then
 on a clean branch with any important local work committed or pushed; Kubernetes
 agents work from git branches, not uncommitted editor state.
 
+For a release smoke through MCP, keep it explicit because it uses subscription
+credentials:
+
+```text
+Use scion-ops on project_root=/home/david/workspace/github/example/project.
+Start a short release smoke round with max_minutes=8, max_review_rounds=1, and final_reviewer=gemini:
+"Make the smallest safe README wording improvement, verify it, push the branch, and report the PR-ready branch name."
+Monitor it with event watching.
+```
+
+The external agent should call `scion_ops_start_round` with those bounded
+arguments, then `scion_ops_watch_round_events`.
+
 When the target repo is not checked out yet, pass a GitHub URL:
 
 ```text

--- a/scripts/release-smoke-round.sh
+++ b/scripts/release-smoke-round.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Start an opt-in subscription-backed Scion round for release confidence.
+set -euo pipefail
+
+die() {
+  printf '\033[31m%s\033[0m\n' "$*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_ROOT_INPUT="${1:-${SCION_OPS_PROJECT_ROOT:-$REPO_ROOT}}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
+PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" || die "target project is not a git repo: $PROJECT_ROOT"
+
+ROUND_ID="${ROUND_ID:-release-smoke-$(date -u +%Y%m%dT%H%M%SZ)}"
+MAX_MINUTES="${SCION_OPS_RELEASE_SMOKE_MAX_MINUTES:-8}"
+MAX_REVIEW_ROUNDS="${SCION_OPS_RELEASE_SMOKE_MAX_REVIEW_ROUNDS:-1}"
+FINAL_REVIEWER="${SCION_OPS_RELEASE_SMOKE_FINAL_REVIEWER:-gemini}"
+PROMPT="${SCION_OPS_RELEASE_SMOKE_PROMPT:-}"
+
+case "$FINAL_REVIEWER" in
+  gemini|codex) ;;
+  *) die "SCION_OPS_RELEASE_SMOKE_FINAL_REVIEWER must be gemini or codex" ;;
+esac
+
+if [[ -z "$PROMPT" ]]; then
+  PROMPT=$(cat <<'EOF'
+Release smoke: make the smallest safe README wording improvement, verify it,
+push the resulting branch, and report the PR-ready branch name. Keep the change
+minimal; this run exists to prove subscription-backed Claude, Codex, and final
+reviewer credentials in Kubernetes.
+EOF
+)
+fi
+
+if [[ "${SCION_OPS_RELEASE_SMOKE_BOOTSTRAP:-1}" != "0" ]]; then
+  task bootstrap -- "$PROJECT_ROOT"
+fi
+
+cat <<EOF
+release smoke
+  project_root:       $PROJECT_ROOT
+  round_id:           $ROUND_ID
+  max_minutes:        $MAX_MINUTES
+  max_review_rounds:  $MAX_REVIEW_ROUNDS
+  final_reviewer:     $FINAL_REVIEWER
+
+This is an opt-in model-backed test. It starts Claude/Codex round agents and
+uses the selected final reviewer. Use task test for frequent no-spend checks.
+EOF
+
+SCION_OPS_PROJECT_ROOT="$PROJECT_ROOT" \
+ROUND_ID="$ROUND_ID" \
+MAX_MINUTES="$MAX_MINUTES" \
+MAX_REVIEW_ROUNDS="$MAX_REVIEW_ROUNDS" \
+FINAL_REVIEWER="$FINAL_REVIEWER" \
+task round -- "$PROMPT"


### PR DESCRIPTION
Closes #52.\n\n## Summary\n- Document static, cheap control-plane, and opt-in release round smoke tiers.\n- Keep task test as the no-auth/no-spend Kubernetes health check.\n- Add task release:smoke with bounded defaults for subscription-backed Claude/Codex rounds and Gemini final review.\n- Document failure classes for setup, Hub, broker, Kubernetes runtime, MCP, and model credentials.\n\n## Verification\n- task verify\n- task test -- --skip-setup\n\nThe subscription-backed release smoke command was not run in this PR because it is intentionally opt-in and consumes model subscription usage.