### PR TITLE
Define workspace persistence model

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -44,25 +44,29 @@ Constraint: this is local-kind only. Browser session continuity depends on
 Exit criteria: replace dev-only auth/session behavior with the supported
 production auth model before supporting non-kind Kubernetes deployments.
 
-## kind MCP Workspace HostPath
+## Local kind MCP Workspace HostPath
 
-Issue: #31
+Issue: #56
 
 Decision: local kind clusters mount the host `scion-ops` checkout into the kind
 node with a kind `extraMount`, so the MCP pod can mount that node path with
-Kubernetes `hostPath`.
+Kubernetes `hostPath`. This remains a local development shortcut only. The
+accepted cluster workspace design is MCP-managed GitHub checkouts on persistent
+storage, with agent pods cloning from Git through Hub mode.
 
 Reason: the MCP server needs live repo access for git, task, Scion, and
 artifact inspection. In kind, pod `hostPath` volumes see the node container
 filesystem, so the host checkout must be mounted into the node before any MCP
-Deployment can use it.
+Deployment can use it. For clusters beyond kind, the same capability should be
+provided by a checkout PVC rather than a workstation bind mount.
 
 Constraint: this is local-kind only and is not an agent workspace pattern. Do
 not use workstation bind mounts for non-kind clusters or for Scion agent
 runtime pods.
 
-Exit criteria: for non-local clusters, replace this with a cloned workspace or
-persistent workspace volume managed by explicit bootstrap/restore tasks.
+Exit criteria: keep hostPath confined to kind manifests. Before adding a
+non-kind deployment target, package MCP without a `/workspace/scion-ops`
+source mount and make the MCP checkout PVC the target project workspace root.
 
 ## kind Hub Dev Auth Secret Restore
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ or stale, `task bootstrap` runs Scion's native broker registration flow,
 recreates the Secret, restarts the broker, and waits for the Hub control-channel
 connection before providing the target grove.
 
+Local kind uses the mounted host workspace for live development. The cluster
+workspace design is Git-based: MCP-managed target checkouts live on persistent
+storage and agent pods clone from Git through Hub mode. See
+`docs/workspace-persistence.md`.
+
 ## MCP And Zed
 
 The supported MCP transport is the Kubernetes-hosted HTTP service. `task up`
@@ -152,6 +157,7 @@ Smoke test the HTTP service with `task kind:mcp:smoke`. See `docs/zed-mcp.md`.
 - `docs/kind-scion-runtime.md` — kind runtime substrate details
 - `docs/openspec-round-workflow.md` — spec-driven round workflow design
 - `docs/testing-plan.md` — verification plan
+- `docs/workspace-persistence.md` — target project workspace persistence model
 - `docs/zed-mcp.md` — Kubernetes-hosted MCP registration
 - `mcp_servers/scion_ops.py` — streamable HTTP MCP server
 - `orchestrator/` — consensus round launcher and agent utilities

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -3,7 +3,8 @@
 This is the supported deployment path for scion-ops. Hub, Web/API, Runtime
 Broker, MCP, and Scion agent pods run in Kubernetes. For local development the
 cluster is `kind`; other Kubernetes clusters need an explicit persistence and
-workspace bootstrap model before they are supported.
+workspace bootstrap implementation before they are supported. The accepted
+workspace design is documented in `docs/workspace-persistence.md`.
 
 ## Operating Contract
 
@@ -98,6 +99,8 @@ The MCP Deployment runs the scion-ops streamable HTTP MCP server and reads Hub
 state through the `scion-hub` ClusterIP service. In local kind, MCP mounts the
 host workspace tree via a kind node `extraMount` and Kubernetes `hostPath`, so
 tools operate on the mounted git checkout selected by `project_root`.
+Cluster deployments should use MCP-managed Git checkouts on persistent storage
+instead of workstation bind mounts.
 
 The broker creates agent pods in `scion-agents` using in-cluster Kubernetes API
 access. It restores Hub HMAC credentials from the `scion-broker-credentials`
@@ -247,7 +250,9 @@ The MCP tool contract mirrors that shape: pass `project_root` to
 `scion_ops_watch_round_events`, and git diff/status tools when operating on a
 target project. If the target is only known by GitHub URL, call
 `scion_ops_prepare_github_repo` first and use the returned MCP-visible
-`project_root`.
+`project_root`. In local kind that path may resolve through the host workspace
+mount or the MCP checkout PVC. In cluster deployments it should resolve through
+the MCP checkout PVC.
 
 ## Persistence
 
