### PR TITLE
Split kind runtime broker into dedicated deployment

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -84,24 +84,26 @@ non-kind Kubernetes deployments.
 Exit criteria: replace dev auth with the supported production auth model before
 supporting non-kind Kubernetes deployments.
 
-## kind Co-Located Broker First
+## kind Dedicated Broker Registration
 
-Issue: #31
+Issue: #55
 
-Decision: the first in-kind Runtime Broker slice runs inside the Hub pod by
-enabling Scion's co-located Hub+broker server mode.
+Decision: the in-kind Runtime Broker runs as its own `scion-broker`
+Deployment. Bootstrap uses Scion's native `broker register` flow when the Hub
+does not already show the broker as connected, stores the resulting HMAC
+credential JSON in the `scion-broker-credentials` Kubernetes Secret, restarts
+the broker, and waits for the Hub control-channel connection.
 
-Reason: a separate broker Deployment needs a reliable HMAC credential bootstrap
-or restore path before it can join Hub mode safely. The co-located Scion server
-path already creates the broker record and broker secret in Hub state, which is
-enough for the local kind control plane to prove Kubernetes runtime access
-without custom registration plumbing.
+Reason: the Hub and Runtime Broker now follow Scion's separate-process Hub mode
+instead of the embedded server shortcut, while broker credentials remain
+restorable through Kubernetes-managed state.
 
-Constraint: this is a local-kind control-plane shape. The broker binds
-to loopback inside the Hub pod and is not exposed as a Kubernetes Service.
+Constraint: this remains a local-kind control-plane shape. The broker API binds
+inside the broker pod; Hub dispatch normally reaches it through Scion's
+control-channel path rather than a public Service.
 
-Exit criteria: add a separate broker Deployment only after the project has an
-explicit broker credential restore or registration bootstrap flow.
+Exit criteria: for non-kind clusters, define the longer-lived broker credential
+rotation and backup policy alongside the workspace persistence model.
 
 ## kind Hub Local Storage Uploads
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scion-ops
 
 Kubernetes-only operating layer for running dueling Scion agents against a
-Scion Hub, co-located Runtime Broker, HTTP MCP server, and agent pods.
+Scion Hub, dedicated Runtime Broker, HTTP MCP server, and agent pods.
 
 The supported deployment target is Kubernetes. Local development uses `kind`
 with Podman as the default provider.
@@ -86,8 +86,10 @@ auth prevents a verdict.
 kind cluster:
   scion-hub Deployment
     Hub/API/Web
-    co-located Kubernetes Runtime Broker
     PVC-backed Scion state
+  scion-broker Deployment
+    Kubernetes Runtime Broker
+    Secret-backed Hub HMAC credentials
   scion-ops-mcp Deployment
     streamable HTTP MCP server
     mounted host workspace tree
@@ -110,6 +112,11 @@ the `scion-hub-dev-auth` Kubernetes Secret so MCP authenticates through a
 Kubernetes resource rather than the Hub state PVC. It also restores the
 `scion-hub-web-session` Secret and stores Hub web session files on the Hub PVC
 so browser sessions behave predictably across Hub pod restarts after bootstrap.
+The Runtime Broker runs as its own Deployment and restores its Hub join
+credential from the `scion-broker-credentials` Secret. If the Secret is missing
+or stale, `task bootstrap` runs Scion's native broker registration flow,
+recreates the Secret, restarts the broker, and waits for the Hub control-channel
+connection before providing the target grove.
 
 ## MCP And Zed
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,6 +152,12 @@ tasks:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub
       - task: kind:hub:status
 
+  update:broker:
+    cmds:
+      - task kind:load-images -- localhost/scion-base:latest
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-broker
+      - task: kind:broker:status
+
   update:mcp:
     cmds:
       - task kind:load-images -- localhost/scion-ops-mcp:latest
