### PR TITLE
Make spec rounds repeatable

### DIFF
--- a/.scion/templates/spec-author/scion-agent.yaml
+++ b/.scion/templates/spec-author/scion-agent.yaml
@@ -1,6 +1,9 @@
 schema_version: "1"
 description: "Spec author - drafts OpenSpec proposal, delta specs, design, and tasks."
 default_harness_config: claude
+model: claude-sonnet-4-6
+command_args:
+  - --print
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 50

--- a/.scion/templates/spec-author/system-prompt.md
+++ b/.scion/templates/spec-author/system-prompt.md
@@ -24,6 +24,24 @@ question, write the question in the artifacts and report it.
   strategy.
 - `tasks.md`: checkbox tasks that are small enough for implementation rounds.
 
+## Validator Contract
+
+The repository validator accepts only the OpenSpec shape below. Satisfy it
+exactly before you commit:
+
+- `tasks.md` must contain checkbox task lines matching `- [ ] ...` or
+  `- [x] ...`. Tables alone are not sufficient.
+- At least one `specs/**/spec.md` file must contain a section named exactly
+  `## ADDED Requirements`, `## MODIFIED Requirements`, or
+  `## REMOVED Requirements`.
+- Each delta spec must include one or more requirement headings using exactly
+  `### Requirement: <name>`.
+- Each requirement must include one or more scenarios using exactly
+  `#### Scenario: <name>`.
+
+Run a local shell check for those markers if the target project does not carry
+the scion-ops validator script.
+
 Commit the artifact-only change, push your branch when `origin` is configured,
 send a summary to the coordinator with `scion message`, and mark completion
 with `sciontool status task_completed "<summary>"`.

--- a/.scion/templates/spec-consensus-runner/scion-agent.yaml
+++ b/.scion/templates/spec-consensus-runner/scion-agent.yaml
@@ -1,6 +1,9 @@
 schema_version: "1"
 description: "Spec consensus runner - coordinates OpenSpec artifact rounds without implementation changes."
 default_harness_config: claude
+model: claude-sonnet-4-6
+command_args:
+  - --print
 system_prompt: system-prompt.md
 max_turns: 80
 max_duration: 12m

--- a/.scion/templates/spec-consensus-runner/system-prompt.md
+++ b/.scion/templates/spec-consensus-runner/system-prompt.md
@@ -16,6 +16,10 @@ Use `sciontool status` throughout:
 - `sciontool status blocked "<question or blocker>"` when the round cannot proceed
 - `sciontool status task_completed "round <round_id> spec complete: <branch>"` on success
 
+Substitute real values in all commands. Never send literal angle-bracket
+placeholder text such as `<round_id>`, `<branch>`, or `<agent names>` in
+`sciontool status` or `scion message` output.
+
 When watching children, treat `activity: "completed"` as complete even if
 `phase` is still `running` for inspection.
 
@@ -62,8 +66,18 @@ The final PR-ready branch is `round-<round_id>-spec-integration`.
    `openspec/changes/<change>/design.md`,
    `openspec/changes/<change>/tasks.md`, and
    `openspec/changes/<change>/specs/**/spec.md`, then commits and pushes.
-6. Create or reset `round-<round_id>-spec-integration` from the author branch.
-7. Spawn the operations reviewer against a snapshot or the integration branch.
+   Require the author to satisfy the validator contract:
+   - `tasks.md` has `- [ ]` or `- [x]` checkbox task lines
+   - at least one delta spec has `## ADDED Requirements`,
+     `## MODIFIED Requirements`, or `## REMOVED Requirements`
+   - delta specs use `### Requirement: <name>` and
+     `#### Scenario: <name>` headings
+6. Create or reset `round-<round_id>-spec-integration` from the author branch:
+   - `git fetch origin round-<round_id>-spec-author`
+   - `git checkout -B round-<round_id>-spec-integration origin/round-<round_id>-spec-author`
+   - `git push origin HEAD:round-<round_id>-spec-integration`
+7. Spawn the operations reviewer against a snapshot or the integration branch
+   using template `spec-ops-reviewer`.
    Require a JSON verdict sent back with `scion message`. The reviewer must
    check OpenSpec structure, implementation readiness, unresolved questions,
    `CLAUDE.md`, Kubernetes-only operation, and task simplicity.

