### PR TITLE
Restore Hub dev auth through Kubernetes Secret

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -62,22 +62,24 @@ runtime pods.
 Exit criteria: for non-local clusters, replace this with a cloned workspace or
 persistent workspace volume managed by explicit bootstrap/restore tasks.
 
-## kind MCP Hub Dev Token Sharing
+## kind Hub Dev Auth Secret Restore
 
-Issue: #31
+Issue: #53
 
-Decision: the local kind MCP Deployment mounts the Hub PVC read-only and reads
-the Hub dev-auth token from `/hub-state/dev-token`.
+Decision: the local kind Hub remains dev-auth based, but `task bootstrap`
+mirrors the active Hub dev-auth token into the `scion-hub-dev-auth`
+Kubernetes Secret. The MCP Deployment reads that Secret through
+`SCION_DEV_TOKEN_FILE` and does not mount the Hub PVC.
 
-Reason: the current kind Hub slice is intentionally dev-auth based and does not
-yet restore a Kubernetes Secret for Hub auth material. Sharing the generated
-token lets the MCP server use the Hub HTTP API without introducing a separate
-bootstrap system in this slice.
+Reason: the Hub still generates and persists the local dev token in its own
+state, but MCP should consume an explicit Kubernetes auth resource rather than
+read Hub storage. `task kind:hub:auth-export` falls back to the Hub pod only
+before bootstrap has restored the Secret.
 
-Constraint: this is local-kind only. The MCP pod can read Hub state from
-the PVC, so it must be treated as a privileged control-plane component.
+Constraint: this is local-kind only. Dev auth remains unsuitable for
+non-kind Kubernetes deployments.
 
-Exit criteria: replace PVC token sharing with explicit Secret restore before
+Exit criteria: replace dev auth with the supported production auth model before
 supporting non-kind Kubernetes deployments.
 
 ## kind Co-Located Broker First

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ come later only if the values and lifecycle model justify it.
 The kind Hub uses a stable `SCION_SERVER_HUB_HUBID` so Hub-scoped bootstrap
 secrets remain visible after Hub pod rollouts. The Hub deployment runs the
 Scion binary from `localhost/scion-base:latest`; persistent Hub state must not
-override the image binary.
+override the image binary. Bootstrap mirrors the local Hub dev-auth token into
+the `scion-hub-dev-auth` Kubernetes Secret so MCP authenticates through a
+Kubernetes resource rather than the Hub state PVC.
 
 ## MCP And Zed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -287,7 +287,10 @@ tasks:
     silent: true
     cmds:
       - |
-        token="$(kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- cat /home/scion/.scion/dev-token)"
+        token="$(kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get secret scion-hub-dev-auth -o jsonpath='{.data.dev-token}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+        if [ -z "$token" ]; then
+          token="$(kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- cat /home/scion/.scion/dev-token)"
+        fi
         printf 'export SCION_HUB_ENDPOINT=%s\n' '{{.SCION_OPS_KIND_HUB_URL}}'
         printf 'export HUB_ENDPOINT=%s\n' '{{.SCION_OPS_KIND_HUB_URL}}'
         printf 'export SCION_DEV_TOKEN=%s\n' "$token"

--- a/deploy/kind/control-plane/mcp-deployment.yaml
+++ b/deploy/kind/control-plane/mcp-deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: SCION_HUB_ENDPOINT
               value: http://scion-hub:8090
             - name: SCION_DEV_TOKEN_FILE
-              value: /hub-state/dev-token
+              value: /run/secrets/scion-hub-dev-auth/dev-token
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -104,8 +104,8 @@ spec:
               mountPath: /workspace
             - name: checkouts
               mountPath: /home/scion/checkouts
-            - name: hub-state
-              mountPath: /hub-state
+            - name: hub-dev-auth
+              mountPath: /run/secrets/scion-hub-dev-auth
               readOnly: true
       volumes:
         - name: workspace
@@ -115,7 +115,7 @@ spec:
         - name: checkouts
           persistentVolumeClaim:
             claimName: scion-ops-mcp-checkouts
