### PR TITLE
Fix spec round id timestamp

### DIFF
--- a/orchestrator/spec-round.sh
+++ b/orchestrator/spec-round.sh
@@ -19,7 +19,7 @@ PROJECT_ROOT="$(cd "$PROJECT_ROOT_INPUT" && pwd -P)"
 PROJECT_ROOT="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)" || die "target project is not a git repo: $PROJECT_ROOT"
 AGENT_PROJECT_ROOT="${SCION_OPS_AGENT_PROJECT_ROOT:-/workspace}"
 
-ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dt%H%M%sz)-$(printf '%04x' "$RANDOM")}"
+ROUND_ID="${ROUND_ID:-$(date -u +%Y%m%dt%H%M%Sz)-$(printf '%04x' "$RANDOM")}"
 ROUND_ID="$(printf '%s' "$ROUND_ID" | tr '[:upper:]' '[:lower:]')"
 CHANGE="${SCION_OPS_SPEC_CHANGE:-}"
 BASE_BRANCH="${BASE_BRANCH:-$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)}"


### PR DESCRIPTION
Closes #117.

## Summary
- Use `%S` for two-digit seconds in generated spec round ids.
- Preserve lower-case generated ids and explicit id normalization.

## Verification
- `SCION_OPS_PROJECT_ROOT=/home/david/workspace/github/dodwyer/scion-test task spec:round:dry-run -- "check generated lower-case id"`
- `SCION_OPS_PROJECT_ROOT=/home/david/workspace/github/dodwyer/scion-test ROUND_ID=TestROUND-ABC123 task spec:round:dry-run -- "check explicit lower-case id"`
- `task verify`