--- a/.scion/templates/spec-finalizer/system-prompt.md
+++ b/.scion/templates/spec-finalizer/system-prompt.md
@@ -12,8 +12,11 @@ artifacts. Ensure:
 
 - `proposal.md`, `design.md`, and `tasks.md` exist
 - at least one `specs/**/spec.md` delta spec exists
-- `tasks.md` uses checkbox tasks
-- requirements and scenarios are concrete enough to verify
+- `tasks.md` has checkbox task lines matching `- [ ] ...` or `- [x] ...`
+- each delta spec has `## ADDED Requirements`, `## MODIFIED Requirements`, or
+  `## REMOVED Requirements`
+- each delta spec has `### Requirement: <name>` and
+  `#### Scenario: <name>` markers with concrete, verifiable behavior
 - implementation readiness is clearly `ready` or `blocked`
 
 Commit and push `round-<round_id>-spec-integration`. Send a final summary to

--- a/.scion/templates/spec-goal-clarifier/scion-agent.yaml
+++ b/.scion/templates/spec-goal-clarifier/scion-agent.yaml
@@ -1,6 +1,9 @@
 schema_version: "1"
 description: "Spec goal clarifier - narrows the user goal before spec drafting."
 default_harness_config: claude
+model: claude-sonnet-4-6
+command_args:
+  - --print
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 30

--- a/.scion/templates/spec-ops-reviewer/system-prompt.md
+++ b/.scion/templates/spec-ops-reviewer/system-prompt.md
@@ -5,8 +5,12 @@ You review a spec artifact branch for implementation readiness.
 Do not modify files. Review only. Check:
 
 - OpenSpec layout and required artifact structure
-- clear requirements and scenarios
-- tasks are small, ordered, and verifiable
+- clear requirements and scenarios using exact OpenSpec markers:
+  `## ADDED Requirements`, `## MODIFIED Requirements`, or
+  `## REMOVED Requirements`, plus `### Requirement:` and
+  `#### Scenario:` headings
+- tasks are small, ordered, verifiable, and include `- [ ]` or `- [x]`
+  checkbox lines
 - design follows `CLAUDE.md`
 - Kubernetes-only operation remains the default
 - task commands remain simple and sane

--- a/deploy/kind/control-plane/broker-deployment.yaml
+++ b/deploy/kind/control-plane/broker-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/part-of: scion-control-plane
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: scion-broker

--- a/deploy/kind/control-plane/mcp-deployment.yaml
+++ b/deploy/kind/control-plane/mcp-deployment.yaml
@@ -74,6 +74,12 @@ spec:
               value: http://scion-hub:8090
             - name: SCION_DEV_TOKEN_FILE
               value: /run/secrets/scion-hub-dev-auth/dev-token
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: scion-github-token
+                  key: GITHUB_TOKEN
+                  optional: true
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -107,6 +113,9 @@ spec:
             - name: hub-dev-auth
               mountPath: /run/secrets/scion-hub-dev-auth
               readOnly: true
+            - name: github-token
+              mountPath: /run/secrets/scion-github-token
+              readOnly: true
       volumes:
         - name: workspace
           hostPath:
@@ -118,4 +127,8 @@ spec:
         - name: hub-dev-auth
           secret:
             secretName: scion-hub-dev-auth
+            optional: true
+        - name: github-token
+          secret:
+            secretName: scion-github-token
             optional: true

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -1034,8 +1034,16 @@ def _round_terminal_status(snapshot: dict[str, Any]) -> dict[str, Any] | None:
     if not consensus:
         return None
     summary = str(consensus.get("taskSummary") or "")
+    phase = str(consensus.get("phase") or "").lower()
     activity = str(consensus.get("activity") or "").lower()