@@ -239,13 +245,13 @@ tasks:
 
   kind:control-plane:restart:
     cmds:
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub deploy/scion-ops-mcp
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub deploy/scion-broker deploy/scion-ops-mcp
 
   kind:control-plane:status:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-broker --timeout=120s
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-ops-mcp --timeout=120s
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- scion --global broker status --json
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc,pvc,cm -l app.kubernetes.io/part-of=scion-control-plane
 
   kind:control-plane:logs:
@@ -276,7 +282,6 @@ tasks:
   kind:hub:status:
     cmds:
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- scion --global broker status --json
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' get deploy,svc,pvc,cm -l app.kubernetes.io/part-of=scion-control-plane
 
   kind:hub:logs:
@@ -297,12 +302,12 @@ tasks:
 
   kind:broker:status:
     cmds:
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-hub -c hub -- scion --global broker status --json
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-broker --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' exec deploy/scion-broker -c broker -- scion --global broker status --json
 
   kind:broker:logs:
     cmds:
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-hub -c hub
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' logs -f deploy/scion-broker -c broker
 
   kind:mcp:status:
     cmds:
@@ -359,4 +364,4 @@ tasks:
       - python3 scripts/test-openspec-change-validator.py
       - python3 scripts/test-openspec-archive.py
       - python3 scripts/test-verdict-schema.py
-      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/release-smoke-round.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh
+      - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/release-smoke-round.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh deploy/kind/control-plane/config/broker-entrypoint.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/deploy/kind/control-plane/broker-deployment.yaml
+++ b/deploy/kind/control-plane/broker-deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scion-broker
+  labels:
+    app.kubernetes.io/name: scion-broker
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scion-broker
+      app.kubernetes.io/component: broker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: scion-broker
+        app.kubernetes.io/component: broker
+        app.kubernetes.io/part-of: scion-control-plane
+    spec:
+      serviceAccountName: scion-control-plane
+      hostname: kind-control-plane
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: broker
+          image: localhost/scion-base:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - /etc/scion/broker-entrypoint.sh
+          env:
+            - name: HOME
+              value: /home/scion
+            - name: USER
+              value: scion
+            - name: LOGNAME
+              value: scion
+            - name: KUBECONFIG
+              value: /home/scion/.kube/config
+            - name: SCION_BROKER_CREDENTIAL_NAME
+              value: in-cluster
+            - name: SCION_BROKER_PORT
+              value: "9800"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          ports:
+            - name: broker
+              containerPort: 9800
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          volumeMounts:
+            - name: state
+              mountPath: /home/scion/.scion
+            - name: settings
+              mountPath: /home/scion/.scion/settings.yaml
+              subPath: settings.yaml
+              readOnly: true
+            - name: kubeconfig
+              mountPath: /home/scion/.kube
+              readOnly: true
+            - name: broker-credentials
+              mountPath: /run/secrets/scion-broker-credentials
+              readOnly: true
+            - name: entrypoint
+              mountPath: /etc/scion/broker-entrypoint.sh
+              subPath: broker-entrypoint.sh
+              readOnly: true
+            - name: bootstrap-server-config
+              mountPath: /etc/scion/broker-bootstrap-server.yaml
+              subPath: server.yaml
+              readOnly: true
+            - name: bootstrap-settings
+              mountPath: /etc/scion/broker-bootstrap-settings.yaml
+              subPath: settings.yaml
+              readOnly: true
+      volumes:
+        - name: state
+          emptyDir: {}
+        - name: settings
+          configMap:
+            name: scion-hub-settings
+        - name: kubeconfig
+          configMap:
+            name: scion-broker-kubeconfig
+        - name: broker-credentials
+          secret:
+            secretName: scion-broker-credentials
+            optional: true
+        - name: entrypoint
+          configMap:
+            name: scion-broker-entrypoint
+            defaultMode: 0555
+        - name: bootstrap-server-config
+          configMap:
+            name: scion-broker-bootstrap-server
+        - name: bootstrap-settings
+          configMap:
+            name: scion-broker-bootstrap-settings

--- a/deploy/kind/control-plane/broker-rbac.yaml
+++ b/deploy/kind/control-plane/broker-rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: scion-control-plane
   labels:
-    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/name: scion-broker
     app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: scion-control-plane
 ---
@@ -12,7 +12,7 @@ kind: Role
 metadata:
   name: scion-control-plane-broker
   labels:
-    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/name: scion-broker
     app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: scion-control-plane
 rules:
@@ -37,7 +37,7 @@ kind: RoleBinding
 metadata:
   name: scion-control-plane-broker
   labels:
-    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/name: scion-broker
     app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: scion-control-plane
 subjects:
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   name: scion-control-plane-broker-namespaces
   labels:
-    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/name: scion-broker
     app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: scion-control-plane
 rules:
@@ -66,7 +66,7 @@ kind: ClusterRoleBinding
 metadata:
   name: scion-control-plane-broker-namespaces
   labels:
-    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/name: scion-broker
     app.kubernetes.io/component: broker
     app.kubernetes.io/part-of: scion-control-plane
 subjects:

--- a/deploy/kind/control-plane/config/broker-bootstrap-server.yaml
+++ b/deploy/kind/control-plane/config/broker-bootstrap-server.yaml
@@ -1,0 +1,2 @@
+runtimeBroker:
+  host: 127.0.0.1

--- a/deploy/kind/control-plane/config/broker-bootstrap-settings.yaml
+++ b/deploy/kind/control-plane/config/broker-bootstrap-settings.yaml
@@ -1,0 +1,14 @@
+schema_version: "1"
+active_profile: kind
+image_registry: localhost
+server:
+  broker:
+    host: 127.0.0.1
+runtimes:
+  kubernetes:
+    type: kubernetes
+    context: in-cluster
+    namespace: scion-agents
+profiles:
+  kind:
+    runtime: kubernetes

--- a/deploy/kind/control-plane/config/broker-entrypoint.sh
+++ b/deploy/kind/control-plane/config/broker-entrypoint.sh
@@ -1,0 +1,31 @@
+set -eu
+
+credential_name="${SCION_BROKER_CREDENTIAL_NAME:-in-cluster}"
+broker_port="${SCION_BROKER_PORT:-9800}"
+secret_credential_file="/run/secrets/scion-broker-credentials/${credential_name}.json"
+credential_dir="${HOME}/.scion/hub-credentials"
+credential_file="${credential_dir}/${credential_name}.json"
+
+mkdir -p "${HOME}/.scion" "${credential_dir}"
+
+if [ -f "${secret_credential_file}" ]; then
+  cp "${secret_credential_file}" "${credential_file}"
+  chmod 0700 "${credential_dir}"
+  chmod 0600 "${credential_file}"
+  exec scion --global server start \
+    --foreground \
+    --production \
+    --enable-runtime-broker \
+    --runtime-broker-port "${broker_port}"
+fi
+
+bootstrap_home="${SCION_BROKER_BOOTSTRAP_HOME:-/tmp/scion-broker-bootstrap}"
+mkdir -p "${bootstrap_home}/.scion"
+cp /etc/scion/broker-bootstrap-settings.yaml "${bootstrap_home}/.scion/settings.yaml"
+
+exec env HOME="${bootstrap_home}" scion --global server start \
+  --foreground \
+  --production \
+  --enable-runtime-broker \
+  --config /etc/scion/broker-bootstrap-server.yaml \
+  --runtime-broker-port "${broker_port}"

--- a/deploy/kind/control-plane/hub-deployment.yaml
+++ b/deploy/kind/control-plane/hub-deployment.yaml
@@ -19,7 +19,6 @@ spec:
         app.kubernetes.io/component: hub
         app.kubernetes.io/part-of: scion-control-plane
     spec:
-      serviceAccountName: scion-control-plane
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
@@ -37,7 +36,6 @@ spec:
             - --production
             - --enable-hub
             - --enable-web
-            - --enable-runtime-broker
             - --dev-auth
             - --host
             - 0.0.0.0
@@ -54,8 +52,6 @@ spec:
               value: scion
             - name: LOGNAME
               value: scion
