### PR TITLE
Persist broker runtime state

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ check.
 `task down` deletes the kind cluster and all cluster-local PVCs and Secrets.
 Host workspace checkouts survive because they are outside the cluster.
 
-Cluster-local state includes Hub DB/storage, dev auth, broker credentials,
-synced templates, harness configs, MCP-prepared GitHub checkouts, and restored
-model credentials. Recreate it with:
+Cluster-local state includes Hub DB/storage, broker runtime state, dev auth,
+broker credentials, synced templates, harness configs, MCP-prepared GitHub
+checkouts, and restored model credentials. Recreate it with:
 
 ```bash
 task up

--- a/deploy/kind/control-plane/broker-deployment.yaml
+++ b/deploy/kind/control-plane/broker-deployment.yaml
@@ -88,7 +88,8 @@ spec:
               readOnly: true
       volumes:
         - name: state
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: scion-broker-state
         - name: settings
           configMap:
             name: scion-hub-settings

--- a/deploy/kind/control-plane/broker-pvc.yaml
+++ b/deploy/kind/control-plane/broker-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scion-broker-state
+  labels:
+    app.kubernetes.io/name: scion-broker
+    app.kubernetes.io/component: broker
+    app.kubernetes.io/part-of: scion-control-plane
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kind/control-plane/kustomization.yaml
+++ b/deploy/kind/control-plane/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: scion-agents
 resources:
   - broker-rbac.yaml
+  - broker-pvc.yaml
   - broker-deployment.yaml
   - mcp-rbac.yaml
   - hub-pvc.yaml

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -104,6 +104,8 @@ It restores:
 
 Codex-backed personas use the repo-managed `codex-exec` harness config.
 Claude templates use `--print` for non-interactive execution.
+Broker runtime state is backed by a PVC so synced templates and harness configs
+survive normal broker pod restarts.
 
 ## Project Targeting
 


### PR DESCRIPTION
Closes #125\n\n## Summary\n- add a broker runtime PVC to the kind control-plane manifests\n- mount broker state from the PVC instead of emptyDir\n- document that synced broker templates and harness configs survive normal pod restarts\n\n## Verification\n- task verify