-    if activity == "completed" or " complete:" in summary or " escalated:" in summary:
+    if phase not in {"stopped", "deleted"} and activity != "completed":
+        return None
+    has_placeholder = any(token in summary for token in ("<round_id>", "<branch>", "<agent"))
+    has_terminal_summary = (
+        (" complete:" in summary or " escalated:" in summary or summary.startswith("spec ready:"))
+        and not has_placeholder
+    )
+    if activity == "completed" or has_terminal_summary:
         return {
             "agent": consensus.get("name"),
             "activity": consensus.get("activity"),
@@ -1049,6 +1057,15 @@ def _default_base_branch(project_root: str = "") -> str:
     result = _run(["git", "branch", "--show-current"], timeout=10, cwd=root)
     current = result["output"].strip()
     return current or "HEAD"
+
+
+def _target_round_env(target_root: Path) -> dict[str, str]:
+    env = {"SCION_OPS_PROJECT_ROOT": str(target_root)}
+    grove_id = _read_text_file(target_root / ".scion" / "grove-id")
+    if grove_id:
+        env["SCION_GROVE_ID"] = grove_id
+        env["SCION_OPS_GROVE_ID"] = grove_id
+    return env
 
 
 def _github_https_remote(remote_url: str) -> str:
@@ -1399,9 +1416,9 @@ def scion_ops_start_round(
         raise ValueError("prompt is required")
     target_root = _project_root(project_root) if project_root else _repo_root()
     env: dict[str, str] = {
+        **_target_round_env(target_root),
         "MAX_MINUTES": str(_clamp(max_minutes, 1, 240)),
         "MAX_REVIEW_ROUNDS": str(_clamp(max_review_rounds, 1, 10)),
-        "SCION_OPS_PROJECT_ROOT": str(target_root),
     }
     if round_id:
         env["ROUND_ID"] = _clean_name(round_id, "round_id")
@@ -1786,7 +1803,7 @@ def scion_ops_start_spec_round(
     if not goal:
         raise ValueError("goal is required")
     target_root = _project_root(project_root)
-    env: dict[str, str] = {"SCION_OPS_PROJECT_ROOT": str(target_root)}
+    env: dict[str, str] = _target_round_env(target_root)
     if change:
         env["SCION_OPS_SPEC_CHANGE"] = _clean_name(change, "change")
     if round_id:
@@ -1840,9 +1857,9 @@ def _start_impl_round(
             },
         }
     env: dict[str, str] = {
+        **_target_round_env(target_root),
         "MAX_MINUTES": str(_clamp(max_minutes, 1, 240)),
         "MAX_REVIEW_ROUNDS": str(_clamp(max_review_rounds, 1, 10)),
-        "SCION_OPS_PROJECT_ROOT": str(target_root),
     }
     if round_id:
         env["ROUND_ID"] = _clean_name(round_id, "round_id")

--- a/orchestrator/spec-round.sh
+++ b/orchestrator/spec-round.sh
@@ -29,6 +29,76 @@ fi
 BASE_BRANCH="${BASE_BRANCH:-main}"
 RUNNER_NAME="round-${ROUND_ID}-spec-consensus"
 RUNNER_BRANCH="$RUNNER_NAME"
+COORDINATOR_PROTOCOL_FILE="$SCION_OPS_ROOT/.scion/templates/spec-consensus-runner/system-prompt.md"
+COORDINATOR_PROTOCOL=""
+if [[ -f "$COORDINATOR_PROTOCOL_FILE" ]]; then
+  COORDINATOR_PROTOCOL="$(cat "$COORDINATOR_PROTOCOL_FILE")"
+fi
+
+github_authenticated_remote() {
+  local remote="$1"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    case "$remote" in
+      https://github.com/*)
+        printf 'https://x-access-token:%s@github.com/%s' "$GITHUB_TOKEN" "${remote#https://github.com/}"
+        return
+        ;;
+      git@github.com:*)
+        printf 'https://x-access-token:%s@github.com/%s' "$GITHUB_TOKEN" "${remote#git@github.com:}"
+        return
+        ;;
+      ssh://git@github.com/*)
+        printf 'https://x-access-token:%s@github.com/%s' "$GITHUB_TOKEN" "${remote#ssh://git@github.com/}"
+        return
+        ;;
+    esac
+  fi
+  printf '%s' "$remote"
+}
+
+ensure_remote_branch() {
+  local branch="$1"
+  local remote push_remote base_ref
+
+  remote="$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)"
+  [[ -n "$remote" ]] || {
+    printf 'Warning: origin remote is missing; cannot pre-create %s\n' "$branch" >&2
+    return 0
+  }
+  push_remote="$(github_authenticated_remote "$remote")"
+
+  if GIT_TERMINAL_PROMPT=0 git -C "$PROJECT_ROOT" ls-remote --exit-code --heads "$push_remote" "$branch" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  base_ref="$BASE_BRANCH"
+  if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    base_ref="origin/$BASE_BRANCH"
+  fi
+  if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    base_ref="HEAD"
+  fi
+
+  printf 'Pre-creating round branch: %s\n' "$branch"
+  if ! GIT_TERMINAL_PROMPT=0 git -C "$PROJECT_ROOT" push "$push_remote" "${base_ref}:refs/heads/${branch}" >/dev/null; then
+    printf 'Warning: failed to pre-create %s; Scion will try to create it during agent start\n' "$branch" >&2
+  fi
+}
+
+precreate_round_branches() {
+  local suffix
+  for suffix in spec-consensus spec-clarifier spec-explorer spec-author spec-ops-review spec-finalizer spec-integration; do
+    ensure_remote_branch "round-${ROUND_ID}-${suffix}"
+  done
+}
+
+load_github_token_for_branch_precreate() {
+  local token_file="/run/secrets/scion-github-token/GITHUB_TOKEN"
+  if [[ -z "${GITHUB_TOKEN:-}" && -r "$token_file" ]]; then
+    GITHUB_TOKEN="$(cat "$token_file")"
+    export GITHUB_TOKEN
+  fi
+}
 
 if [[ "${SCION_OPS_ROUND_PREFLIGHT:-1}" != "0" && "${SCION_OPS_DRY_RUN:-0}" != "1" ]]; then
   bash "$SCION_OPS_ROOT/scripts/kind-round-preflight.sh"
@@ -43,9 +113,14 @@ project_root: $AGENT_PROJECT_ROOT
 original_goal:
 $GOAL
 
-Start the spec-building protocol described in your system prompt. Produce only
-OpenSpec artifacts under openspec/changes/<change>/ in the target project. Do
-not implement code, tests, manifests, or runtime changes during this round.
+Coordinator protocol:
+$COORDINATOR_PROTOCOL
+
+Start the spec-building protocol above. Produce only OpenSpec artifacts under
+openspec/changes/<change>/ in the target project. Do not implement code, tests,
+manifests, product docs, or runtime changes during this round. Do not exit until
+the final branch round-${ROUND_ID}-spec-integration exists on origin and contains
+the committed OpenSpec artifacts.
 EOF
 )
 
