### PR TITLE
Fix MCP spec round completion

### DIFF
--- a/.scion/templates/consensus-runner/system-prompt.md
+++ b/.scion/templates/consensus-runner/system-prompt.md
@@ -6,29 +6,46 @@ them through Scion state and messages, and keep an audit trail.
 
 ## Non-Interactive Execution
 
-This template runs Claude in print mode so Kubernetes rounds can submit the
-entire prompt as one non-interactive turn. You will not receive another model
-turn after your final response. Do not say that you will check back later or
-wait for a future notification after exiting.
+This template runs Claude non-interactively with `--print`, so the coordinator
+must drive the whole round inside one session. Do not rely on tmux-delivered
+follow-up messages to start another turn after you spawn child agents. Child
+agents must send summaries and verdicts to the Hub user inbox, and you must poll
+Scion state and the inbox until each required phase completes or blocks.
+
+Use `user:dev@localhost` as the default collection recipient unless the task
+prompt explicitly provides a different `collection_recipient`. Never infer the
+recipient from a Claude account email, git identity, or human display name.
+
+Use these commands while monitoring:
+
+- `scion --non-interactive list --format json`
+- `scion --non-interactive messages --all --json`
 
 Drive the whole protocol before you finish: spawn children, monitor Scion state
 and messages until each required phase completes or blocks, launch review and
 integration agents, run final review, and only then report success or a concrete
-blocker. Keep `sciontool status` current while child agents are working.
+blocker. Status updates are useful while child agents are working, but only use
+complete one-line `sciontool status` commands with concrete values from the
+current round.
 
-When waiting on child agents, prefer Hub activity over pod lifetime. In
-`scion list --format json`, `activity: "completed"` means the agent finished
-its assigned work even when `phase` is still `running` for inspection. Do not
-wait for a completed agent's pod to stop before moving to the next protocol
-step.
+When waiting on child agents, use both Hub activity and Kubernetes completion
+state. In `scion list --format json`, treat an agent as complete when any of
+these are true: `activity` is `completed`; `phase` is `stopped`, `deleted`,
+`ended`, or `completed`; or `containerStatus` contains `Succeeded` or
+`Completed`. Do not wait only for `activity: "completed"` because Kubernetes
+agents may finish with `phase: "running"`, `activity: "idle"`, and
+`containerStatus: "Succeeded (Completed)"` while kept for inspection.
 
 ## Status Signalling
 
-- Before asking the user a question: `sciontool status ask_user "<question>"`
-- While waiting on child agents: `sciontool status blocked "Waiting for <agent names>"`
-- When the round succeeds: `sciontool status task_completed "round <round_id> complete: <branch>"`
-- When review rounds are exhausted without consensus: `sciontool status task_completed "round <round_id> escalated: <concrete reason>"`
-- When the round cannot proceed because of an external blocker: `sciontool status blocked "<concrete reason>"`
+Use `ask_user` before asking the user a question, `blocked` while waiting or
+when there is an external blocker, and `task_completed` only when the round has
+actually finished or escalated. The status message must name the actual current
+agents, reason, or branch.
+
+Never run `sciontool status` without both the status type and a quoted message.
+Never split the status type or message onto another line. Never put examples,
+ellipses, or placeholder text in status output.
 
 Do not report success until the final reviewer accepts the integrated branch.
 
@@ -106,23 +123,24 @@ The audit file is a working artifact. It does not need to be committed.
 1. Initialize `state/<round_id>.json`.
 2. Spawn both implementers in parallel:
    - Claude: `scion start <claude_impl> --type impl-claude --branch <claude_impl> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<implementation task>"`
-   - Codex: `scion start <codex_impl> --type impl-codex --branch <codex_impl> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<implementation task>"`
-3. Wait for both implementers to reach `completed`. In `scion list --format
-   json`, treat an agent as complete when `activity` is `completed`; do not
+   - Codex: `scion start <codex_impl> --type impl-codex --branch <codex_impl> --broker kind-control-plane --harness-config codex-exec --harness-auth auth-file --no-upload --non-interactive --notify "<implementation task>"`
+3. Wait for both implementers to reach completion. In `scion list --format
+   json`, apply the completion rules from Non-Interactive Execution; do not
    require `phase` to be `stopped` because completed Kubernetes agents may keep
-   their pod running for inspection. Use `sciontool status blocked` while
-   waiting. Inspect failed or stalled agents with `scion look`.
+   their pod running for inspection. If you set waiting status, include the
+   concrete waiting reason in the same command. Inspect failed or stalled agents
+   with `scion look`.
 4. For each review round up to `max_review_rounds`:
    - Create review snapshot branches with `git branch -f <snapshot_branch> <implementation_branch>`.
    - Spawn Claude review on the Codex snapshot branch with this exact shape:
      `scion start <review_claude> --type reviewer-claude --branch <codex_snapshot_branch> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<review task>"`
    - Spawn Codex review on the Claude snapshot branch with this exact shape:
-     `scion start <review_codex> --type reviewer-codex --branch <claude_snapshot_branch> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<review task>"`
+     `scion start <review_codex> --type reviewer-codex --branch <claude_snapshot_branch> --broker kind-control-plane --harness-config codex-exec --harness-auth auth-file --no-upload --non-interactive --notify "<review task>"`
    - Never use `impl-claude` or `impl-codex` templates for review agents. If a review agent appears with an `impl-*` template, stop and delete it, then recreate it with the matching `reviewer-*` template before continuing.
