### PR TITLE
Adopt OpenSpec CLI and Docker image workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ task down       # destroy the kind cluster and cluster-local state
 ## Prerequisites
 
 - `task`
-- `podman`
+- `docker`
 - `kind`
 - `kubectl`
 - `uv`
@@ -159,6 +159,9 @@ task spec:implement -- --change add-widget "Implement the approved change."
 MCP callers should prefer `scion_ops_run_spec_round` for spec rounds because it
 starts, monitors, validates, and returns the PR-ready branch in one repeatable
 tool loop.
+
+The MCP runtime uses the official OpenSpec CLI for validation and status when
+available, with the repo-local validator kept as the local fallback.
 
 OpenSpec operations are documented in
 [docs/openspec-round-workflow.md](docs/openspec-round-workflow.md).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -197,9 +197,9 @@ tasks:
       - bash scripts/storage-status.sh
 
   storage:prune:
-    prompt: This prunes dangling local Podman image layers. Continue?
+    prompt: This prunes dangling local Docker image layers. Continue?
     cmds:
-      - podman image prune -f
+      - docker image prune -f
       - task: storage:status
 
   destroy:
@@ -245,7 +245,12 @@ tasks:
 
   kind:control-plane:restart:
     cmds:
-      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub deploy/scion-broker deploy/scion-ops-mcp
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-hub
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-hub --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-broker
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-broker --timeout=120s
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-ops-mcp
+      - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout status deploy/scion-ops-mcp --timeout=120s
 
   kind:control-plane:status:
     cmds:
@@ -360,8 +365,9 @@ tasks:
     cmds:
       - git diff --check
       - task --list
-      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/archive-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-openspec-archive.py', 'scripts/test-verdict-schema.py')]"
+      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/archive-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-openspec-archive.py', 'scripts/test-mcp-openspec-cli.py', 'scripts/test-verdict-schema.py')]"
       - python3 scripts/test-openspec-change-validator.py
       - python3 scripts/test-openspec-archive.py
+      - uv run scripts/test-mcp-openspec-cli.py
       - python3 scripts/test-verdict-schema.py
       - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/release-smoke-round.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh deploy/kind/control-plane/config/broker-entrypoint.sh orchestrator/lib/github-branches.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/deploy/kind/control-plane/mcp-deployment.yaml
+++ b/deploy/kind/control-plane/mcp-deployment.yaml
@@ -73,6 +73,10 @@ spec:
               value: http://scion-hub:8090
             - name: SCION_HUB_ENDPOINT
               value: http://scion-hub:8090
