### PR TITLE
Restore Hub web session state

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -26,21 +26,23 @@ can stay simple, native, and reproducible from this repo.
 
 ## kind Hub Dev Auth
 
-Issue: #31
+Issue: #54
 
-Decision: the first in-kind Hub slice runs `scion server start` with explicit
-Hub/Web components and dev auth enabled.
+Decision: the in-kind Hub runs `scion server start` with explicit Hub/Web
+components and dev auth enabled. `task bootstrap` restores the dev-auth token
+as `scion-hub-dev-auth`, restores the web session signing secret as
+`scion-hub-web-session`, and sets Hub `TMPDIR` to the Hub PVC so filesystem
+session data survives Hub pod restarts.
 
 Reason: `--production` prevents workstation defaults from starting extra
-components, while `--dev-auth` keeps the local kind Hub usable before OAuth,
-broker credentials, and secret restore are implemented.
+components, while `--dev-auth` keeps the local kind Hub usable before the
+project supports a non-kind production auth model.
 
-Constraint: this is local-kind only. The web session secret is
-auto-generated on pod start, so browser sessions do not survive Hub pod
-restarts.
+Constraint: this is local-kind only. Browser session continuity depends on
+`task bootstrap` having restored the session Secret and restarted Hub.
 
-Exit criteria: replace dev-only auth/session behavior with Kubernetes Secret
-restore before supporting non-kind Kubernetes deployments.
+Exit criteria: replace dev-only auth/session behavior with the supported
+production auth model before supporting non-kind Kubernetes deployments.
 
 ## kind MCP Workspace HostPath
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ secrets remain visible after Hub pod rollouts. The Hub deployment runs the
 Scion binary from `localhost/scion-base:latest`; persistent Hub state must not
 override the image binary. Bootstrap mirrors the local Hub dev-auth token into
 the `scion-hub-dev-auth` Kubernetes Secret so MCP authenticates through a
-Kubernetes resource rather than the Hub state PVC.
+Kubernetes resource rather than the Hub state PVC. It also restores the
+`scion-hub-web-session` Secret and stores Hub web session files on the Hub PVC
+so browser sessions behave predictably across Hub pod restarts after bootstrap.
 
 ## MCP And Zed
 

--- a/deploy/kind/control-plane/hub-deployment.yaml
+++ b/deploy/kind/control-plane/hub-deployment.yaml
@@ -56,8 +56,16 @@ spec:
               value: scion
             - name: KUBECONFIG
               value: /home/scion/.kube/config
+            - name: TMPDIR
+              value: /home/scion/.scion/tmp
             - name: SCION_SERVER_HUB_HUBID
               value: scion-ops-kind
+            - name: SCION_SERVER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: scion-hub-web-session
+                  key: session-secret
+                  optional: true
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -169,6 +169,9 @@ Hub pod rollouts or bootstrap credentials will become invisible after restart.
 `task bootstrap` also mirrors the active Hub dev-auth token into the
 `scion-hub-dev-auth` Kubernetes Secret. MCP reads that Secret and no longer
 mounts the Hub state PVC for auth.
+Bootstrap restores `scion-hub-web-session` as the Hub web session signing
+Secret and sets Hub `TMPDIR` to the Hub PVC, so filesystem-backed browser
+session records and the signing key survive Hub pod restarts after bootstrap.
 
 ## Smoke Test
 
@@ -250,6 +253,7 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Hub database/state | `scion-hub-state` PVC | yes |
 | Hub ID | `SCION_SERVER_HUB_HUBID=scion-ops-kind` in `deploy/kind/control-plane/hub-deployment.yaml` | no |
 | Hub dev token | `scion-hub-state` PVC, mirrored to `scion-hub-dev-auth` by `task bootstrap` | yes |
+| Hub web sessions | `scion-hub-web-session` Secret plus session files under `scion-hub-state` PVC | yes |
 | Broker registration | Hub state for co-located broker | yes |
 | MCP workspace | host checkout mounted into kind node | no |
 | MCP-prepared GitHub checkouts | `scion-ops-mcp-checkouts` PVC | yes |

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -43,7 +43,7 @@ credentials, harness configs, and templates before a round is started.
 
 - kind cluster and workspace mount
 - Kubernetes control-plane rollout
-- kind-hosted Hub dev auth and restored `scion-hub-dev-auth` Secret
+- kind-hosted Hub dev auth and restored Hub auth/session Secrets
 - co-located Runtime Broker status
 - HTTP MCP service readiness
 - Hub-backed MCP status call
@@ -94,7 +94,7 @@ Use the nearest failing tier to classify problems:
 | Class | Signals | First check |
 |---|---|---|
 | Setup | missing tools, broken task surface, invalid manifests or scripts | `task verify` |