-   - Include your coordinator agent name in each review prompt and require the reviewer to send its `verdict.json` back to you with `scion message`.
+   - Include the round ID in each review prompt and require the reviewer to send its `verdict.json` to the Hub user inbox with `scion message`.
    - Wait for reviewer `activity` to be `completed`, or for `taskSummary` to
      report a verdict. Do not require reviewer `phase` to be `stopped`.
-   - Collect both JSON verdicts from Scion messages or visible terminal output.
+   - Collect both JSON verdicts from `scion messages --all --json`.
    - Append the verdicts to `state/<round_id>.json`.
    - Consensus is reached when both correctness scores are at least 4.
    - If consensus is not reached, send only blocking issues back to the relevant implementer. If the implementer stopped, resume it first with `scion resume <agent> --non-interactive`, then message the feedback with `--notify`.
@@ -136,13 +154,13 @@ The audit file is a working artifact. It does not need to be committed.
    - push `round-<round_id>-integration`.
 8. Create `round-<round_id>-final-review-snapshot` from `round-<round_id>-integration`, then spawn the final reviewer on that snapshot branch with `--broker kind-control-plane --harness-auth auth-file --no-upload`.
    - If `final_reviewer` is missing or exactly `codex`, start `final-reviewer-codex` with:
-     `scion start <final_review_agent> --type final-reviewer-codex --branch <final_review_snapshot_branch> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<final review task>"`
+     `scion start <final_review_agent> --type final-reviewer-codex --branch <final_review_snapshot_branch> --broker kind-control-plane --harness-config codex-exec --harness-auth auth-file --no-upload --non-interactive --notify "<final review task>"`
    - If `final_reviewer` is exactly `gemini`, first start `final-reviewer-gemini` with:
      `scion start <final_review_agent> --type final-reviewer-gemini --branch <final_review_snapshot_branch> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<final review task>"`
    - If Gemini cannot start, reaches `phase == error`, reports `activity == limits_exceeded`, or reports a quota/capacity/auth failure instead of a verdict, start `final-reviewer-codex` as the fallback.
    - If you fall back from Gemini to Codex, record the failed Gemini output or state and fallback reason in `state/<round_id>.json`.
    - Never use an `impl-*` template for final review. If the final-review agent appears with an `impl-*` template, stop and delete it, then recreate it with the requested `final-reviewer-*` template before continuing.
-   - Require the final reviewer to send the final verdict JSON back to you.
+   - Require the final reviewer to send the final verdict JSON to the Hub user inbox.
 9. Accept only if the final reviewer verdict is `accept`. Otherwise set status `blocked` and report the final blocking issues.
 10. On success, set status `success` and report the integration branch.
 
@@ -151,12 +169,13 @@ The audit file is a working artifact. It does not need to be committed.
 When spawning reviewers, include this exact contract in the task:
 
 ```text
-Coordinator: <your agent name>
+Round: <round_id>
+Coordinator collection inbox: user:dev@localhost
 Base branch: <base_branch>
 Review the checked-out snapshot branch against the base branch for the original task.
 Write verdict.json in the current workspace root.
-Then send the exact JSON contents to the coordinator:
-scion message <coordinator> --non-interactive --notify '<verdict json>'
+Then send the exact JSON contents to the coordinator collection inbox:
+scion --non-interactive message --notify "user:dev@localhost" 'actual JSON verdict'
 Do not modify source files. Do not commit verdict.json.
 ```
 

--- a/.scion/templates/final-reviewer-codex/scion-agent.yaml
+++ b/.scion/templates/final-reviewer-codex/scion-agent.yaml
@@ -1,6 +1,6 @@
 schema_version: "1"
 description: "Final reviewer (Codex) — smoke-test pass on the integrated branch. Blocks only on critical bugs."
-default_harness_config: codex
+default_harness_config: codex-exec
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 20

--- a/.scion/templates/impl-codex/scion-agent.yaml
+++ b/.scion/templates/impl-codex/scion-agent.yaml
@@ -1,6 +1,6 @@
 schema_version: "1"
 description: "Implementer (Codex) — drafts changes to satisfy the task and tests."
-default_harness_config: codex
+default_harness_config: codex-exec
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 60

--- a/.scion/templates/reviewer-codex/scion-agent.yaml
+++ b/.scion/templates/reviewer-codex/scion-agent.yaml
@@ -1,6 +1,6 @@
 schema_version: "1"
 description: "Reviewer (Codex) — peer-reviews the other implementer's diff and produces verdict.json."
-default_harness_config: codex
+default_harness_config: codex-exec
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 30

--- a/.scion/templates/spec-author/agents.md
+++ b/.scion/templates/spec-author/agents.md
@@ -1,4 +1,5 @@
 # Spec Author
 
 Create or update only the OpenSpec change artifact set requested by the
-coordinator. Commit and push your branch when complete.
+task prompt. Commit and push your branch when complete, then report to the
+message recipient named in the task prompt.

--- a/.scion/templates/spec-author/system-prompt.md
+++ b/.scion/templates/spec-author/system-prompt.md
@@ -43,5 +43,11 @@ Run a local shell check for those markers if the target project does not carry
 the scion-ops validator script.
 
 Commit the artifact-only change, push your branch when `origin` is configured,