-        - name: hub-state
-          persistentVolumeClaim:
-            claimName: scion-hub-state
-            readOnly: true
+        - name: hub-dev-auth
+          secret:
+            secretName: scion-hub-dev-auth
+            optional: true

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -166,6 +166,9 @@ Hub is available at `http://192.168.122.103:18090`; MCP is available at
 The kind Hub sets `SCION_SERVER_HUB_HUBID` to `scion-ops-kind`. Scion
 namespaces Hub-scoped secrets by Hub ID, so this value must stay stable across
 Hub pod rollouts or bootstrap credentials will become invisible after restart.
+`task bootstrap` also mirrors the active Hub dev-auth token into the
+`scion-hub-dev-auth` Kubernetes Secret. MCP reads that Secret and no longer
+mounts the Hub state PVC for auth.
 
 ## Smoke Test
 
@@ -246,7 +249,7 @@ Deleting the kind cluster deletes cluster-local Scion state.
 |---|---|---|
 | Hub database/state | `scion-hub-state` PVC | yes |
 | Hub ID | `SCION_SERVER_HUB_HUBID=scion-ops-kind` in `deploy/kind/control-plane/hub-deployment.yaml` | no |
-| Hub dev token | `scion-hub-state` PVC | yes |
+| Hub dev token | `scion-hub-state` PVC, mirrored to `scion-hub-dev-auth` by `task bootstrap` | yes |
 | Broker registration | Hub state for co-located broker | yes |
 | MCP workspace | host checkout mounted into kind node | no |
 | MCP-prepared GitHub checkouts | `scion-ops-mcp-checkouts` PVC | yes |

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -43,7 +43,7 @@ credentials, harness configs, and templates before a round is started.
 
 - kind cluster and workspace mount
 - Kubernetes control-plane rollout
-- kind-hosted Hub dev auth
+- kind-hosted Hub dev auth and restored `scion-hub-dev-auth` Secret
 - co-located Runtime Broker status
 - HTTP MCP service readiness
 - Hub-backed MCP status call
@@ -94,7 +94,7 @@ Use the nearest failing tier to classify problems:
 | Class | Signals | First check |
 |---|---|---|
 | Setup | missing tools, broken task surface, invalid manifests or scripts | `task verify` |
-| Hub | unhealthy Hub, missing dev auth, missing grove link, missing Hub secrets | `task kind:hub:status` and `task bootstrap` |
+| Hub | unhealthy Hub, missing dev auth Secret, missing grove link, missing Hub secrets | `task kind:hub:status` and `task bootstrap` |
 | Broker | no broker provider, broker auth failure, dispatch rejected before pod creation | `task kind:broker:status` |
 | Kubernetes runtime | no agent pod, pod stuck, image pull, RBAC, or namespace errors | `kubectl --context kind-scion-ops -n scion-agents get pods` |
 | MCP | HTTP service unavailable or missing tool surface | `task kind:mcp:smoke` |

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -111,9 +111,9 @@ MCP checkout PVC at `/home/scion/checkouts/github` by default. Use the returned
 ## Tool State
 
 The MCP pod reads Hub state through the in-cluster `scion-hub` Service and
-uses the Hub dev token mounted read-only from the Hub PVC. Treat this MCP
-service as a privileged project-control interface. Do not expose it outside a
-trusted local tunnel, VPN, or authenticated ingress.
+uses the `scion-hub-dev-auth` Kubernetes Secret restored by `task bootstrap`.
+Treat this MCP service as a privileged project-control interface. Do not expose
+it outside a trusted local tunnel, VPN, or authenticated ingress.
 
 ## Rounds
 

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -70,6 +70,30 @@ run_in_hub() {
   kubectl_ctx -n "$NAMESPACE" exec "$pod" -c hub -- sh -lc "$command"
 }
 