@@ -67,6 +142,11 @@ Rendered prompt:
 $TASK_PROMPT
 EOF
   exit 0
+fi
+
+if [[ "${SCION_OPS_PRECREATE_ROUND_BRANCHES:-1}" != "0" ]]; then
+  load_github_token_for_branch_precreate
+  precreate_round_branches
 fi
 
 "$SCION_BIN" --grove "$PROJECT_ROOT" start "$RUNNER_NAME" \

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -16,6 +16,7 @@ BROKER="${SCION_KIND_CP_BROKER:-kind-control-plane}"
 BROKER_CREDENTIAL_NAME="${SCION_KIND_CP_BROKER_CREDENTIAL_NAME:-in-cluster}"
 BROKER_CREDENTIAL_SECRET="${SCION_KIND_CP_BROKER_CREDENTIAL_SECRET:-scion-broker-credentials}"
 BROKER_BOOTSTRAP_HOME="${SCION_BROKER_BOOTSTRAP_HOME:-/tmp/scion-broker-bootstrap}"
+GITHUB_TOKEN_SECRET="${SCION_GITHUB_TOKEN_SECRET:-scion-github-token}"
 HUB_IN_CLUSTER="${SCION_OPS_KIND_IN_CLUSTER_HUB_URL:-http://127.0.0.1:8090}"
 HUB_FOR_BROKER="${SCION_OPS_KIND_BROKER_HUB_URL:-http://scion-hub:8090}"
 HUB_PUBLIC="${SCION_HUB_ENDPOINT:-${HUB_ENDPOINT:-${SCION_OPS_KIND_HUB_URL:-http://${SCION_OPS_KIND_LISTEN_ADDRESS:-192.168.122.103}:${SCION_OPS_KIND_HUB_PORT:-18090}}}}"
@@ -307,6 +308,27 @@ set_env_secret() {
   log "set Hub environment secret ${key}"
 }
 