-send a summary to the coordinator with `scion message`, and mark completion
-with `sciontool status task_completed "<summary>"`.
+send a summary to the message recipient named in the task prompt, and mark
+completion with `sciontool status task_completed "<summary>"`. If the task does
+not name a recipient, use:
+
+`scion --non-interactive message --notify "user:dev@localhost" "Round ROUND_ID AGENT_NAME complete: CONCRETE_SUMMARY"`
+
+Replace `ROUND_ID`, `AGENT_NAME`, and `CONCRETE_SUMMARY` with actual values.
+Never copy placeholder text into a message.

--- a/.scion/templates/spec-consensus-runner/scion-agent.yaml
+++ b/.scion/templates/spec-consensus-runner/scion-agent.yaml
@@ -2,8 +2,8 @@ schema_version: "1"
 description: "Spec consensus runner - coordinates OpenSpec artifact rounds without implementation changes."
 default_harness_config: claude
 model: claude-sonnet-4-6
+system_prompt: system-prompt.md
 command_args:
   - --print
-system_prompt: system-prompt.md
 max_turns: 80
 max_duration: 12m

--- a/.scion/templates/spec-consensus-runner/system-prompt.md
+++ b/.scion/templates/spec-consensus-runner/system-prompt.md
@@ -3,23 +3,41 @@
 You coordinate a Scion spec-building round. Do not implement code. Your job is
 to produce a reviewable OpenSpec change artifact set in the target project.
 
-## Non-Interactive Execution
+## Coordinator Execution
 
-This template runs as one non-interactive turn. Drive the full protocol before
-you finish: spawn child agents, monitor Scion state and messages, collect their
-outputs, run finalization, and report the PR-ready spec branch or a concrete
-blocker.
+This coordinator runs Claude non-interactively with `--print`, so it must drive
+the whole round inside one session. Do not rely on tmux-delivered follow-up
+messages to start another turn after you spawn child agents. Child agents must
+send their summaries to the Hub user inbox, and you must poll Scion state and
+the inbox until each phase completes or blocks.
 
-Use `sciontool status` throughout. While child agents work, set blocked status
-with the concrete child agent names. When the round cannot proceed, set blocked
-status with the concrete reason or question. On success, set task-completed
-status with the actual round id and the actual integration branch.
+Use the `collection_recipient` value from the task prompt exactly when writing
+child prompts. If it is missing, use `user:dev@localhost`. Never infer the
+recipient from a Claude account email, git identity, or human display name.
 
-Never send literal angle-bracket placeholder text such as `<round_id>`,
-`<branch>`, or `<agent names>` in `sciontool status` or `scion message` output.
+Use these commands while monitoring:
 
-When watching children, treat `activity: "completed"` as complete even if
-`phase` is still `running` for inspection.
+- `scion --non-interactive list --format json`
+- `scion --non-interactive messages --all --json`
+
+Filter inbox messages by this round ID and the expected child agent names.
+Drive the full protocol before you finish: spawn child agents, monitor Scion
+state and messages, collect their outputs, run finalization, and report the
+PR-ready spec branch or a concrete blocker.
+
+Status updates are optional during intermediate waits. When you do update
+status, `sciontool status` requires two arguments: a status type and a quoted
+message. The message must use the actual current agent names, reason, or branch
+name from this round. Never run `sciontool status` without both arguments.
+Never split the status type or message onto another line. Never put examples,
+ellipses, or placeholder text in status output.
+
+When watching children, treat an agent as complete when any of these are true:
+`activity` is `completed`; `phase` is `stopped`, `deleted`, `ended`, or
+`completed`; or `containerStatus` contains `Succeeded` or `Completed`. Do not
+wait only for `activity: "completed"` because Kubernetes agents may finish with
+`phase: "running"`, `activity: "idle"`, and `containerStatus: "Succeeded
+(Completed)"` while kept for inspection.
 
 ## Inputs
 
@@ -29,11 +47,13 @@ The task prompt includes:
 - `base_branch`
 - `change` (optional; derive a stable kebab-case change name when blank)
 - `project_root`
+- `collection_recipient` (Hub user inbox recipient for child summaries)
 - `original_goal`
 
 All child agents work in the same target project grove. Stay in Hub-backed
 Kubernetes operation. Use `--broker kind-control-plane --harness-auth auth-file
---no-upload --non-interactive --notify` for child agents.
+--no-upload --non-interactive --notify` for child agents. For every
+Codex-backed child agent, also pass `--harness-config codex-exec` explicitly.
 
 ## Branches And Agents
 
@@ -56,9 +76,9 @@ The final PR-ready branch is `round-<round_id>-spec-integration`.
    kebab-case name from the goal.
 3. Spawn the goal clarifier and repo explorer in parallel:
    - `scion start <clarifier> --type spec-goal-clarifier --branch <clarifier> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<clarifier task>"`
-   - `scion start <explorer> --type spec-repo-explorer --branch <explorer> --broker kind-control-plane --harness-auth auth-file --no-upload --non-interactive --notify "<explorer task>"`
-4. Wait for both to complete. Require them to send summaries back with
-   `scion message`.
+   - `scion start <explorer> --type spec-repo-explorer --branch <explorer> --broker kind-control-plane --harness-config codex-exec --harness-auth auth-file --no-upload --non-interactive --notify "<explorer task>"`
+4. Wait for both to complete. Require them to send summaries to the Hub user
+   inbox, then collect those summaries with `scion messages --all --json`.
 5. Spawn the spec author on `round-<round_id>-spec-author`. The author creates
    or updates only `openspec/changes/<change>/proposal.md`,
    `openspec/changes/<change>/design.md`,