+            - name: OPENSPEC_TELEMETRY
+              value: "0"
+            - name: DO_NOT_TRACK
+              value: "1"
             - name: SCION_K8S_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -142,8 +142,8 @@ task load:image -- localhost/scion-codex:latest
 task dev:test
 ```
 
-Use `task storage:status` before full image rebuilds. If Podman is using `vfs`,
-switch to overlay storage before large rebuild cycles.
+Use `task storage:status` before full image rebuilds. If Docker is using `vfs`,
+switch to `overlay2` storage before large rebuild cycles.
 
 ## Destroy
 

--- a/docs/openspec-round-workflow.md
+++ b/docs/openspec-round-workflow.md
@@ -138,5 +138,10 @@ Implementation PR review checks:
 
 ## Runtime Dependency Policy
 
-Validation remains repo-local and script-based. Do not add the OpenSpec CLI to
-runtime images unless the current validator leaves a concrete validation gap.
+The MCP runtime includes the pinned OpenSpec CLI and uses it for canonical
+`validate` and `status` results when available. The repo-local Python validator
+remains the fallback for local development and for environments where the CLI is
+not present.
+
+Archive remains script-based for now because the local command gives us a
+previewable, JSON result before moving files under `openspec/changes/archive/`.

--- a/image-build/scion-ops-mcp/Dockerfile
+++ b/image-build/scion-ops-mcp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG BASE_IMAGE=localhost/scion-base:latest
 FROM ${BASE_IMAGE}
+ARG OPENSPEC_VERSION=1.3.1
 
 USER root
 
@@ -9,8 +10,13 @@ ENV VIRTUAL_ENV=/opt/scion-ops-mcp/venv
 RUN python3 -m venv "${VIRTUAL_ENV}" \
   && "${VIRTUAL_ENV}/bin/pip" install --no-cache-dir "mcp>=1.13,<2" "PyYAML>=6,<7"
 
+RUN npm install -g "@fission-ai/openspec@${OPENSPEC_VERSION}" \
+  && npm cache clean --force
+
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
     PYTHONDONTWRITEBYTECODE=1 \
+    OPENSPEC_TELEMETRY=0 \
+    DO_NOT_TRACK=1 \
     SCION_OPS_ROOT=/workspace/scion-ops \
     SCION_OPS_MCP_TRANSPORT=streamable-http \
     SCION_OPS_MCP_HOST=0.0.0.0 \

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -68,6 +68,7 @@ SPEC_CHILD_TEMPLATES = {
     "spec-ops-reviewer",
     "spec-finalizer",
 }
+OPENSPEC_REQUIRED_FILES = ("proposal.md", "design.md", "tasks.md")
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -162,6 +163,15 @@ def _run(
             "command": args,
             "output": output,
             "error": f"command timed out after {timeout}s",
+        }
+    except OSError as exc:
+        return {
+            "ok": False,
+            "timed_out": False,
+            "returncode": None,
+            "command": args,
+            "output": "",
+            "error": str(exc),
         }
 
     ok = result.returncode == 0
@@ -1437,6 +1447,160 @@ def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _relative_to_root(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _openspec_cli_env() -> dict[str, str]:
+    return {
+        "OPENSPEC_TELEMETRY": "0",
+        "DO_NOT_TRACK": "1",
+        "NO_COLOR": "1",
+    }
+
+
+def _openspec_command_summary(result: dict[str, Any]) -> dict[str, Any]:
+    output = result.get("output", "")
+    if len(output) > 2000:
+        output = output[:2000] + "\n[truncated]"
+    return {
+        "ok": result.get("ok", False),
+        "timed_out": result.get("timed_out", False),
+        "returncode": result.get("returncode"),
+        "command": result.get("command", []),
+        "output": output,
+        "error": result.get("error", ""),
+    }
+
+
+def _openspec_change_file_metadata(root: Path, change: str) -> dict[str, Any]:
+    change_path = root / "openspec" / "changes" / change
+    specs_dir = change_path / "specs"
+    spec_files = sorted(path for path in specs_dir.glob("**/spec.md") if path.is_file()) if specs_dir.exists() else []
+    return {
+        "change_path": _relative_to_root(change_path, root),
+        "required_files": {
+            filename: _relative_to_root(change_path / filename, root) for filename in OPENSPEC_REQUIRED_FILES
+        },
+        "spec_files": [_relative_to_root(path, root) for path in spec_files],
+    }
+
+
+def _openspec_issue_to_finding(issue: Any, root: Path) -> dict[str, str]:
+    if isinstance(issue, dict):
+        path = issue.get("path") or issue.get("file") or issue.get("location") or ""
+        message = issue.get("message") or issue.get("error") or issue.get("detail") or json.dumps(issue, sort_keys=True)
+    else:
+        path = ""
+        message = str(issue)
+    if isinstance(path, list):
+        path = ".".join(str(item) for item in path)
+    path = str(path or root)
+    return {"path": path, "message": str(message)}
+
+
+def _openspec_validate_payload(root: Path, change: str, cli_payload: dict[str, Any]) -> dict[str, Any]:
+    items = cli_payload.get("items", [])
+    selected_item: dict[str, Any] = {}
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict) and item.get("id") == change:
+                selected_item = item
+                break
+        if not selected_item and len(items) == 1 and isinstance(items[0], dict):
+            selected_item = items[0]
+
+    issues = selected_item.get("issues", []) if selected_item else []
+    if not isinstance(issues, list):
+        issues = [issues]
+    totals = cli_payload.get("summary", {}).get("totals", {}) if isinstance(cli_payload.get("summary"), dict) else {}
+    failed_count = totals.get("failed") if isinstance(totals, dict) else None
+    if isinstance(selected_item.get("valid"), bool):
+        ok = selected_item["valid"]
+    elif isinstance(failed_count, int):
+        ok = failed_count == 0
+    else:
+        ok = not issues
+
+    return {
+        "ok": ok,
+        "validator": "openspec_cli",
+        "project_root": str(root),
+        "change": change,
+        **_openspec_change_file_metadata(root, change),
+        "errors": [] if ok else [_openspec_issue_to_finding(issue, root) for issue in issues],
+        "warnings": [],
+        "openspec_cli": cli_payload,
+    }
+
+
+def _run_openspec_validation(root: Path, change: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    result = _run(
+        ["openspec", "validate", change, "--json", "--no-interactive"],
+        timeout=30,
+        cwd=root,
+        env=_openspec_cli_env(),
+    )
+    payload = _parse_json_result(result)
+    if not payload:
+        return result, {}
+
+    validation = _openspec_validate_payload(root, change, payload)
+    command_result = _command_result(result)
+    command_result["source"] = "openspec_cli"
+    if not validation.get("ok"):
+        command_result["error_kind"] = "openspec_validation"
+    return command_result, validation
+
+
+def _run_python_openspec_validation(
+    root: Path,
+    change: str,
+    cli_attempt: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    result = _run(
+        [
+            "python3",
+            str(_repo_root() / "scripts" / "validate-openspec-change.py"),
+            "--project-root",
+            str(root),
+            "--change",
+            change,
+            "--json",
+        ],
+        timeout=20,
+        cwd=_repo_root(),
+    )
+    payload = _parse_json_result(result)
+    if payload:
+        payload["validator"] = "scion_ops_python"
+        if cli_attempt:
+            payload["openspec_cli_attempt"] = _openspec_command_summary(cli_attempt)
+    command_result = _command_result(result)
+    command_result["source"] = "scion_ops_python"
+    if payload and not payload.get("ok"):
+        command_result["error_kind"] = "openspec_validation"
+    return command_result, payload
+
+
+def _openspec_status_result(root: Path, change: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    result = _run(
+        ["openspec", "status", "--change", change, "--json"],
+        timeout=20,
+        cwd=root,
+        env=_openspec_cli_env(),
+    )
+    payload = _parse_json_result(result)
+    command_result = _command_result(result)
+    command_result["source"] = "openspec_cli_status"
+    if not payload and not result.get("ok"):
+        command_result["error_kind"] = "openspec_status"
+    return command_result, payload
+
+
 def _parse_started_round_id(output: str, fallback: str = "") -> str:
     for pattern in (r"round_id\s*:\s*(\S+)", r"Round id:\s*(\S+)"):
         match = re.search(pattern, output, flags=re.IGNORECASE)
@@ -1472,24 +1636,12 @@ def _start_round_response(
 
 
 def _validate_spec_change_result(root: Path, change: str) -> tuple[dict[str, Any], dict[str, Any]]:
-    result = _run(
-        [
-            "python3",
-            str(_repo_root() / "scripts" / "validate-openspec-change.py"),
-            "--project-root",
-            str(root),
-            "--change",
-            change,
-            "--json",
-        ],
-        timeout=20,
-        cwd=_repo_root(),
-    )
-    payload = _parse_json_result(result)
-    command_result = _command_result(result)
-    if payload and not payload.get("ok"):
-        command_result["error_kind"] = "openspec_validation"
-    return command_result, payload
+    if _env_bool("SCION_OPS_USE_OPENSPEC_CLI", True):
+        cli_result, cli_payload = _run_openspec_validation(root, change)
+        if cli_payload:
+            return cli_result, cli_payload
+        return _run_python_openspec_validation(root, change, cli_result)
+    return _run_python_openspec_validation(root, change)
 
 
 def _archive_spec_change_result(root: Path, change: str, confirm: bool) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -2116,10 +2268,14 @@ def scion_ops_spec_status(project_root: str, change: str = "") -> dict[str, Any]
             archived_changes.append({"archive": path.name, "path": str(path.relative_to(root))})
     validation: dict[str, Any] = {}
     validation_result: dict[str, Any] = {}
+    openspec_status: dict[str, Any] = {}
+    openspec_status_result: dict[str, Any] = {}
     ok = True
     if change:
         change = _clean_name(change, "change")
         validation_result, validation = _validate_spec_change_result(root, change)
+        if validation.get("validator") == "openspec_cli":
+            openspec_status_result, openspec_status = _openspec_status_result(root, change)
         ok = bool(validation.get("ok"))
     return {
         "ok": ok,
@@ -2132,6 +2288,8 @@ def scion_ops_spec_status(project_root: str, change: str = "") -> dict[str, Any]
         "change": change,
         "validation": validation,
         "validation_result": validation_result,
+        "openspec_status": openspec_status,
+        "openspec_status_result": openspec_status_result,
         "next": {
             "draft_spec_tool": "scion_ops_start_spec_round",
             "validate_tool": "scion_ops_validate_spec_change",

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build Scion container images natively with podman, single-arch.
+# Build Scion container images natively with Docker, single-arch.
 #
 # Requires the upstream scion source checked out (we read its image-build/
 # Dockerfiles). By default it expects the source at
@@ -49,7 +49,7 @@ while [[ $# -gt 0 ]]; do
       BUILD_MCP=0
       case "$2" in
         core) BUILD_CORE=1 ;;
-        base) BUILD_BASE=1 ;;
+        base) BUILD_CORE=1; BUILD_BASE=1 ;;
         harnesses) BUILD_HARNESSES=1 ;;
         mcp) BUILD_MCP=1 ;;
         claude|codex|gemini|opencode)
@@ -87,7 +87,8 @@ EOF
 done
 
 [[ -d "$SCION_SRC/image-build" ]] || { red "scion source not found at $SCION_SRC"; exit 1; }
-command -v podman >/dev/null || { red "podman not on PATH"; exit 1; }
+command -v docker >/dev/null || { red "docker not on PATH"; exit 1; }
+docker info >/dev/null 2>&1 || { red "docker daemon is not available"; exit 1; }
 
 "$REPO_ROOT/scripts/scion-runtime-patches.sh" ensure --src "$SCION_SRC"
 
@@ -97,18 +98,18 @@ storage_preflight() {
   [[ "${SCION_OPS_SKIP_STORAGE_CHECK:-}" == "1" ]] && return
 
   local driver graph_root available_kb
-  driver="$(podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || true)"
-  graph_root="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || true)"
+  driver="$(docker info --format '{{.Driver}}' 2>/dev/null || true)"
+  graph_root="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
 
   if [[ "$driver" == "vfs" ]]; then
-    printf '\033[33m%s\033[0m\n' "Warning: Podman is using the vfs storage driver; image rebuilds will consume much more disk than overlay-backed storage."
+    printf '\033[33m%s\033[0m\n' "Warning: Docker is using the vfs storage driver; image rebuilds will consume much more disk than overlay-backed storage."
     printf '\033[33m%s\033[0m\n' "         Use targeted build tasks, or run 'task storage:status' and 'task storage:prune' before a full build."
   fi
 
   if [[ -n "$graph_root" && -d "$graph_root" ]]; then
     available_kb="$(df -Pk "$graph_root" | awk 'NR == 2 {print $4}')"
     if [[ -n "$available_kb" && "$available_kb" -lt 41943040 ]]; then
-      red "Podman storage has less than 40GiB available at $graph_root."
+      red "Docker storage has less than 40GiB available at $graph_root."
       red "Run 'task storage:status' and prune old images before building."
       exit 1
     fi
@@ -119,7 +120,7 @@ build() {
   local name="$1" dockerfile="$2" context="$3"; shift 3
   local tag="${REGISTRY}/${name}:${TAG}"
   log "build $tag"
-  podman build \
+  docker build \
     --tag "$tag" \
     --file "$dockerfile" \
     "$@" \
@@ -174,4 +175,4 @@ fi
 green ""
 green "All images built."
 echo  "Configure scion:  scion config set --global image_registry ${REGISTRY}"
-podman images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" | awk 'NR==1 || /scion|core-base/' | head -10
+docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" | awk 'NR==1 || /scion|core-base/' | head -10

--- a/scripts/kind-bootstrap.sh
+++ b/scripts/kind-bootstrap.sh
@@ -165,8 +165,12 @@ PY
 }
 
 restart_control_plane_for_restored_auth_state() {
-  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-hub deploy/scion-broker deploy/scion-ops-mcp >/dev/null
-  wait_for_control_plane_rollouts
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-hub >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-hub --timeout=120s >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-broker >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-broker --timeout=120s >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout restart deploy/scion-ops-mcp >/dev/null
+  kubectl_ctx -n "$NAMESPACE" rollout status deploy/scion-ops-mcp --timeout=120s >/dev/null
   log "restarted Hub, broker, and MCP after auth/session Secret restore"
 }
 

--- a/scripts/kind-scion-runtime.sh
+++ b/scripts/kind-scion-runtime.sh
@@ -32,7 +32,7 @@ case "$REPO_ROOT" in
     SCION_OPS_REPO_NODE_PATH="${SCION_OPS_REPO_NODE_PATH:-${WORKSPACE_NODE_PATH}/scion-ops}"
     ;;
 esac
-KIND_PROVIDER="${KIND_EXPERIMENTAL_PROVIDER:-${SCION_OPS_KIND_PROVIDER:-docker}}"
+KIND_PROVIDER="docker"
 KIND_CLUSTER_CONFIG_TEMPLATE="${SCION_OPS_KIND_CLUSTER_CONFIG_TEMPLATE:-${REPO_ROOT}/deploy/kind/cluster.yaml.tpl}"
 KIND_LISTEN_ADDRESS="${SCION_OPS_KIND_LISTEN_ADDRESS:-192.168.122.103}"
 HUB_HOST_PORT="${SCION_OPS_KIND_HUB_PORT:-18090}"
@@ -73,8 +73,6 @@ Environment:
                                  (default: /workspace)
   SCION_OPS_REPO_NODE_PATH       scion-ops repo path inside the kind node
                                  (default: derived from host/node paths)
-  SCION_OPS_KIND_PROVIDER        kind provider when KIND_EXPERIMENTAL_PROVIDER
-                                 is unset (default: docker)
   SCION_OPS_KIND_CLUSTER_CONFIG_TEMPLATE
                                  kind cluster template (default: deploy/kind/cluster.yaml.tpl)
   SCION_OPS_KIND_LISTEN_ADDRESS  Host listen address for kind port mappings
@@ -149,28 +147,10 @@ kind_node_name() {
 
 container_runtime_for_node() {
   local node="$1"
-  local runtime
-  local runtimes
-
-  case "$KIND_PROVIDER" in
-    podman)
-      runtimes=(podman docker)
-      ;;
-    docker)
-      runtimes=(docker podman)
-      ;;
-    *)
-      runtimes=("$KIND_PROVIDER" podman docker)
-      ;;
-  esac
-
-  for runtime in "${runtimes[@]}"; do
-    if command -v "$runtime" >/dev/null 2>&1 && "$runtime" container inspect "$node" >/dev/null 2>&1; then
-      printf '%s\n' "$runtime"
-      return 0
-    fi
-  done
-
+  if command -v docker >/dev/null 2>&1 && docker container inspect "$node" >/dev/null 2>&1; then
+    printf 'docker\n'
+    return 0
+  fi
   return 1
 }
 
@@ -365,7 +345,7 @@ cmd_load_images() {
 
   for image in "$@"; do
     log "load image $image into $CLUSTER_NAME"
-    if command -v podman >/dev/null 2>&1 && podman image exists "$image" && image_loaded_in_kind "$image"; then
+    if command -v docker >/dev/null 2>&1 && docker image inspect "$image" >/dev/null 2>&1 && image_loaded_in_kind "$image"; then
       log "image $image already loaded in $CLUSTER_NAME"
       continue
     fi
@@ -376,23 +356,8 @@ cmd_load_images() {
       continue
     fi
 
-    if ! command -v podman >/dev/null 2>&1 || ! podman image exists "$image"; then
-      printf '%s\n' "$load_output" >&2
-      die "image $image is not available to kind or podman; run: task build"
-    fi
-
-    local archive
-    archive="$(mktemp "${TMPDIR:-/tmp}/scion-kind-image.XXXXXX.tar")"
-    log "export podman image $image for kind"
-    if ! podman save "$image" -o "$archive"; then
-      rm -f "$archive"
-      die "failed to export podman image $image"
-    fi
-    if ! import_image_archive "$archive"; then
-      rm -f "$archive"
-      die "failed to load podman archive for $image into $CLUSTER_NAME"
-    fi
-    rm -f "$archive"
+    printf '%s\n' "$load_output" >&2
+    die "image $image is not available to Docker or failed to load into kind; run: task build"
   done
 }
 
@@ -401,7 +366,7 @@ image_loaded_in_kind() {
   local image_id node runtime
   local nodes=()
 
-  image_id="$(podman image inspect "$image" --format '{{.Id}}' 2>/dev/null || true)"
+  image_id="$(docker image inspect "$image" --format '{{.Id}}' 2>/dev/null || true)"
   image_id="${image_id#sha256:}"
   [[ -n "$image_id" ]] || return 1
 
@@ -429,9 +394,6 @@ import_image_archive() {
     [[ -n "$node" ]] || continue
     runtime="$(container_runtime_for_node "$node")" || return 1
     snapshotter="${SCION_OPS_KIND_IMAGE_SNAPSHOTTER:-}"
-    if [[ -z "$snapshotter" && "$runtime" == "podman" ]]; then
-      snapshotter="fuse-overlayfs"
-    fi
 
     import_cmd=(ctr --namespace=k8s.io images import --local --digests --platform "$KIND_IMAGE_PLATFORM")
     if [[ -n "$snapshotter" ]]; then

--- a/scripts/storage-status.sh
+++ b/scripts/storage-status.sh
@@ -6,26 +6,22 @@ warn() {
   printf '\033[33m%s\033[0m\n' "$*"
 }
 
-if ! command -v podman >/dev/null 2>&1; then
-  echo "podman is not on PATH"
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is not on PATH"
   exit 1
 fi
 
-driver="$(podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || true)"
-graph_root="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || true)"
-run_root="$(podman info --format '{{.Store.RunRoot}}' 2>/dev/null || true)"
-image_tmp="$(podman info --format '{{.Store.ImageCopyTmpDir}}' 2>/dev/null || true)"
+driver="$(docker info --format '{{.Driver}}' 2>/dev/null || true)"
+graph_root="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
 
-printf 'Podman storage\n'
+printf 'Docker storage\n'
 printf '  driver:   %s\n' "${driver:-unknown}"
-printf '  graph:    %s\n' "${graph_root:-unknown}"
-printf '  run:      %s\n' "${run_root:-unknown}"
-printf '  tmp:      %s\n\n' "${image_tmp:-unknown}"
+printf '  root:     %s\n\n' "${graph_root:-unknown}"
 
 if [[ "$driver" == "vfs" ]]; then
   warn "Warning: vfs copies layers instead of sharing them efficiently."
   warn "         Full Scion image rebuilds can consume hundreds of GiB."
-  warn "         Rootless Podman should use overlay storage for normal work."
+  warn "         Docker should use overlay2 storage for normal work."
   warn "         Prefer task dev:* or targeted task build:* commands for iteration."
   printf '\n'
 fi
@@ -39,8 +35,8 @@ if [[ -n "$graph_root" && -d "$graph_root" ]]; then
   printf '\n'
 fi
 
-podman system df
+docker system df
 
 printf '\nLargest scion images\n'
-podman images --format 'table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}' |
+docker images --format 'table {{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}' |
   awk 'NR == 1 || /localhost\/(core-base|scion-)/'

--- a/scripts/test-mcp-openspec-cli.py
+++ b/scripts/test-mcp-openspec-cli.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "mcp>=1.13,<2",
+#   "PyYAML>=6,<7",
+# ]
+# ///
+"""Exercise MCP OpenSpec CLI selection and fallback behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_mcp_module():
+    os.environ.setdefault("SCION_OPS_ROOT", str(ROOT))
+    spec = importlib.util.spec_from_file_location("scion_ops_mcp", ROOT / "mcp_servers" / "scion_ops.py")
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load mcp_servers/scion_ops.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["scion_ops_mcp"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _sample_change(root: Path) -> None:
+    change = root / "openspec" / "changes" / "add-widget"
+    _write(change / "proposal.md", "# Proposal: Add Widget\n\nAdd widget behavior.\n")
+    _write(change / "design.md", "# Design: Add Widget\n\nUse the existing path.\n")
+    _write(change / "tasks.md", "# Tasks\n\n- [ ] 1.1 Add widget behavior\n")
+    _write(
+        change / "specs" / "widgets" / "spec.md",
+        "# Delta for Widgets\n\n"
+        "## ADDED Requirements\n\n"
+        "### Requirement: Widget Creation\n"
+        "The system SHALL create a widget.\n\n"
+        "#### Scenario: Create widget\n"
+        "- GIVEN a valid request\n"
+        "- WHEN the widget is created\n"
+        "- THEN the widget is visible\n",
+    )
+
+
+def _fake_openspec(bin_dir: Path) -> None:
+    script = bin_dir / "openspec"
+    script.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import sys
+
+            args = sys.argv[1:]
+            if args and args[0] == "validate":
+                change = args[1]
+                print(json.dumps({
+                    "items": [{"id": change, "type": "change", "valid": True, "issues": []}],
+                    "summary": {"totals": {"items": 1, "passed": 1, "failed": 0}},
+                    "version": "1.0",
+                }))
+                raise SystemExit(0)
+            if args and args[0] == "status":
+                change = args[args.index("--change") + 1]
+                print(json.dumps({
+                    "changeName": change,
+                    "isComplete": True,
+                    "artifacts": [{"id": "tasks", "outputPath": "tasks.md", "status": "done"}],
+                }))
+                raise SystemExit(0)
+            raise SystemExit(2)
+            """
+        )
+    )
+    script.chmod(0o755)
+
+
+def main() -> int:
+    module = _load_mcp_module()
+    old_path = os.environ.get("PATH", "")
+    old_cli_flag = os.environ.get("SCION_OPS_USE_OPENSPEC_CLI")
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "project"
+            bin_dir = Path(tmp) / "bin"
+            bin_dir.mkdir()
+            _sample_change(root)
+            _fake_openspec(bin_dir)
+
+            os.environ["PATH"] = f"{bin_dir}:{old_path}"
+            os.environ["SCION_OPS_USE_OPENSPEC_CLI"] = "1"
+
+            result, payload = module._validate_spec_change_result(root, "add-widget")
+            assert result["source"] == "openspec_cli", result
+            assert payload["validator"] == "openspec_cli", payload
+            assert payload["ok"] is True, payload
+            assert payload["spec_files"] == ["openspec/changes/add-widget/specs/widgets/spec.md"], payload
+
+            status_result, status = module._openspec_status_result(root, "add-widget")
+            assert status_result["source"] == "openspec_cli_status", status_result
+            assert status["changeName"] == "add-widget", status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "project"
+            _sample_change(root)
+            os.environ["SCION_OPS_USE_OPENSPEC_CLI"] = "0"
+            result, payload = module._validate_spec_change_result(root, "add-widget")
+            assert result["source"] == "scion_ops_python", result
+            assert payload["validator"] == "scion_ops_python", payload
+            assert payload["ok"] is True, payload
+            assert "openspec_cli_attempt" not in payload, payload
+    finally:
+        os.environ["PATH"] = old_path
+        if old_cli_flag is None:
+            os.environ.pop("SCION_OPS_USE_OPENSPEC_CLI", None)
+        else:
+            os.environ["SCION_OPS_USE_OPENSPEC_CLI"] = old_cli_flag
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Pin OpenSpec CLI in the MCP image and use it for MCP validation/status with Python fallback.
- Align image build, storage, and kind image loading around Docker.
- Restart Hub, broker, and MCP in dependency order so broker dispatch survives `task up`.
- Update operational docs and verification coverage.

Closes #123.

## Verification
- `task verify`
- `task storage:status`
- `task build:base`
- `task build:mcp`
- `task build`
- `task update:mcp`
- `task up`
- `task kind:mcp:smoke`
- `task test -- --skip-setup`
- MCP `scion_ops_validate_spec_change` returned `validator: openspec_cli` and `ok: true` for `/home/david/workspace/github/dodwyer/scion-test` change `add-readme-development-note`