-            - name: KUBECONFIG
-              value: /home/scion/.kube/config
             - name: TMPDIR
               value: /home/scion/.scion/tmp
             - name: SCION_SERVER_HUB_HUBID
@@ -74,8 +70,6 @@ spec:
           ports:
             - name: http
               containerPort: 8090
-            - name: broker
-              containerPort: 9800
           readinessProbe:
             httpGet:
               path: /healthz
@@ -102,9 +96,6 @@ spec:
               mountPath: /home/scion/.scion/settings.yaml
               subPath: settings.yaml
               readOnly: true
-            - name: kubeconfig
-              mountPath: /home/scion/.kube
-              readOnly: true
       volumes:
         - name: state
           persistentVolumeClaim:
@@ -112,6 +103,3 @@ spec:
         - name: settings
           configMap:
             name: scion-hub-settings
-        - name: kubeconfig
-          configMap:
-            name: scion-broker-kubeconfig

--- a/deploy/kind/control-plane/kustomization.yaml
+++ b/deploy/kind/control-plane/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: scion-agents
 resources:
   - broker-rbac.yaml
+  - broker-deployment.yaml
   - hub-pvc.yaml
   - hub-service.yaml
   - hub-deployment.yaml
@@ -19,6 +20,15 @@ configMapGenerator:
   - name: scion-broker-kubeconfig
     files:
       - config=config/broker-kubeconfig.yaml
+  - name: scion-broker-entrypoint
+    files:
+      - broker-entrypoint.sh=config/broker-entrypoint.sh
+  - name: scion-broker-bootstrap-server
+    files:
+      - server.yaml=config/broker-bootstrap-server.yaml
+  - name: scion-broker-bootstrap-settings
+    files:
+      - settings.yaml=config/broker-bootstrap-settings.yaml
   - name: scion-hub-settings
     files:
       - settings.yaml=config/hub-settings.yaml

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -56,8 +56,12 @@ deploy/kind/
   smoke/
     generic-smoke-agent.yaml
   control-plane/
+    broker-deployment.yaml
     broker-rbac.yaml
     config/
+      broker-bootstrap-server.yaml
+      broker-bootstrap-settings.yaml
+      broker-entrypoint.sh
       broker-kubeconfig.yaml
       hub-settings.yaml
     hub-deployment.yaml
@@ -84,11 +88,10 @@ literal Kubernetes YAML bodies.
 
 ## Control-Plane Shape
 
-The Hub Deployment runs:
+The Kubernetes control plane includes:
 
-- Scion Hub/API/Web
-- Scion's co-located Runtime Broker
-- PVC-backed mutable Scion state
+- a Hub Deployment for Scion Hub/API/Web and PVC-backed Hub state
+- a dedicated Runtime Broker Deployment
 - an in-cluster Kubernetes runtime profile
 
 The MCP Deployment runs the scion-ops streamable HTTP MCP server and reads Hub
@@ -97,7 +100,9 @@ host workspace tree via a kind node `extraMount` and Kubernetes `hostPath`, so
 tools operate on the mounted git checkout selected by `project_root`.
 
 The broker creates agent pods in `scion-agents` using in-cluster Kubernetes API
-access. It does not use host Podman or Docker sockets.
+access. It restores Hub HMAC credentials from the `scion-broker-credentials`
+Secret and connects back to the Hub over Scion's control channel. It does not
+use host Podman or Docker sockets.
 
 ## Development Loop
 