-| Hub | unhealthy Hub, missing dev auth Secret, missing grove link, missing Hub secrets | `task kind:hub:status` and `task bootstrap` |
+| Hub | unhealthy Hub, missing dev auth/session Secret, missing grove link, missing Hub secrets | `task kind:hub:status` and `task bootstrap` |
 | Broker | no broker provider, broker auth failure, dispatch rejected before pod creation | `task kind:broker:status` |
 | Kubernetes runtime | no agent pod, pod stuck, image pull, RBAC, or namespace errors | `kubectl --context kind-scion-ops -n scion-agents get pods` |
 | MCP | HTTP service unavailable or missing tool surface | `task kind:mcp:smoke` |

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -112,6 +112,8 @@ MCP checkout PVC at `/home/scion/checkouts/github` by default. Use the returned
 
 The MCP pod reads Hub state through the in-cluster `scion-hub` Service and
 uses the `scion-hub-dev-auth` Kubernetes Secret restored by `task bootstrap`.
+Hub web session signing state is restored separately as
+`scion-hub-web-session`.
 Treat this MCP service as a privileged project-control interface. Do not expose
 it outside a trusted local tunnel, VPN, or authenticated ingress.
 

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -55,6 +55,27 @@ run_scion() {
   (cd "$PROJECT_ROOT" && SCION_HUB_ENDPOINT="$HUB_PUBLIC" SCION_DEV_TOKEN="$SCION_DEV_TOKEN" "$SCION_BIN" "$@")
 }
 
+wait_for_public_hub() {
+  local attempt
+  log "wait for public Hub endpoint ${HUB_PUBLIC}"
+  for attempt in $(seq 1 30); do
+    if python3 - "$HUB_PUBLIC" <<'PY' >/dev/null 2>&1
+import sys
+import urllib.request
+
+endpoint = sys.argv[1].rstrip("/") + "/healthz"
+with urllib.request.urlopen(endpoint, timeout=2) as response:
+    if response.status != 200:
+        raise SystemExit(1)
+PY
+    then
+      return
+    fi
+    sleep 2
+  done
+  die "Hub at ${HUB_PUBLIC} did not become ready"
+}
+
 hub_pod() {
   local pod
   pod="$(kubectl_ctx -n "$NAMESPACE" get pod \
@@ -88,10 +109,40 @@ restore_hub_dev_auth_secret() {
   log "restored Kubernetes Secret scion-hub-dev-auth"
 }
 
-restart_mcp_for_hub_auth_secret() {
-  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-ops-mcp >/dev/null
+restore_hub_web_session_secret() {
+  local existing
+  local session_secret
+  local secret_file
+  existing="$(kubectl_ctx -n "$NAMESPACE" get secret scion-hub-web-session -o jsonpath='{.data.session-secret}' 2>/dev/null || true)"
+  if [[ -n "$existing" ]]; then
+    log "preserved Kubernetes Secret scion-hub-web-session"
+    return
+  fi
+
+  session_secret="$(python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+  secret_file="$(mktemp "${TMPDIR:-/tmp}/scion-hub-session.XXXXXX")"
+  chmod 0600 "$secret_file"
+  printf '%s\n' "$session_secret" > "$secret_file"
+  if ! kubectl_ctx -n "$NAMESPACE" create secret generic scion-hub-web-session \
+    --from-file=session-secret="$secret_file" \
+    --dry-run=client \
+    -o yaml | kubectl_ctx -n "$NAMESPACE" apply -f - >/dev/null; then
+    rm -f "$secret_file"
+    return 1
+  fi
+  rm -f "$secret_file"
+  log "restored Kubernetes Secret scion-hub-web-session"
+}
+
+restart_control_plane_for_restored_auth_state() {
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-hub deploy/scion-ops-mcp >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-hub --timeout=120s >/dev/null
   kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-ops-mcp --timeout=120s >/dev/null
-  log "restarted MCP after Hub auth Secret restore"
+  log "restarted Hub and MCP after auth/session Secret restore"
 }
 
 github_token() {
@@ -272,10 +323,12 @@ main() {
   log "read kind Hub auth"
   load_hub_auth
   restore_hub_dev_auth_secret "$SCION_DEV_TOKEN"
+  restore_hub_web_session_secret
 
   log "wait for Hub and MCP rollouts"
   task kind:control-plane:status >/dev/null
-  restart_mcp_for_hub_auth_secret
+  restart_control_plane_for_restored_auth_state
+  wait_for_public_hub
 
   log "link target grove and provide broker ${BROKER}"
   log "target project: ${PROJECT_ROOT}"


### PR DESCRIPTION
Closes #54.

## Summary
- Restore scion-hub-web-session from task bootstrap and preserve it across bootstrap runs.
- Set Hub SCION_SERVER_SESSION_SECRET from that Secret and move Hub TMPDIR onto the Hub PVC so filesystem-backed web sessions survive pod restarts.
- Restart Hub and MCP after auth/session Secret restore, then wait for the host-facing Hub health endpoint before linking/providing the target grove.
- Narrow the kind Hub dev auth known issue and update docs.

## Verification
- task verify
- task kind:control-plane:apply
- task bootstrap
- confirmed Hub TMPDIR is /home/scion/.scion/tmp, session directory exists, and SCION_SERVER_SESSION_SECRET is present
- confirmed scion-hub-web-session Secret exists
- task kind:mcp:smoke
- task test -- --skip-setup
- Hub logs after restart do not contain the random session secret warning

I did not run full task x because no image build inputs changed; the deployment/bootstrap/test path was exercised directly.