@@ -260,8 +265,8 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Hub dev token | `scion-hub-state` PVC, mirrored to `scion-hub-dev-auth` by `task bootstrap` | yes |
 | Hub web sessions | `scion-hub-web-session` Secret plus session files under `scion-hub-state` PVC | yes |
 | Broker registration | Hub state plus `scion-broker-credentials` Secret restored by `task bootstrap` | yes |
-| MCP workspace | host checkout mounted into kind node | no |
-| MCP-prepared GitHub checkouts | `scion-ops-mcp-checkouts` PVC | yes |
+| MCP workspace | host checkout mounted into kind node; local-kind only | no |
+| MCP-prepared GitHub checkouts | `scion-ops-mcp-checkouts` PVC; cluster design treats this as the target checkout root | yes |
 | Agent artifacts | Hub agent records and pushed git branches | pod-local state is ephemeral |
 | Subscription credentials | Hub-scoped Claude, Codex, and Gemini secrets restored by `task bootstrap` | yes |
 | Vertex ADC credentials | optional Hub-scoped secrets restored only when `SCION_OPS_BOOTSTRAP_VERTEX_ADC=1`; cleared by default bootstrap | yes |

--- a/docs/kind-scion-runtime.md
+++ b/docs/kind-scion-runtime.md
@@ -52,6 +52,8 @@ The kind node is created with an `extraMount` from the host workspace tree to
 This is what lets one MCP server operate on multiple local git checkouts. The
 target repo must be under the mounted host workspace tree; otherwise recreate
 kind with `SCION_OPS_WORKSPACE_HOST_PATH` set to a common parent.
+This is a local kind behavior only. Cluster deployments should use the
+PVC-backed Git checkout model in `docs/workspace-persistence.md`.
 
 For GitHub URLs that are not checked out locally yet, the MCP Deployment uses
 the `scion-ops-mcp-checkouts` PVC at `/home/scion/checkouts/github`. That keeps