@@ -182,7 +187,7 @@ task test
 ```
 
 This dispatches the checked-in no-auth generic smoke config through the Kubernetes-hosted
-Hub and co-located broker, verifies that an agent pod appears in kind, checks
+Hub and dedicated broker, verifies that an agent pod appears in kind, checks
 MCP Hub status through HTTP, and deletes the smoke agent after success.
 
 `task test` is deliberately no-auth and no-spend. For release confidence, run
@@ -254,7 +259,7 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Hub ID | `SCION_SERVER_HUB_HUBID=scion-ops-kind` in `deploy/kind/control-plane/hub-deployment.yaml` | no |
 | Hub dev token | `scion-hub-state` PVC, mirrored to `scion-hub-dev-auth` by `task bootstrap` | yes |
 | Hub web sessions | `scion-hub-web-session` Secret plus session files under `scion-hub-state` PVC | yes |
-| Broker registration | Hub state for co-located broker | yes |
+| Broker registration | Hub state plus `scion-broker-credentials` Secret restored by `task bootstrap` | yes |
 | MCP workspace | host checkout mounted into kind node | no |
 | MCP-prepared GitHub checkouts | `scion-ops-mcp-checkouts` PVC | yes |
 | Agent artifacts | Hub agent records and pushed git branches | pod-local state is ephemeral |

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -44,7 +44,7 @@ credentials, harness configs, and templates before a round is started.
 - kind cluster and workspace mount
 - Kubernetes control-plane rollout
 - kind-hosted Hub dev auth and restored Hub auth/session Secrets
-- co-located Runtime Broker status
+- dedicated Runtime Broker registration and control-channel status
 - HTTP MCP service readiness
 - Hub-backed MCP status call
 - no-auth generic agent dispatch through the broker

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -13,7 +13,11 @@ CLUSTER_NAME="${KIND_CLUSTER_NAME:-scion-ops}"
 CONTEXT="${KIND_CONTEXT:-kind-${CLUSTER_NAME}}"
 NAMESPACE="${SCION_K8S_NAMESPACE:-scion-agents}"
 BROKER="${SCION_KIND_CP_BROKER:-kind-control-plane}"
+BROKER_CREDENTIAL_NAME="${SCION_KIND_CP_BROKER_CREDENTIAL_NAME:-in-cluster}"
+BROKER_CREDENTIAL_SECRET="${SCION_KIND_CP_BROKER_CREDENTIAL_SECRET:-scion-broker-credentials}"
+BROKER_BOOTSTRAP_HOME="${SCION_BROKER_BOOTSTRAP_HOME:-/tmp/scion-broker-bootstrap}"
 HUB_IN_CLUSTER="${SCION_OPS_KIND_IN_CLUSTER_HUB_URL:-http://127.0.0.1:8090}"
+HUB_FOR_BROKER="${SCION_OPS_KIND_BROKER_HUB_URL:-http://scion-hub:8090}"
 HUB_PUBLIC="${SCION_HUB_ENDPOINT:-${HUB_ENDPOINT:-${SCION_OPS_KIND_HUB_URL:-http://${SCION_OPS_KIND_LISTEN_ADDRESS:-192.168.122.103}:${SCION_OPS_KIND_HUB_PORT:-18090}}}}"
 SCION_BIN="${SCION_BIN:-scion}"
 HARNESS_CONFIG_ROOT="${SCION_OPS_HARNESS_CONFIG_ROOT:-${HOME}/.scion/harness-configs}"
@@ -85,10 +89,31 @@ hub_pod() {
   printf '%s\n' "$pod"
 }
 
+broker_pod() {
+  local pod
+  pod="$(kubectl_ctx -n "$NAMESPACE" get pod \
+    -l app.kubernetes.io/name=scion-broker \
+    -o jsonpath='{.items[0].metadata.name}')"
+  [[ -n "$pod" ]] || die "scion-broker pod not found in ${CONTEXT}/${NAMESPACE}; run task up"
+  printf '%s\n' "$pod"
+}
+
 run_in_hub() {
   local pod="$1"
   local command="$2"
   kubectl_ctx -n "$NAMESPACE" exec "$pod" -c hub -- sh -lc "$command"
+}
+
+run_in_broker() {
+  local pod="$1"
+  local command="$2"
+  kubectl_ctx -n "$NAMESPACE" exec "$pod" -c broker -- sh -lc "$command"
+}
+
+wait_for_control_plane_rollouts() {
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-hub --timeout=120s >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-broker --timeout=120s >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-ops-mcp --timeout=120s >/dev/null
 }
 
 restore_hub_dev_auth_secret() {
@@ -139,10 +164,125 @@ PY
 }
 
 restart_control_plane_for_restored_auth_state() {
-  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-hub deploy/scion-ops-mcp >/dev/null
-  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-hub --timeout=120s >/dev/null
-  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-ops-mcp --timeout=120s >/dev/null
-  log "restarted Hub and MCP after auth/session Secret restore"
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-hub deploy/scion-broker deploy/scion-ops-mcp >/dev/null
+  wait_for_control_plane_rollouts
+  log "restarted Hub, broker, and MCP after auth/session Secret restore"
+}
+
+restore_broker_credentials_secret() {
+  local pod="$1"
+  local credential_file
+  credential_file="$(mktemp "${TMPDIR:-/tmp}/scion-broker-credentials.XXXXXX.json")"
+  chmod 0600 "$credential_file"
+
+  if ! kubectl_ctx -n "$NAMESPACE" exec "$pod" -c broker -- \
+    cat "${BROKER_BOOTSTRAP_HOME}/.scion/hub-credentials/${BROKER_CREDENTIAL_NAME}.json" >"$credential_file"; then
+    rm -f "$credential_file"
+    return 1
+  fi
+
+  python3 - "$credential_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+missing = [key for key in ("brokerId", "secretKey", "hubEndpoint") if not data.get(key)]
+if missing:
+    raise SystemExit(f"broker credential file is missing: {', '.join(missing)}")
+PY
+
+  if ! kubectl_ctx -n "$NAMESPACE" create secret generic "$BROKER_CREDENTIAL_SECRET" \
+    --from-file="${BROKER_CREDENTIAL_NAME}.json=${credential_file}" \
+    --dry-run=client \
+    -o yaml | kubectl_ctx -n "$NAMESPACE" apply -f - >/dev/null; then
+    rm -f "$credential_file"
+    return 1
+  fi
+  rm -f "$credential_file"
+  kubectl_ctx -n "$NAMESPACE" label secret "$BROKER_CREDENTIAL_SECRET" \
+    app.kubernetes.io/name=scion-broker \
+    app.kubernetes.io/component=broker \
+    app.kubernetes.io/part-of=scion-control-plane \
+    --overwrite >/dev/null
+  log "restored Kubernetes Secret ${BROKER_CREDENTIAL_SECRET}"
+}
+
+broker_credentials_secret_exists() {
+  kubectl_ctx -n "$NAMESPACE" get secret "$BROKER_CREDENTIAL_SECRET" >/dev/null 2>&1
+}
+
+broker_control_channel_ready() {
+  local pod
+  pod="$(broker_pod)"
+  kubectl_ctx -n "$NAMESPACE" logs "$pod" -c broker 2>/dev/null |
+    grep -q "Connected to Hub control channel"
+}
+
+broker_connection_ready() {
+  local info
+  broker_credentials_secret_exists || return 1
+  broker_control_channel_ready || return 1
+
+  if ! info="$(run_scion hub brokers info "$BROKER" --json --non-interactive 2>/dev/null)"; then
+    return 1
+  fi
+
+  BROKER_INFO="$info" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["BROKER_INFO"])
+if isinstance(data, dict) and isinstance(data.get("broker"), dict):
+    data = data["broker"]
+
+status = str(data.get("status") or data.get("brokerStatus") or "").lower()
+connection = str(data.get("connectionState") or data.get("connection_state") or "").lower()
+
+if status == "online" and connection in ("", "connected"):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+wait_for_broker_connection() {
+  local attempt
+  log "wait for dedicated broker ${BROKER} to connect to Hub"
+  for attempt in $(seq 1 30); do
+    if broker_connection_ready; then
+      return
+    fi
+    sleep 2
+  done
+  die "broker ${BROKER} did not become connected"
+}
+
+ensure_broker_registration() {
+  local pod
+  local hub_url
+  local token
+  local credential_name
+  local bootstrap_home
+
+  if broker_connection_ready; then
+    log "dedicated broker ${BROKER} is already connected"
+    return
+  fi
+
+  pod="$(broker_pod)"
+  hub_url="$(sh_quote "$HUB_FOR_BROKER")"
+  token="$(sh_quote "$SCION_DEV_TOKEN")"
+  credential_name="$(sh_quote "$BROKER_CREDENTIAL_NAME")"
+  bootstrap_home="$(sh_quote "$BROKER_BOOTSTRAP_HOME")"
+
+  log "register dedicated broker ${BROKER} with Hub"
+  run_in_broker "$pod" "HOME=${bootstrap_home} SCION_HUB_ENDPOINT=${hub_url} HUB_ENDPOINT=${hub_url} SCION_DEV_TOKEN=${token} scion --global broker register --hub ${hub_url} --name ${credential_name} --force --auto-provide --non-interactive --yes >/tmp/scion-broker-register.log 2>&1 || { cat /tmp/scion-broker-register.log >&2; exit 1; }"
+  restore_broker_credentials_secret "$pod"
+
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-broker >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-broker --timeout=120s >/dev/null
+  wait_for_broker_connection
 }
 
 github_token() {
@@ -325,10 +465,11 @@ main() {
   restore_hub_dev_auth_secret "$SCION_DEV_TOKEN"
   restore_hub_web_session_secret
 
-  log "wait for Hub and MCP rollouts"
-  task kind:control-plane:status >/dev/null
+  log "wait for control-plane rollouts"
+  wait_for_control_plane_rollouts
   restart_control_plane_for_restored_auth_state
   wait_for_public_hub
+  ensure_broker_registration
 
   log "link target grove and provide broker ${BROKER}"
   log "target project: ${PROJECT_ROOT}"

--- a/scripts/kind-control-plane-smoke.py
+++ b/scripts/kind-control-plane-smoke.py
@@ -105,7 +105,7 @@ def hint_for_output(output: str, default: str) -> str:
     if category == "hub_auth":
         return 'Refresh kind Hub auth:\n  eval "$(task kind:hub:auth-export)"'
     if category == "broker_dispatch":
-        return "Check the co-located broker:\n  task kind:broker:status"
+        return "Check the dedicated broker:\n  task kind:broker:status"
     if category == "image":
         return IMAGE_HINT
     if category == "kubernetes":
@@ -336,7 +336,7 @@ def bootstrap_grove(
         ],
         env=env,
         category="broker_dispatch",
-        hint="Check the co-located broker:\n  task kind:broker:status",
+        hint="Check the dedicated broker:\n  task kind:broker:status",
         timeout=120,
     )
 
@@ -362,7 +362,7 @@ def verify_broker(
         ],
         env=env,
         category="broker_dispatch",
-        hint="Check the co-located broker:\n  task kind:broker:status",
+        hint="Check the dedicated broker:\n  task kind:broker:status",
         timeout=60,
     )
     try:
@@ -379,7 +379,15 @@ def verify_broker(
         raise SmokeFailure(
             "broker_dispatch",
             f"broker {broker} is not online: {status}",
-            hint="Check the co-located broker:\n  task kind:broker:status",
+            hint="Check the dedicated broker:\n  task kind:broker:status",
+            output=json.dumps(data, indent=2),
+        )
+    connection = str(data.get("connectionState") or data.get("connection_state") or "").lower()
+    if connection and connection != "connected":
+        raise SmokeFailure(
+            "broker_dispatch",
+            f"broker {broker} control channel is not connected: {connection}",
+            hint="Check the dedicated broker:\n  task kind:broker:status",
             output=json.dumps(data, indent=2),
         )
 


### PR DESCRIPTION
Closes #55

## Summary
- move the kind Runtime Broker out of the Hub pod into a dedicated scion-broker Deployment
- add native broker bootstrap/restore using scion broker register and the scion-broker-credentials Secret
- update task helpers, smoke checks, and docs for the dedicated broker control-plane shape

## Verification
- task verify
- kubectl kustomize deploy/kind/control-plane
- task bootstrap
- task kind:mcp:smoke
- task test -- --skip-setup

Runtime proof: broker logs show Connected to Hub control channel and task test dispatched a smoke agent through Hub to the dedicated broker pod.