+restore_github_token_kubernetes_secret() {
+  local token="$1"
+  [[ -n "$token" ]] || die "GITHUB_TOKEN is empty"
+  kubectl_ctx -n "$NAMESPACE" create secret generic "$GITHUB_TOKEN_SECRET" \
+    --from-literal=GITHUB_TOKEN="$token" \
+    --dry-run=client \
+    -o yaml |
+    kubectl_ctx -n "$NAMESPACE" apply -f - >/dev/null
+  log "restored Kubernetes Secret ${GITHUB_TOKEN_SECRET} for MCP git branch preparation"
+}
+
+restart_mcp_for_github_token() {
+  if [[ -n "${SCION_OPS_MCP_PORT:-}" && -n "${KUBERNETES_SERVICE_HOST:-}" ]]; then
+    log "skip MCP restart from inside MCP pod; restart MCP from the host to reload ${GITHUB_TOKEN_SECRET}"
+    return 0
+  fi
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-ops-mcp >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-ops-mcp --timeout=120s >/dev/null
+  log "restarted MCP to load ${GITHUB_TOKEN_SECRET}"
+}
+
 set_file_secret() {
   local key="$1"
   local source="$2"
@@ -450,6 +472,15 @@ sync_templates() {
   hub_url="$(sh_quote "$HUB_IN_CLUSTER")"
   token="$(sh_quote "$SCION_DEV_TOKEN")"
   run_in_hub "$pod" "SCION_DEV_TOKEN=${token} SCION_HUB_ENDPOINT=${hub_url} scion --global templates sync --all --hub ${hub_url} --non-interactive --yes"
+
+  log "copy synced template storage into broker pod"
+  local broker
+  broker="$(broker_pod)"
+  run_in_broker "$broker" "mkdir -p /home/scion/.scion/storage/templates"
+  kubectl_ctx -n "$NAMESPACE" exec "$pod" -c hub -- \
+    tar -C /home/scion/.scion/storage/templates -cf - . |
+    kubectl_ctx -n "$NAMESPACE" exec -i "$broker" -c broker -- \
+      tar -C /home/scion/.scion/storage/templates -xf -
 }
 
 main() {
@@ -480,6 +511,8 @@ main() {
   token="$(github_token)"
   [[ -n "$token" ]] || die "GITHUB_TOKEN, GH_TOKEN, or a usable gh auth token is required"
   set_env_secret GITHUB_TOKEN "$token"
+  restore_github_token_kubernetes_secret "$token"
+  restart_mcp_for_github_token
   unset token
 
   set_file_secret CLAUDE_AUTH "${CLAUDE_AUTH_FILE:-${HOME}/.claude/.credentials.json}" "~/.claude/.credentials.json"

--- a/scripts/kind-round-preflight.sh
+++ b/scripts/kind-round-preflight.sh
@@ -49,6 +49,12 @@ required_templates=(
   reviewer-codex
   final-reviewer-gemini
   final-reviewer-codex
+  spec-consensus-runner
+  spec-goal-clarifier
+  spec-repo-explorer
+  spec-author
+  spec-ops-reviewer
+  spec-finalizer
 )
 
 for template in "${required_templates[@]}"; do


### PR DESCRIPTION
Closes #101

## Summary
- bind MCP-started rounds to the requested project grove instead of inheriting the MCP pod grove
- run Claude spec templates in non-interactive print mode
- pre-create expected spec round branches from the base branch when GitHub credentials are available
- expose the GitHub token to MCP through a Kubernetes Secret and sync Hub template storage into the broker
- prevent placeholder status summaries from ending MCP event watches early
- tighten spec personas to produce validator-compliant OpenSpec artifacts
- switch the dedicated broker deployment to Recreate rollout strategy

## Verification
- task verify
- kubectl kustomize deploy/kind/control-plane
- task kind:control-plane:apply
- task bootstrap -- /home/david/workspace/github/dodwyer/scion-test
- task kind:mcp:smoke
- SCION_OPS_PROJECT_ROOT=/home/david/workspace/github/dodwyer/scion-test SCION_OPS_SPEC_CHANGE=create-redis-operator-repeat-test ROUND_ID=repeatability-dryrun-20260507a task spec:round:dry-run -- "Specify a repeatability dry-run only."