--- a/docs/workspace-persistence.md
+++ b/docs/workspace-persistence.md
@@ -1,0 +1,134 @@
+# Workspace Persistence Model
+
+This design defines how scion-ops should manage target project workspaces when
+the Kubernetes deployment moves beyond local kind.
+
+The product contract stays the same: an MCP client supplies a target project
+and a goal, scion-ops links that project to the Hub, and Scion agents solve the
+problem in Kubernetes through Hub-managed branches.
+
+## Principles
+
+- GitHub is the source of truth for target project content.
+- `project_root` means "the checkout visible to the MCP server".
+- Scion agent pods do not use the MCP checkout as their workspace. In Hub mode
+  agents clone from Git, work in pod-local storage, and push result branches.
+- Uncommitted editor buffers are not part of a round. Important work must be
+  committed or pushed before the round starts.
+- Workstation bind mounts are allowed only for the local kind development
+  substrate.
+- Cluster workspace cleanup must be explicit and must not delete dirty or
+  unpushed work by default.
+
+## Current kind Shape
+
+Local kind keeps two workspace sources:
+
+| Source | Path | Purpose | Persistence |
+|---|---|---|---|
+| Host workspace mount | `/workspace` | Live access to local checkouts, including scion-ops itself | Survives `task down` because it is host state |
+| MCP checkout PVC | `/home/scion/checkouts/github` | GitHub repos prepared by `scion_ops_prepare_github_repo` | Deleted with the kind cluster |
+
+The host mount is a local development convenience. It is not the cluster
+workspace model.
+
+## Cluster Shape
+
+Cluster deployments should not mount a workstation path. The intended shape is:
+
+| Component | Workspace responsibility |
+|---|---|
+| MCP image | Contains the scion-ops MCP server and repo operational scripts at a release path such as `/opt/scion-ops` |
+| MCP checkout PVC | Stores target project checkouts under `/home/scion/checkouts/github/<owner>/<repo>` |
+| Hub state PVC | Stores Hub records, grove links, templates, harness configs, and round metadata |
+| Runtime Broker | Starts agent pods through Scion's Kubernetes runtime |
+| Agent pods | Clone the target Git repo from Hub/GitHub, push branches, and discard pod-local workspace state on exit |
+
+For a GitHub target, the operator or external agent calls
+`scion_ops_prepare_github_repo(repo_url)`. The MCP server clones or reuses the
+repo in its checkout PVC and returns the MCP-visible `project_root`. All
+subsequent status, spec, round, and artifact calls use that returned path.
+
+For a target already known by path, the path must still resolve inside the MCP
+server's configured workspace roots. In cluster deployments that should normally
+mean the checkout PVC, not a node `hostPath`.
+
+## Lifecycle
+
+1. Prepare the repo.
+   `scion_ops_prepare_github_repo` resolves the GitHub URL, creates the owner
+   and repo directory, clones using the requested HTTPS or SSH URL, validates
+   that any existing checkout has the expected origin, and returns `project_root`.
+
+2. Bootstrap the target.
+   `task bootstrap -- <project_root>` or the equivalent MCP flow links the
+   checkout as a Hub grove, provides the Kubernetes broker, restores shared
+   credentials, and syncs templates and harness configs through the Hub pod.
+
+3. Start the round.
+   Scion starts agents through Hub mode. Agents clone from Git, create or update
+   round branches, push the branch result, and write Hub records.
+
+4. Inspect artifacts.
+   MCP artifact tools inspect Hub records, pushed branches, local checkout
+   state, and OpenSpec files where relevant. Hub and GitHub are the durable
+   artifacts; pod-local agent workspaces are not.
+
+5. Refresh or clean up.
+   A future workspace refresh command should fetch or reset only after checking
+   that the MCP checkout is clean or after an explicit force option. A future
+   prune command should delete only clean, pushed, inactive checkouts by default.
+
+## Persistent State
+
+| State | Required beyond kind | Restore policy |
+|---|---|---|
+| Hub database/state PVC | yes | Back up or retain across control-plane upgrades |
+| Stable Hub ID | yes | Keep as deployment config so Hub-scoped secrets remain addressable |
+| Broker HMAC credential Secret | yes | Recreate through native `scion broker register` or restore from backup |
+| Hub auth/session Secrets | yes | Replace kind dev auth with the supported production auth model before cluster support |
+| Hub-scoped model credentials | yes | Restore from operator-provided Kubernetes Secret or bootstrap source |
+| Templates and harness configs | yes | Re-sync from the scion-ops release image or repo source during bootstrap |
+| MCP checkout PVC | yes for convenience, no as source of truth | Retain for active workspaces; rebuild from Git if lost |
+| Agent pod workspaces | no | Ephemeral by design |
+| Round output branches | yes | Pushed to GitHub |
+
+The MCP checkout PVC may contain `.scion/grove-id` files and local spec files
+before they are pushed. It should be treated as useful state, but GitHub and Hub
+must remain the durable record for completed work.
+
+## Destroy And Cleanup
+
+Local kind keeps the simple contract:
+
+```bash
+task down
+```
+
+That deletes the kind cluster and all cluster-local PVCs and Secrets. Host
+workspace checkouts survive because they are outside the cluster.
+
+For cluster deployments, use two explicit modes:
+
+| Mode | Behavior |
+|---|---|
+| Teardown | Delete workloads, Services, ConfigMaps, and RBAC while retaining labeled PVCs and Secrets |
+| Purge | Delete the namespace or all labeled state after an explicit confirmation |
+
+All persistent resources should carry the scion-ops labels already used by the
+kind manifests, plus any future retention labels needed to distinguish
+rebuildable state from state that needs backup. Cleanup commands should refuse
+to delete a checkout that has uncommitted changes, unpushed branches, or an
+active Hub round unless forced.
+
+## Implementation Implications
+
+This issue is design-only. Implementation should be split into later PRs:
+
+- Package the MCP server source and operational scripts into the MCP image for
+  cluster deployments, instead of relying on `/workspace/scion-ops`.
+- Add a cluster overlay that omits the kind workspace `hostPath` and uses the
+  MCP checkout PVC as the target workspace root.
+- Add workspace list, refresh, and prune operations with dirty-workspace guards.
+- Add documented teardown and purge tasks once the non-kind deployment target
+  exists.

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -107,6 +107,9 @@ scion-ops and the target repo.
 Repo URLs prepared through `scion_ops_prepare_github_repo` are cloned into the
 MCP checkout PVC at `/home/scion/checkouts/github` by default. Use the returned
 `project_root`; it is the path visible to the MCP server and round launcher.
+That PVC-backed checkout path is the intended target-project model for
+cluster deployments. The host workspace mount is only the local kind
+development shortcut.
 
 ## Tool State
 


### PR DESCRIPTION
Closes #56

## Summary
- add a design doc for target-project workspace persistence beyond local kind
- narrow the kind hostPath exception to local development only
- document the intended cluster model: MCP-owned release code, PVC-backed GitHub checkouts, and Hub/GitHub as durable round records

## Verification
- task verify

## Design notes
No implementation is included in this PR. The follow-up implementation should package MCP source into the MCP image for cluster deployments, add a non-hostPath cluster overlay, and add workspace list/refresh/prune operations with dirty-checkout guards.