### PR TITLE
Document Kubernetes packaging decision

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -3,26 +3,28 @@
 Track intentional exceptions, unresolved risks, and design decisions that need
 revisit before they become hidden assumptions.
 
-## Kustomize-First Kubernetes Control Plane
+## Kubernetes Packaging Review Trigger
 
-Issue: #31
+Issue: #57
 
 Decision: keep the supported local Kubernetes deployment as native manifests
-and Kustomize, not Helm.
+and Kustomize. The dated packaging decision record is
+`docs/kubernetes-packaging.md`.
 
 Reason: the first implementation target is a local kind environment with a
 small resource set, minimal templating requirements, and an existing
 `kubectl apply -k deploy/kind` workflow. This keeps the day-zero path
 inspectable and avoids designing a chart values API before the resource model is
-proven. Kubernetes is the only supported deployment path; this decision is
-about packaging, not whether the control plane runs in Kubernetes.
+proven. Kubernetes is the only supported deployment path; this decision is about
+packaging, not whether the control plane runs in Kubernetes.
 
 Constraint: if configuration expands beyond a small local overlay, or if we
 need install/upgrade lifecycle from the console, move to Helm managed through a
 helmfile rather than ad hoc `helm install` commands.
 
-Exit criteria: Kustomize remains acceptable only while the control-plane config
-can stay simple, native, and reproducible from this repo.
+Exit criteria: re-open the packaging decision when the triggers in
+`docs/kubernetes-packaging.md` are met, especially when a non-kind cluster
+deployment target is added.
 
 ## kind Hub Dev Auth
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ host:
 
 The Kubernetes resources are native Kustomize manifests under `deploy/kind`.
 They are intentionally deployable with `kubectl apply -k`; Helm packaging can
-come later only if the values and lifecycle model justify it.
+come later only if the values and lifecycle model justify it. See
+`docs/kubernetes-packaging.md` for the review triggers.
 The kind Hub uses a stable `SCION_SERVER_HUB_HUBID` so Hub-scoped bootstrap
 secrets remain visible after Hub pod rollouts. The Hub deployment runs the
 Scion binary from `localhost/scion-base:latest`; persistent Hub state must not
@@ -155,6 +156,7 @@ Smoke test the HTTP service with `task kind:mcp:smoke`. See `docs/zed-mcp.md`.
 - `deploy/kind/` — Kubernetes resources for kind, Hub, broker, and MCP
 - `docs/kind-control-plane.md` — Kubernetes deployment model
 - `docs/kind-scion-runtime.md` — kind runtime substrate details
+- `docs/kubernetes-packaging.md` — Kustomize versus Helm packaging decision
 - `docs/openspec-round-workflow.md` — spec-driven round workflow design
 - `docs/testing-plan.md` — verification plan
 - `docs/workspace-persistence.md` — target project workspace persistence model

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -81,7 +81,9 @@ kubectl --context kind-scion-ops apply -k deploy/kind/control-plane
 ```
 
 Kustomize is intentional for the current resource size. Do not introduce Helm
-until the values model and upgrade behavior are worth packaging.
+until the values model and upgrade behavior are worth packaging. The packaging
+decision and Helm review triggers are documented in
+`docs/kubernetes-packaging.md`.
 
 Config payloads remain source files under `deploy/kind/control-plane/config`
 and are included with Kustomize `configMapGenerator`; scripts do not carry

--- a/docs/kubernetes-packaging.md
+++ b/docs/kubernetes-packaging.md
@@ -1,0 +1,108 @@
+# Kubernetes Packaging Decision
+
+Date: 2026-05-06
+
+Issue: #57
+
+## Decision
+
+Keep scion-ops Kubernetes resources as native manifests managed by Kustomize for
+the current local kind deployment.
+
+Do not introduce Helm yet. If the packaging model grows beyond Kustomize, move
+to a Helm chart managed by helmfile, not ad hoc `helm install` commands.
+
+The operator interface remains:
+
+```bash
+task up
+task test
+task down
+```
+
+Packaging changes must not change that top-level contract.
+
+## Why Kustomize Fits Now
+
+The current deployment has one supported runtime target: local kind. The
+resource set is small, native, and directly inspectable:
+
+- namespace and runtime RBAC
+- Hub Deployment, Service, and PVC
+- dedicated Runtime Broker Deployment and RBAC
+- MCP Deployment, Service, and checkout PVC
+- ConfigMaps generated from checked-in files
+- a checked-in no-auth smoke agent config
+
+Kustomize keeps these resources deployable with:
+
+```bash
+kubectl apply -k deploy/kind
+kubectl apply -k deploy/kind/control-plane
+```
+
+That matches the current need better than a chart values API. It also keeps the
+manifest files referenceable while the control-plane shape is still changing.
+
+## Helm Review Triggers
+
+Re-evaluate packaging when one or more of these becomes true:
+
+| Trigger | Why it matters |
+|---|---|
+| More than one supported non-kind cluster target exists | Repeated overlays may need a stable values schema |
+| Operators need install, diff, upgrade, and rollback lifecycle as a first-class workflow | Helm plus helmfile provides a standard release workflow |
+| Configuration becomes mostly parameterized rather than environment-specific overlays | A chart values API may become clearer than Kustomize patches |
+| The same resource changes need to be applied across several environments | helmfile can coordinate shared chart versions and per-environment values |
+| State retention policies need explicit release semantics | Helm hooks and helmfile ordering may be useful once stateful upgrades are real |
+
+These are not triggers by themselves:
+
+- adding a small number of native Kubernetes resources
+- adding another ConfigMap generated from a checked-in file
+- keeping local kind ports or workspace mounts separate from future cluster
+  overlays
+- wanting a one-line user command, because `task` already provides that
+
+## Required Helm Shape If We Move
+
+If the triggers are met, the accepted shape is:
+
+```text
+deploy/
+  chart/scion-ops/
+    Chart.yaml
+    values.yaml
+    templates/
+  helmfile.yaml
+  environments/
+    kind.yaml
+    cluster.yaml
+```
+
+Rules for that migration:
+
+- `task up`, `task test`, and `task down` remain the supported entry points.
+- Helm is invoked through helmfile tasks only.
+- No ad hoc `helm install`, `helm upgrade`, or `helm uninstall` commands become
+  part of docs or scripts.
+- Values files are checked in for non-secret defaults.
+- Secrets are referenced from Kubernetes Secrets or external secret tooling,
+  not embedded in chart values.
+- `helm template` output must be easy to inspect during review.
+- Kustomize and Helm must not both own the same live resource set.
+
+## Guardrails
+
+Kubernetes resources must stay source-controlled and reviewable. Scripts should
+not embed literal Kubernetes YAML bodies when a native manifest, Kustomize
+generator, or chart template is the clearer source of truth.
+
+The packaging layer should not decide runtime behavior. Runtime behavior stays
+in Scion, the Hub, the broker, MCP, and the checked-in task lifecycle.
+
+## Current Follow-up
+
+No implementation change is needed for this decision. The next packaging review
+should happen when scion-ops adds a non-kind cluster deployment target or when
+the control-plane configuration starts duplicating across overlays.


### PR DESCRIPTION
Closes #57

## Summary
- add a dated Kubernetes packaging decision record
- keep Kustomize as the current packaging path for local kind
- define review triggers and guardrails for a future Helm chart managed by helmfile
- update README, kind docs, and KNOWNISSUES to point at the decision

## Verification
- task verify

## Design notes
No Helm implementation or ad hoc Helm commands are introduced. The top-level task lifecycle remains the operator interface.