### PR TITLE
Clarify spec round OpenSpec-only defaults

### DIFF
--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -139,6 +139,10 @@ tools so the artifact contract is visible in the request. For Zed and other
 External Agent use, prefer `scion_ops_run_spec_round` unless you need to inspect
 intermediate events manually.
 
+A `spec round` is OpenSpec-only by definition. The round prompt adds the
+artifact-only contract, so users and MCP callers should provide the product goal
+without repeating "Produce OpenSpec artifacts only."
+
 ## Validation
 
 Use the validator before an implementation round starts:
@@ -178,6 +182,9 @@ For a no-model prompt rendering check:
 ```bash
 task spec:round:dry-run -- "draft the spec goal"
 ```
+
+The rendered prompt restricts the round to `openspec/changes/<change>/` and
+forbids code, tests, manifests, product docs, or runtime changes.
 
 The spec round uses these templates:
 

--- a/docs/zed-mcp.md
+++ b/docs/zed-mcp.md
@@ -172,8 +172,11 @@ Ask for a spec round with the target project and goal:
 ```text
 Use scion-ops on project_root=/home/david/workspace/github/example/project.
 Run a spec round for change=add-widget:
-"Specify the smallest useful widget improvement. Produce OpenSpec artifacts only."
+"Specify the smallest useful widget improvement."
 ```
+
+`spec round` implies OpenSpec artifacts only. The MCP caller does not need to
+repeat that in the goal.
 
 The external agent should make the compact call:
 

--- a/docs/zed-openspec-example.md
+++ b/docs/zed-openspec-example.md
@@ -17,9 +17,9 @@ workspace-prune-preview
 
 Goal: specify and then implement a dry-run workspace prune operation that lists
 MCP-prepared GitHub checkouts, identifies clean inactive checkouts that would be
-safe to delete, and refuses dirty or active workspaces. The spec round must
-produce OpenSpec artifacts only. The implementation round must make the code
-change from the approved spec.
+safe to delete, and refuses dirty or active workspaces. The spec round is
+OpenSpec-only by definition. The implementation round must make the code change
+from the approved spec.
 
 ## 1. Start scion-ops
 
@@ -118,7 +118,7 @@ Open Zed's agent panel and paste this exact request:
 Use scion-ops on project_root=/home/david/workspace/github/livewyer-ops/scion-ops.
 
 Run a spec round for change=workspace-prune-preview:
-"Specify a dry-run workspace prune operation for MCP-prepared GitHub checkouts. It should list checkout candidates, identify clean inactive checkouts that are safe to delete, refuse dirty checkouts and active round workspaces, and not delete anything in this change. Produce OpenSpec artifacts only."
+"Specify a dry-run workspace prune operation for MCP-prepared GitHub checkouts. It should list checkout candidates, identify clean inactive checkouts that are safe to delete, refuse dirty checkouts and active round workspaces, and not delete anything in this change."
 ```
 
 The external agent should use this MCP tool:
@@ -313,8 +313,7 @@ Use a GitHub URL instead of a local path. Paste this into Zed:
 ```text
 Use scion-ops to prepare repo_url=https://github.com/<owner>/<repo>.git.
 Then use the returned project_root for a spec round with change=workspace-prune-preview:
-"Specify a dry-run workspace prune operation. Produce OpenSpec artifacts only."
-Monitor it with event watching and report the PR-ready spec branch.
+"Specify a dry-run workspace prune operation."
 ```
 
 The external agent should call `scion_ops_prepare_github_repo` first and then

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -1906,7 +1906,7 @@ def scion_ops_start_spec_round(
     round_id: str = "",
     base_branch: str = "",
 ) -> dict[str, Any]:
-    """Start a spec-building Scion round for a target project."""
+    """Start an OpenSpec-only spec-building Scion round for a target project."""
     goal = goal.strip()
     if not goal:
         raise ValueError("goal is required")
@@ -1970,11 +1970,13 @@ def scion_ops_run_spec_round(
     poll_interval_seconds: int = 3,
     validate: bool = True,
 ) -> dict[str, Any]:
-    """Start, monitor, collect artifacts, and validate a spec-building round.
+    """Start, monitor, collect artifacts, and validate an OpenSpec-only spec round.
 
     This is the compact default workflow for external agents: call it once with
     project_root, goal, and optional change. It uses the event watcher internally
-    and returns the PR-ready spec branch or a concrete blocker.
+    and returns the PR-ready spec branch or a concrete blocker. Callers should
+    provide the goal only; the spec round contract already restricts output to
+    OpenSpec artifacts.
     """
     started = scion_ops_start_spec_round(
         goal=goal,


### PR DESCRIPTION
Closes #105.

## Summary
- Mark spec-round MCP tools as OpenSpec-only by default.
- Remove repeated artifact-only wording from Zed/OpenSpec examples.
- Document that the spec round prompt injects the artifact-only contract.

## Verification
- task verify