@@ -75,20 +95,24 @@ The final PR-ready branch is `round-<round_id>-spec-integration`.
    - `git checkout -B round-<round_id>-spec-integration origin/round-<round_id>-spec-author`
    - `git push origin HEAD:round-<round_id>-spec-integration`
 7. Spawn the operations reviewer against a snapshot or the integration branch
-   using template `spec-ops-reviewer`.
-   Require a JSON verdict sent back with `scion message`. The reviewer must
-   check OpenSpec structure, implementation readiness, unresolved questions,
+   using template `spec-ops-reviewer`:
+   - `scion start <ops_review> --type spec-ops-reviewer --branch <integration_or_snapshot_branch> --broker kind-control-plane --harness-config codex-exec --harness-auth auth-file --no-upload --non-interactive --notify "<ops review task>"`
+   Require a JSON verdict sent to the Hub user inbox. The reviewer must check
+   OpenSpec structure, implementation readiness, unresolved questions,
    `CLAUDE.md`, Kubernetes-only operation, and task simplicity.
-8. Spawn the spec finalizer on `round-<round_id>-spec-integration`. It applies
-   accepted reviewer feedback, preserves the artifact-only boundary, commits,
-   pushes, and sends a final summary with:
+8. Spawn the spec finalizer on `round-<round_id>-spec-integration`:
+   - `scion start <finalizer> --type spec-finalizer --branch round-<round_id>-spec-integration --broker kind-control-plane --harness-config codex-exec --harness-auth auth-file --no-upload --non-interactive --notify "<finalizer task>"`
+   It applies accepted reviewer feedback, preserves the artifact-only boundary,
+   commits, pushes, and sends a final summary with:
    - `change`
    - `branch`
    - unresolved questions
    - implementation readiness: `ready|blocked`
    - validation notes
 9. If unresolved questions block implementation, report `blocked` with the
-   questions. Otherwise report success with the integration branch.
+   questions. Otherwise report success with the integration branch. Do not mark
+   the round complete before the finalizer has committed and pushed the actual
+   integration branch.
 
 ## Child Prompt Contract
 
@@ -101,7 +125,11 @@ Base branch: <base_branch>
 Target project root: <project_root>
 Spec-only boundary: modify only openspec/changes/<change>/ artifacts when your role writes files.
 Do not implement code, tests, Kubernetes manifests, runtime scripts, or product docs outside the requested artifact set.
