### PR TITLE
Return concise MCP progress updates

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -365,9 +365,10 @@ tasks:
     cmds:
       - git diff --check
       - task --list
-      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/archive-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-openspec-archive.py', 'scripts/test-mcp-openspec-cli.py', 'scripts/test-verdict-schema.py')]"
+      - python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('mcp_servers/scion_ops.py', 'scripts/kind-control-plane-smoke.py', 'scripts/smoke-mcp-server.py', 'scripts/validate-openspec-change.py', 'scripts/archive-openspec-change.py', 'scripts/test-openspec-change-validator.py', 'scripts/test-openspec-archive.py', 'scripts/test-mcp-openspec-cli.py', 'scripts/test-mcp-progress-lines.py', 'scripts/test-verdict-schema.py')]"
       - python3 scripts/test-openspec-change-validator.py
       - python3 scripts/test-openspec-archive.py
       - uv run scripts/test-mcp-openspec-cli.py
+      - uv run scripts/test-mcp-progress-lines.py
       - python3 scripts/test-verdict-schema.py
       - bash -n scripts/build-images.sh scripts/kind-bootstrap.sh scripts/kind-round-preflight.sh scripts/release-smoke-round.sh scripts/scion-runtime-patches.sh scripts/storage-status.sh deploy/kind/control-plane/config/broker-entrypoint.sh orchestrator/lib/github-branches.sh orchestrator/run-round.sh orchestrator/round.sh orchestrator/spec-round.sh orchestrator/spec-implementation-round.sh orchestrator/abort.sh