+restore_hub_dev_auth_secret() {
+  local token="$1"
+  local token_file
+  [[ "$token" == scion_dev_* ]] || die "refusing to restore invalid Hub dev token"
+  token_file="$(mktemp "${TMPDIR:-/tmp}/scion-hub-dev-token.XXXXXX")"
+  chmod 0600 "$token_file"
+  printf '%s\n' "$token" > "$token_file"
+  if ! kubectl_ctx -n "$NAMESPACE" create secret generic scion-hub-dev-auth \
+    --from-file=dev-token="$token_file" \
+    --dry-run=client \
+    -o yaml | kubectl_ctx -n "$NAMESPACE" apply -f - >/dev/null; then
+    rm -f "$token_file"
+    return 1
+  fi
+  rm -f "$token_file"
+  log "restored Kubernetes Secret scion-hub-dev-auth"
+}
+
+restart_mcp_for_hub_auth_secret() {
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-ops-mcp >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-ops-mcp --timeout=120s >/dev/null
+  log "restarted MCP after Hub auth Secret restore"
+}
+
 github_token() {
   if [[ -n "${GITHUB_TOKEN:-}" ]]; then
     printf '%s' "$GITHUB_TOKEN"
@@ -210,9 +234,11 @@ sync_harness_configs() {
 
   log "sync harness configs from inside Hub pod"
   local hub_url
+  local token
   hub_url="$(sh_quote "$HUB_IN_CLUSTER")"
+  token="$(sh_quote "$SCION_DEV_TOKEN")"
   for config in "${configs[@]}"; do
-    run_in_hub "$pod" "SCION_DEV_TOKEN=\$(cat /home/scion/.scion/dev-token) SCION_HUB_ENDPOINT=${hub_url} scion harness-config sync ${config} --hub ${hub_url} --non-interactive --yes"
+    run_in_hub "$pod" "SCION_DEV_TOKEN=${token} SCION_HUB_ENDPOINT=${hub_url} scion harness-config sync ${config} --hub ${hub_url} --non-interactive --yes"
   done
 }
 
@@ -229,8 +255,10 @@ sync_templates() {
 
   log "sync templates from inside Hub pod"
   local hub_url
+  local token
   hub_url="$(sh_quote "$HUB_IN_CLUSTER")"
-  run_in_hub "$pod" "SCION_DEV_TOKEN=\$(cat /home/scion/.scion/dev-token) SCION_HUB_ENDPOINT=${hub_url} scion --global templates sync --all --hub ${hub_url} --non-interactive --yes"
+  token="$(sh_quote "$SCION_DEV_TOKEN")"
+  run_in_hub "$pod" "SCION_DEV_TOKEN=${token} SCION_HUB_ENDPOINT=${hub_url} scion --global templates sync --all --hub ${hub_url} --non-interactive --yes"
 }
 
 main() {
@@ -243,9 +271,11 @@ main() {
 
   log "read kind Hub auth"
   load_hub_auth
+  restore_hub_dev_auth_secret "$SCION_DEV_TOKEN"
 
   log "wait for Hub and MCP rollouts"
   task kind:control-plane:status >/dev/null
+  restart_mcp_for_hub_auth_secret
 
   log "link target grove and provide broker ${BROKER}"
   log "target project: ${PROJECT_ROOT}"


### PR DESCRIPTION
Closes #53.

## Summary
- Restore the active kind Hub dev token into the scion-hub-dev-auth Kubernetes Secret during task bootstrap.
- Change MCP to read SCION_DEV_TOKEN_FILE from that Secret and remove the Hub PVC mount from the MCP deployment.
- Keep kind:hub:auth-export working from the Secret, with a pre-bootstrap Hub-pod fallback for fresh clusters.
- Update docs and KNOWNISSUES to resolve the MCP Hub PVC token-sharing exception.

## Verification
- task verify
- task kind:control-plane:apply
- task bootstrap
- kubectl rollout restart deploy/scion-hub deploy/scion-ops-mcp
- task kind:control-plane:status
- task kind:mcp:smoke
- task test -- --skip-setup
- kind:hub:auth-export returned a scion_dev_* token without printing it

I also rotated the local kind dev token after catching a PR body shell-expansion mistake, then reran Hub/MCP rollout status and task kind:mcp:smoke successfully. I did not run full task x because this change does not modify image build inputs; the deployment/bootstrap/test path was exercised directly.