-Send your result to the coordinator with scion message <coordinator> --non-interactive --notify '<summary>'.
+Send your result to the coordinator collection inbox with:
+scion --non-interactive message --notify "COLLECTION_RECIPIENT" "Round ROUND_ID AGENT_NAME complete: CONCRETE_SUMMARY"
+Replace `COLLECTION_RECIPIENT`, `ROUND_ID`, `AGENT_NAME`, and
+`CONCRETE_SUMMARY` with actual values from the current round. Never copy
+placeholder text into a message.
 ```
 
 ## Output

--- a/.scion/templates/spec-finalizer/agents.md
+++ b/.scion/templates/spec-finalizer/agents.md
@@ -1,4 +1,5 @@
 # Spec Finalizer
 
 Finalize the approved OpenSpec artifact set on the integration branch. Keep the
-diff artifact-only, commit, push, and report implementation readiness.
+diff artifact-only, commit, push, and report implementation readiness to the
+message recipient named in the task prompt.

--- a/.scion/templates/spec-finalizer/scion-agent.yaml
+++ b/.scion/templates/spec-finalizer/scion-agent.yaml
@@ -1,6 +1,6 @@
 schema_version: "1"
 description: "Spec finalizer - integrates review feedback into a PR-ready spec branch."
-default_harness_config: codex
+default_harness_config: codex-exec
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 50

--- a/.scion/templates/spec-finalizer/system-prompt.md
+++ b/.scion/templates/spec-finalizer/system-prompt.md
@@ -20,12 +20,19 @@ artifacts. Ensure:
 - implementation readiness is clearly `ready` or `blocked`
 
 Commit and push `round-<round_id>-spec-integration`. Send a final summary to
-the coordinator with `scion message`, including:
+the message recipient named in the task prompt, including:
 
 - change name
 - branch name
 - unresolved questions
 - implementation readiness
 - validation notes
+
+If the task does not name a recipient, use:
+
+`scion --non-interactive message --notify "user:dev@localhost" "Round ROUND_ID AGENT_NAME complete: CONCRETE_SUMMARY"`
+
+Replace `ROUND_ID`, `AGENT_NAME`, and `CONCRETE_SUMMARY` with actual values.
+Never copy placeholder text into a message.
 
 Then mark completion with `sciontool status task_completed "<summary>"`.

--- a/.scion/templates/spec-goal-clarifier/agents.md
+++ b/.scion/templates/spec-goal-clarifier/agents.md
@@ -1,4 +1,4 @@
 # Spec Goal Clarifier
 
 Clarify intent, scope, non-goals, and unresolved questions. Do not write files.
-Send a concise summary to the coordinator with `scion message`.
+Send a concise summary to the message recipient named in the task prompt.

--- a/.scion/templates/spec-goal-clarifier/system-prompt.md
+++ b/.scion/templates/spec-goal-clarifier/system-prompt.md
@@ -12,5 +12,11 @@ Focus on:
 - unresolved questions that would block implementation
 
 If a question is not blocking, convert it into an assumption. Send your result
-to the coordinator with `scion message`, then mark completion with
-`sciontool status task_completed "<summary>"`.
+to the message recipient named in the task prompt. If none is named, use:
+
+`scion --non-interactive message --notify "user:dev@localhost" "Round ROUND_ID AGENT_NAME complete: CONCRETE_SUMMARY"`
+
+Replace `ROUND_ID`, `AGENT_NAME`, and `CONCRETE_SUMMARY` with actual values.
+Never copy placeholder text into a message.
+
+Then mark completion with `sciontool status task_completed "<summary>"`.

--- a/.scion/templates/spec-ops-reviewer/agents.md
+++ b/.scion/templates/spec-ops-reviewer/agents.md
@@ -1,4 +1,4 @@
 # Spec Operations Reviewer
 
 Review the OpenSpec artifact branch. Do not modify files. Return a JSON verdict
-to the coordinator.
+to the message recipient named in the task prompt.

--- a/.scion/templates/spec-ops-reviewer/scion-agent.yaml
+++ b/.scion/templates/spec-ops-reviewer/scion-agent.yaml
@@ -1,6 +1,6 @@
 schema_version: "1"
 description: "Spec operations reviewer - checks artifact quality and operational fit."
-default_harness_config: codex
+default_harness_config: codex-exec
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 40

--- a/.scion/templates/spec-ops-reviewer/system-prompt.md
+++ b/.scion/templates/spec-ops-reviewer/system-prompt.md
@@ -17,7 +17,12 @@ Do not modify files. Review only. Check:
 - unresolved questions are explicit
 - no implementation files changed outside `openspec/changes/<change>/`
 
-Send this JSON to the coordinator with `scion message`:
+Send this JSON to the message recipient named in the task prompt. If none is
+named, send it to the Hub user inbox with:
+
+`scion --non-interactive message --notify "user:dev@localhost" '<json verdict>'`
+
+The JSON shape is:
 
 ```json
 {

--- a/.scion/templates/spec-repo-explorer/agents.md
+++ b/.scion/templates/spec-repo-explorer/agents.md
@@ -1,4 +1,5 @@
 # Spec Repo Explorer
 
 Inspect the target project and report the existing structures relevant to the
-spec. Do not write files or implement changes.
+spec. Do not write files or implement changes. Report to the message recipient
+named in the task prompt.

--- a/.scion/templates/spec-repo-explorer/scion-agent.yaml
+++ b/.scion/templates/spec-repo-explorer/scion-agent.yaml
@@ -1,6 +1,6 @@
 schema_version: "1"
 description: "Spec repo explorer - inspects the target repo to ground the spec."
-default_harness_config: codex
+default_harness_config: codex-exec
 system_prompt: system-prompt.md
 agent_instructions: agents.md
 max_turns: 30

--- a/.scion/templates/spec-repo-explorer/system-prompt.md
+++ b/.scion/templates/spec-repo-explorer/system-prompt.md
@@ -12,5 +12,12 @@ shape, and any existing `openspec/` tree. Report:
 - constraints from `CLAUDE.md`, README, and Kubernetes lifecycle docs
 - risks or ambiguity the spec author should address
 
-Send your summary to the coordinator with `scion message`, then mark completion
-with `sciontool status task_completed "<summary>"`.
+Send your summary to the message recipient named in the task prompt. If none is
+named, use:
+
+`scion --non-interactive message --notify "user:dev@localhost" "Round ROUND_ID AGENT_NAME complete: CONCRETE_SUMMARY"`
+
+Replace `ROUND_ID`, `AGENT_NAME`, and `CONCRETE_SUMMARY` with actual values.
+Never copy placeholder text into a message.
+
+Then mark completion with `sciontool status task_completed "<summary>"`.

--- a/README.md
+++ b/README.md
@@ -71,11 +71,17 @@ When restoring `CLAUDE_CONFIG`, bootstrap preserves the subscription state and
 marks Scion's `/workspace` agent checkout as trusted so Claude starts
 non-interactively in Kubernetes. Bootstrap also prepares the synced Claude
 harness settings to skip the bypass-permissions warning inside Scion's
-sandboxed agent pods. Host-local Claude MCP server registrations are stripped
-from the agent config; Scion rounds should use the repo's explicit harness and
-template configuration. Claude round templates pass `--print` through native
-Scion `command_args` so multiline prompts are submitted as a single
-non-interactive model turn.
+sandboxed agent pods. Codex-backed personas use repo-managed Codex harness
+configs in `deploy/kind/harness-configs/`: both `codex` and `codex-exec` run
+`codex exec` as a single non-interactive task while still using the restored
+Codex subscription auth file.
+Host-local Claude MCP server registrations are stripped from the agent config;
+Scion rounds should use the repo's explicit harness and template
+configuration. Claude templates pass `--print` through native Scion
+`command_args` so multiline prompts are submitted as a single non-interactive
+model turn. Coordinators collect child outputs through the Hub user inbox with
+`scion messages --json` instead of depending on interactive tmux prompt
+delivery.
 Rounds default to a Codex final reviewer for the reliable path; Gemini remains
 available as an explicit final reviewer and falls back to Codex if capacity or
 auth prevents a verdict.

--- a/deploy/kind/harness-configs/codex-exec/config.yaml
+++ b/deploy/kind/harness-configs/codex-exec/config.yaml
@@ -1,0 +1,12 @@
+harness: generic
+image: scion-codex:latest
+user: scion
+auth_selected_type: auth-file
+args:
+  - codex
+  - exec
+  - --sandbox
+  - danger-full-access
+  - --dangerously-bypass-approvals-and-sandbox
+env:
+  SCION_CODEX_NOTIFY_AUTO_COMPLETE: "true"

--- a/deploy/kind/harness-configs/codex/config.yaml
+++ b/deploy/kind/harness-configs/codex/config.yaml
@@ -1,0 +1,12 @@
+harness: generic
+image: scion-codex:latest
+user: scion
+auth_selected_type: auth-file
+args:
+  - codex
+  - exec
+  - --sandbox
+  - danger-full-access
+  - --dangerously-bypass-approvals-and-sandbox
+env:
+  SCION_CODEX_NOTIFY_AUTO_COMPLETE: "true"

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -235,11 +235,16 @@ Default model authentication uses subscription credential files restored by
 The restored Claude config keeps subscription state and adds `/workspace` as a
 trusted project path for Scion-managed agent pods. Bootstrap also prepares the
 Claude harness settings to skip the bypass-permissions warning in the
-Kubernetes agent sandbox. Host-local Claude MCP server registrations are
-stripped from the agent config so startup depends on Scion's explicit harness
-and template configuration. Claude round templates pass `--print` through
-native Scion `command_args` so multiline prompts are submitted
-non-interactively.
+Kubernetes agent sandbox. Codex-backed personas use repo-managed Codex harness
+configs in `deploy/kind/harness-configs/`: both `codex` and `codex-exec` run
+`codex exec` as a single non-interactive task while still using the restored
+Codex subscription auth file.
+Host-local Claude MCP server registrations are stripped from the agent config
+so startup depends on Scion's explicit harness and template configuration.
+Claude templates pass `--print` through native Scion `command_args` so
+multiline prompts are submitted non-interactively. Coordinators collect child
+outputs through the Hub user inbox with `scion messages --json` instead of
+depending on interactive tmux prompt delivery.
 The default round personas use Scion's `--harness-auth auth-file` path for
 Claude, Codex, and optional Gemini final review. Codex is the reliable default
 final reviewer; Gemini can be requested explicitly and falls back to Codex when
@@ -272,4 +277,4 @@ Deleting the kind cluster deletes cluster-local Scion state.
 | Agent artifacts | Hub agent records and pushed git branches | pod-local state is ephemeral |
 | Subscription credentials | Hub-scoped Claude, Codex, and Gemini secrets restored by `task bootstrap` | yes |
 | Vertex ADC credentials | optional Hub-scoped secrets restored only when `SCION_OPS_BOOTSTRAP_VERTEX_ADC=1`; cleared by default bootstrap | yes |
-| Templates/harness configs | Hub global templates and Hub harness configs restored by `task bootstrap` | yes |
+| Templates/harness configs | Hub global templates plus Hub and broker harness configs restored by `task bootstrap` | yes |

--- a/docs/workspace-persistence.md
+++ b/docs/workspace-persistence.md
@@ -63,7 +63,8 @@ mean the checkout PVC, not a node `hostPath`.
 2. Bootstrap the target.
    `task bootstrap -- <project_root>` or the equivalent MCP flow links the
    checkout as a Hub grove, provides the Kubernetes broker, restores shared
-   credentials, and syncs templates and harness configs through the Hub pod.
+   credentials, and syncs templates plus host and repo-managed harness configs
+   through the Hub pod.
 
 3. Start the round.
    Scion starts agents through Hub mode. Agents clone from Git, create or update

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -42,7 +42,24 @@ NAME_RE = re.compile(r"^[A-Za-z0-9._:/@+-]+$")
 DEFAULT_HOST_WORKSPACE_ROOT = "/home/david/workspace"
 DEFAULT_CONTAINER_WORKSPACE_ROOT = "/workspace"
 DEFAULT_REPO_CHECKOUT_SUBDIR = "github"
-PLACEHOLDER_SUMMARY_TOKENS = ("<round_id>", "<branch>", "<agent")
+PLACEHOLDER_SUMMARY_TOKENS = (
+    "<round_id>",
+    "<branch>",
+    "<agent",
+    "<summary>",
+    "<json verdict>",
+    "round ...",
+    "round-...",
+    "...-integration",
+    "...-spec-",
+    "concrete reason",
+    "concrete question",
+    "concrete verdict json",
+    "round_id",
+    "agent_name",
+    "concrete_summary",
+    "collection_recipient",
+)
 SPEC_CHILD_TEMPLATES = {
     "spec-goal-clarifier",
     "spec-repo-explorer",
@@ -1971,7 +1988,14 @@ def _short_text(value: Any, limit: int = 220) -> str:
 def _round_agent_inactive(agent: dict[str, Any]) -> bool:
     phase = str(agent.get("phase") or "").lower()
     activity = str(agent.get("activity") or "").lower()
-    return phase in {"stopped", "deleted", "ended"} or activity == "completed"
+    container_status = str(agent.get("containerStatus") or "").lower()
+    return (
+        phase in {"stopped", "deleted", "ended", "completed"}
+        or activity == "completed"
+        or "succeeded" in container_status
+        or "completed" in container_status
+        or container_status == "stopped"
+    )
 
 
 def _round_agents_inactive(agents: list[dict[str, Any]]) -> bool:
@@ -1982,7 +2006,7 @@ def _round_agents_inactive(agents: list[dict[str, Any]]) -> bool:
 
 def _has_placeholder_summary(agent: dict[str, Any]) -> bool:
     summary = str(agent.get("taskSummary") or agent.get("summary") or "")
-    return any(token in summary for token in PLACEHOLDER_SUMMARY_TOKENS)
+    return any(token in summary.lower() for token in PLACEHOLDER_SUMMARY_TOKENS)
 
 
 def _is_spec_consensus_agent(agent: dict[str, Any]) -> bool:
@@ -2004,17 +2028,37 @@ def _is_spec_child_agent(agent: dict[str, Any]) -> bool:
     )
 
 
+def _spec_agents_for_phase(agents: list[dict[str, Any]], *, template: str, name_suffix: str) -> list[dict[str, Any]]:
+    return [
+        agent
+        for agent in agents
+        if str(agent.get("template") or "") == template
+        or str(agent.get("name") or agent.get("slug") or "").endswith(name_suffix)
+    ]
+
+
+def _spec_phase_complete(agents: list[dict[str, Any]], *, template: str, name_suffix: str) -> bool:
+    return any(
+        _round_agent_inactive(agent)
+        for agent in _spec_agents_for_phase(
+            agents,
+            template=template,
+            name_suffix=name_suffix,
+        )
+    )
+
+
 def _agent_health(agent: dict[str, Any]) -> str:
     phase = str(agent.get("phase") or "").lower()
     activity = str(agent.get("activity") or "").lower()
     status = json.dumps(agent.get("containerStatus") or "", default=str).lower()
     status_text = f"{phase} {activity} {status}"
-    if activity == "stalled" or "stalled" in status_text:
-        return "stalled"
     if any(token in status_text for token in ("error", "failed", "crashloop", "imagepull", "backoff")):
         return "error"
     if _round_agent_inactive(agent):
         return "completed"
+    if activity == "stalled" or "stalled" in status_text:
+        return "stalled"
     if phase in {"running", "started"} or activity in {"active", "running", "working"}:
         return "running"
     if phase in {"pending", "created", "queued", "scheduled", "starting"}:
@@ -2188,6 +2232,26 @@ def _spec_round_progress_response(
     progress = _round_agent_progress(summaries)
     consensus_agent = next((agent for agent in summaries if _is_spec_consensus_agent(agent)), {})
     child_agents = [agent for agent in summaries if _is_spec_child_agent(agent)]
+    ops_review_agents = _spec_agents_for_phase(
+        child_agents,
+        template="spec-ops-reviewer",
+        name_suffix="-spec-ops-review",
+    )
+    finalizer_agents = _spec_agents_for_phase(
+        child_agents,
+        template="spec-finalizer",
+        name_suffix="-spec-finalizer",
+    )
+    ops_review_complete = _spec_phase_complete(
+        child_agents,
+        template="spec-ops-reviewer",
+        name_suffix="-spec-ops-review",
+    )
+    finalizer_complete = _spec_phase_complete(
+        child_agents,
+        template="spec-finalizer",
+        name_suffix="-spec-finalizer",
+    )
     placeholder_agents = [agent for agent in summaries if _has_placeholder_summary(agent)]
     placeholder_summary = bool(placeholder_agents)
     terminal = last_watch.get("terminal") or _round_terminal_status({
@@ -2210,7 +2274,12 @@ def _spec_round_progress_response(
     done = False
     status = "running" if summaries else "starting"
     round_finished = bool(terminal) or _round_agents_inactive(summaries)
-    if artifact_state["branch_changed"] and artifact_state["validation_status"] in {"passed", "skipped"}:
+    integration_branch_valid = (
+        artifact_state["branch_changed"]
+        and artifact_state["validation_status"] in {"passed", "skipped"}
+    )
+    protocol_complete = integration_branch_valid and ops_review_complete and finalizer_complete
+    if protocol_complete:
         done = True
         status = "completed"
     elif round_finished and placeholder_summary and not child_agents:
@@ -2240,8 +2309,26 @@ def _spec_round_progress_response(
             blockers.append(f"expected branch was not found on origin: {expected_branch}")
         elif not artifact_state["branch_changed"]:
             blockers.append(f"expected branch did not move from base SHA: {expected_branch}")
+        elif integration_branch_valid:
+            if not ops_review_agents:
+                blockers.append("spec operations reviewer was not spawned")
+            elif not ops_review_complete:
+                blockers.append("spec operations reviewer did not complete")
+            if not finalizer_agents:
+                blockers.append("spec finalizer was not spawned")
+            elif not finalizer_complete:
+                blockers.append("spec finalizer did not complete")
         if terminal and not blockers:
             blockers.append("round reported terminal status before a valid spec branch was available")
+
+    if integration_branch_valid and not protocol_complete and status in {"starting", "running"}:
+        missing = []
+        if not ops_review_complete:
+            missing.append("spec operations review")
+        if not finalizer_complete:
+            missing.append("spec finalizer")
+        if missing:
+            warnings.append(f"integration branch validates; waiting for {', '.join(missing)}")
 
     if progress["unhealthy_agents"] and status in {"starting", "running"}:
         status = "running_degraded"
@@ -2304,6 +2391,14 @@ def _spec_round_progress_response(
         "branch_changed": artifact_state["branch_changed"],
         "validation_status": artifact_state["validation_status"],
         "validation": artifact_state["validation"],
+        "protocol": {
+            "integration_branch_valid": integration_branch_valid,
+            "ops_review_agent_count": len(ops_review_agents),
+            "ops_review_complete": ops_review_complete,
+            "finalizer_agent_count": len(finalizer_agents),
+            "finalizer_complete": finalizer_complete,
+            "complete": protocol_complete,
+        },
         "blockers": blockers,
         "warnings": warnings,
         "terminal": terminal,

--- a/orchestrator/spec-round.sh
+++ b/orchestrator/spec-round.sh
@@ -24,6 +24,7 @@ ROUND_ID="$(printf '%s' "$ROUND_ID" | tr '[:upper:]' '[:lower:]')"
 CHANGE="${SCION_OPS_SPEC_CHANGE:-}"
 BASE_BRANCH="${BASE_BRANCH:-$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)}"
 BROKER="${SCION_KIND_CP_BROKER:-kind-control-plane}"
+COLLECTION_RECIPIENT="${SCION_OPS_COLLECTION_RECIPIENT:-user:dev@localhost}"
 if [[ -z "$BASE_BRANCH" ]]; then
   BASE_BRANCH="$(git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
 fi
@@ -110,6 +111,7 @@ round_id: $ROUND_ID
 base_branch: $BASE_BRANCH
 change: $CHANGE
 project_root: $AGENT_PROJECT_ROOT
+collection_recipient: $COLLECTION_RECIPIENT
 
 original_goal:
 $GOAL
@@ -130,6 +132,7 @@ printf 'Round id: %s\n' "$ROUND_ID"
 printf 'Base branch: %s\n' "$BASE_BRANCH"
 printf 'Change: %s\n' "${CHANGE:-<derive in round>}"
 printf 'Broker: %s\n' "$BROKER"
+printf 'Collection recipient: %s\n' "$COLLECTION_RECIPIENT"
 printf 'Grove root: %s\n' "$PROJECT_ROOT"
 printf 'Agent project root: %s\n' "$AGENT_PROJECT_ROOT"
 

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -425,8 +425,9 @@ truthy() {
 
 sync_harness_configs() {
   local pod="$1"
-  local configs=(claude codex gemini)
+  local configs=(claude codex codex-exec gemini)
   local existing=()
+  local repo_existing=()
 
   if [[ -d "$HARNESS_CONFIG_ROOT" ]]; then
     for config in "${configs[@]}"; do
@@ -443,6 +444,19 @@ sync_harness_configs() {
     log "no host harness configs found; using Hub image defaults"
   fi
 
+  if [[ -d "${REPO_ROOT}/deploy/kind/harness-configs" ]]; then
+    for config in "${configs[@]}"; do
+      [[ -d "${REPO_ROOT}/deploy/kind/harness-configs/${config}" ]] && repo_existing+=("$config")
+    done
+  fi
+
+  if [[ "${#repo_existing[@]}" -gt 0 ]]; then
+    log "copy repo-managed harness configs into Hub pod: ${repo_existing[*]}"
+    tar -C "${REPO_ROOT}/deploy/kind/harness-configs" -cf - "${repo_existing[@]}" |
+      kubectl_ctx -n "$NAMESPACE" exec -i "$pod" -c hub -- \
+        tar -C /home/scion/.scion/harness-configs -xf -
+  fi
+
   prepare_hub_harness_configs "$pod"
 
   log "sync harness configs from inside Hub pod"
@@ -453,6 +467,15 @@ sync_harness_configs() {
   for config in "${configs[@]}"; do
     run_in_hub "$pod" "SCION_DEV_TOKEN=${token} SCION_HUB_ENDPOINT=${hub_url} scion harness-config sync ${config} --hub ${hub_url} --non-interactive --yes"
   done
+
+  log "copy prepared harness configs into broker pod"
+  local broker
+  broker="$(broker_pod)"
+  run_in_broker "$broker" "mkdir -p /home/scion/.scion/harness-configs"
+  kubectl_ctx -n "$NAMESPACE" exec "$pod" -c hub -- \
+    tar -C /home/scion/.scion/harness-configs -cf - "${configs[@]}" |
+    kubectl_ctx -n "$NAMESPACE" exec -i "$broker" -c broker -- \
+      tar -C /home/scion/.scion/harness-configs -xf -
 }
 
 sync_templates() {


### PR DESCRIPTION
## Summary

Closes #119.

- require spec ops review and finalizer completion before MCP reports a spec round as PR-ready
- treat Kubernetes Succeeded/Completed container states as completed agent health, even when Hub activity later shows stalled
- route non-interactive child outputs through the Hub user inbox and teach coordinators to poll messages
- add repo-managed Codex codex/codex-exec harness configs and sync them into both Hub and broker during bootstrap
- update docs for the subscription-backed non-interactive harness flow

## Verification

- task verify
- task build:mcp
- task update:mcp
- task kind:mcp:smoke
- real MCP spec round completed for /workspace/github/dodwyer/scion-test, change create-redis-operator-1, branch round-20260507t121818z-16f9-spec-integration, SHA a794fe7e2c47b9f4e03350550d66a0a416b34a1c, validation passed