--- a/mcp_servers/scion_ops.py
+++ b/mcp_servers/scion_ops.py
@@ -1821,11 +1821,14 @@ def scion_ops_round_events(
     except HubAPIError as exc:
         return _hub_error_payload(exc, "round_events")
     events = _round_events_since(snapshot, previous, include_existing=include_existing)
+    progress_lines = _snapshot_progress_lines(snapshot, round_id)
     return {
         "ok": all(snapshot["commands_ok"].values()),
         "source": "hub_api",
         "hub": snapshot.get("hub"),
         "round_id": round_id,
+        "summary": progress_lines[0] if progress_lines else f"round {round_id} observed",
+        "progress_lines": progress_lines,
         "changed": bool(events),
         "events": events,
         "cursor": _encode_cursor(snapshot),
@@ -1882,11 +1885,14 @@ def scion_ops_watch_round_events(
         events = _round_events_since(snapshot, previous, include_existing=include_existing)
         terminal = _round_terminal_status(snapshot)
         if events or terminal:
+            progress_lines = _snapshot_progress_lines(snapshot, round_id)
             return {
                 "ok": all(snapshot["commands_ok"].values()),
                 "source": "hub_api",
                 "hub": snapshot.get("hub"),
                 "round_id": round_id,
+                "summary": progress_lines[0] if progress_lines else f"round {round_id} observed",
+                "progress_lines": progress_lines,
                 "changed": bool(events),
                 "events": events,
                 "cursor": _encode_cursor(snapshot),
@@ -1904,11 +1910,14 @@ def scion_ops_watch_round_events(
         snapshot = last_snapshot or _round_event_snapshot(round_id, project_root)
     except HubAPIError as exc:
         return _hub_error_payload(exc, "watch_round_events")
+    progress_lines = _snapshot_progress_lines(snapshot, round_id)
     return {
         "ok": all(snapshot["commands_ok"].values()),
         "source": "hub_api",
         "hub": snapshot.get("hub"),
         "round_id": round_id,
+        "summary": progress_lines[0] if progress_lines else f"round {round_id} observed",
+        "progress_lines": progress_lines,
         "changed": False,
         "events": [],
         "cursor": _encode_cursor(snapshot),
@@ -2549,6 +2558,62 @@ def _latest_event_summaries(events: list[dict[str, Any]]) -> list[str]:
     return summaries
 
 
+def _agent_progress_line(agent: dict[str, Any]) -> str:
+    name = str(agent.get("name") or agent.get("template") or "agent")
+    health = str(agent.get("health") or "unknown")
+    summary = _short_text(agent.get("summary"), limit=180)
+    if health == "completed":
+        status = "complete"
+    elif health == "pending":
+        status = "started"
+    else:
+        status = health
+    detail = f" {summary}" if summary else ""
+    return _short_text(f"agent {name} {status}{detail}", limit=260)
+
+
+def _round_progress_lines(
+    *,
+    round_id: str,
+    status: str,
+    progress: dict[str, Any],
+    validation_status: str = "",
+    pr_ready_branch: str = "",
+    blockers: list[str] | None = None,
+    warnings: list[str] | None = None,
+) -> list[str]:
+    active = progress.get("active_agents", [])
+    completed = progress.get("completed_agents", [])
+    unhealthy = progress.get("unhealthy_agents", [])
+    parts = [
+        f"round {round_id} {status}",
+        f"agents={progress.get('agent_count', 0)}",
+        f"active={len(active)}",
+        f"complete={len(completed)}",
+        f"unhealthy={len(unhealthy)}",
+    ]
+    if validation_status:
+        parts.append(f"validation={validation_status}")
+    lines = [" ".join(parts)]
+    lines.extend(_agent_progress_line(agent) for agent in unhealthy)
+    lines.extend(_agent_progress_line(agent) for agent in active)
+    lines.extend(_agent_progress_line(agent) for agent in completed)
+    if pr_ready_branch:
+        lines.append(f"round {round_id} complete branch {pr_ready_branch}")
+    for warning in warnings or []:
+        lines.append(_short_text(f"warning {warning}", limit=260))
+    for blocker in blockers or []:
+        lines.append(_short_text(f"blocker {blocker}", limit=260))
+    return lines
+
+
+def _snapshot_progress_lines(snapshot: dict[str, Any], round_id: str) -> list[str]:
+    progress = _round_agent_progress(snapshot.get("agents", []))
+    terminal = _round_terminal_status(snapshot)
+    status = "completed" if terminal else "running" if progress["active_agents"] else "observed"
+    return _round_progress_lines(round_id=round_id, status=status, progress=progress)
+
+
 def _spec_round_artifact_state(
     *,
     target_root: Path,
@@ -2758,6 +2823,15 @@ def _spec_round_progress_response(
     elif not summaries:
         overall_health = "starting"
 
+    progress_lines = _round_progress_lines(
+        round_id=round_id,
+        status=status,
+        progress=progress,
+        validation_status=artifact_state["validation_status"],
+        pr_ready_branch=expected_branch if status == "completed" else "",
+        blockers=blockers,
+        warnings=warnings,
+    )
     artifacts = artifact_state["artifacts"] if done else {
         "source": artifact_state["artifacts"].get("source"),
         "project_root": artifact_state["artifacts"].get("project_root"),
@@ -2792,6 +2866,8 @@ def _spec_round_progress_response(
         "done": done,
         "status": status,
         "health": overall_health,
+        "summary": progress_lines[0] if progress_lines else f"round {round_id} {status}",
+        "progress_lines": progress_lines,
         "source": "spec_round_runner",
         "project_root": project_root,
         "round_id": round_id,

--- a/scripts/test-mcp-progress-lines.py
+++ b/scripts/test-mcp-progress-lines.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "mcp>=1.13,<2",
+#   "PyYAML>=6,<7",
+# ]
+# ///
+"""Exercise compact MCP progress line helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_mcp_module():
+    os.environ.setdefault("SCION_OPS_ROOT", str(ROOT))
+    spec = importlib.util.spec_from_file_location("scion_ops_mcp", ROOT / "mcp_servers" / "scion_ops.py")
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load mcp_servers/scion_ops.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["scion_ops_mcp"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    module = _load_mcp_module()
+    progress = {
+        "agent_count": 3,
+        "active_agents": [
+            {
+                "name": "round-test-spec-consensus",
+                "health": "running",
+                "summary": "",
+            }
+        ],
+        "completed_agents": [
+            {
+                "name": "round-test-spec-author",
+                "health": "completed",
+                "summary": "wrote OpenSpec artifacts",
+            }
+        ],
+        "unhealthy_agents": [
+            {
+                "name": "round-test-spec-review",
+                "health": "stalled",
+                "summary": "waiting for branch",
+            }
+        ],
+    }
+
+    lines = module._round_progress_lines(
+        round_id="test",
+        status="running_degraded",
+        progress=progress,
+        validation_status="pending",
+        warnings=["integration branch validates; waiting for finalizer"],
+    )
+    assert lines[0] == "round test running_degraded agents=3 active=1 complete=1 unhealthy=1 validation=pending"
+    assert "agent round-test-spec-consensus running" in lines
+    assert "agent round-test-spec-author complete wrote OpenSpec artifacts" in lines
+    assert "agent round-test-spec-review stalled waiting for branch" in lines
+    assert lines[-1] == "warning integration branch validates; waiting for finalizer"
+
+    complete_lines = module._round_progress_lines(
+        round_id="test",
+        status="completed",
+        progress={**progress, "active_agents": [], "unhealthy_agents": []},
+        validation_status="passed",
+        pr_ready_branch="round-test-spec-integration",
+    )
+    assert complete_lines[0] == "round test completed agents=3 active=0 complete=1 unhealthy=0 validation=passed"
+    assert complete_lines[-1] == "round test complete branch round-test-spec-integration"
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #127\n\n## Summary\n- add top-level summary and progress_lines to spec round responses\n- add summary and progress_lines to round event/watch responses\n- add a focused test for compact progress line formatting\n\n## Verification\n- task verify\n- task dev:mcp:restart\n- HTTP MCP call to scion_ops_run_spec_round for round 20260508t131820z-5e39 returned summary/progress_lines and PR-ready branch