### PR TITLE
OpenSpec: holly-ops-branding

### DIFF
--- a/openspec/changes/holly-ops-branding/design.md
+++ b/openspec/changes/holly-ops-branding/design.md
@@ -1,0 +1,54 @@
+# Design: Holly Ops Branding
+
+## Overview
+
+The implementation should treat Holly Ops as a display-layer brand, not a runtime migration. The web app remains the read-only browser surface over Scion Hub, Runtime Broker, MCP, Kubernetes, OpenSpec, and steward-session state, but the operator-facing experience should no longer present `scion-ops hub` as the product name.
+
+## Naming Model
+
+Display names:
+
+- Product experience: `Holly Ops`
+- Web UI: `Holly Ops Drive`
+- Web UI short name: `HHD`
+- Operator-facing bot/coordinator persona: `Holly`
+
+Preserved runtime names:
+
+- Scion primitives: Hub, Runtime Broker, agents, MCP, templates, steward sessions, rounds, OpenSpec
+- MCP server identity, tool names, resource URIs, result field names, and protocol semantics
+- Kubernetes resource names and kind cluster/resource conventions
+- `.scion-ops` paths and persisted session state
+- Branch names, template names, kind names, environment variables, package/module names, and CLI command names unless a specific item is clearly display-only
+
+## Web UI Copy
+
+The web UI should update visible product chrome and browser metadata to use Holly Ops Drive. This includes the document title, main heading, navigation labels where they name the app, read-only error messages, startup log messages intended for operators, and empty/degraded copy that currently describes the browser surface as the scion-ops hub.
+
+HHD may be used where constrained UI space benefits from a short label, but the first prominent app identity should use Holly Ops Drive. Views that describe backing systems should continue to use Scion names when referring to actual runtime sources, for example Scion Hub readiness, MCP status, broker registration, agent state, and steward-session evidence.
+
+## Coordinator Copy
+
+Operator-facing copy that describes the action-taking coordinator or bot should call it Holly. This should be limited to display text such as headings, labels, summaries, and operator help text.
+
+Structured data, source identifiers, agent records, log-derived fields, MCP fields, and status payloads that use `coordinator` as a runtime role should remain unchanged. The UI may render a display label of Holly for those records while preserving the source role for diagnostics.
+
+## Compatibility Boundaries
+
+The implementation should avoid broad search-and-replace changes. Strings must be evaluated by role:
+
+- Display copy naming the product or web UI should change to Holly Ops, Holly Ops Drive, or HHD.
+- Display copy naming the operator-facing coordinator persona should change to Holly.
+- Runtime identifiers and compatibility contracts should stay as-is.
+- Documentation should distinguish display names from preserved implementation names where both appear.
+
+No migration is required for existing state. Any future change that renames MCP tools, Kubernetes resources, `.scion-ops` paths, branch conventions, or Scion primitive names should be proposed separately with an explicit migration plan.
+
+## Verification Strategy
+
+Verification should include focused checks that the user-visible web app name changed and that compatibility-sensitive identifiers did not change. Suitable checks include:
+
+- Web app fixture or snapshot tests for title, heading, and coordinator display labels.
+- Static review or tests for startup/operator-facing copy where the app name is emitted.
+- Existing MCP, web app, and kind manifest tests to confirm tool names, resource names, and `.scion-ops` paths remain stable.
+- OpenSpec validation for this change artifact.

--- a/openspec/changes/holly-ops-branding/proposal.md
+++ b/openspec/changes/holly-ops-branding/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: Holly Ops Branding
+
+## Summary
+
+Rename the operator-facing product experience from scion-ops to Holly Ops. The browser UI should present itself as Holly Ops Drive, with HHD as the short display name, and the operator-facing bot/coordinator should be called Holly in user-visible copy.
+
+This is a low-risk user-facing rename only. Runtime identifiers and compatibility surfaces that represent real Scion primitives or persisted infrastructure stay unchanged unless a later migration is explicitly specified.
+
+## Motivation
+
+Operators currently see scion-ops as both the product experience name and as part of real runtime, repository, MCP, Kubernetes, and session identifiers. The requested brand separates those concerns: Holly Ops is the user-facing product name, Holly Ops Drive is the web UI, and Holly is the operator-facing coordinator persona.
+
+Keeping runtime identifiers stable avoids unnecessary migration risk for local kind environments, MCP clients, branch and session state, templates, and existing automation.
+
+## Scope
+
+In scope:
+
+- Update user-facing web UI copy so the product experience is called Holly Ops.
+- Update browser UI title, primary app chrome, empty states, status copy, and operator documentation references so the web UI is called Holly Ops Drive or HHD where short copy is needed.
+- Update operator-facing coordinator copy so the acting bot/coordinator is called Holly.
+- Preserve real Scion primitive terminology such as Hub, Runtime Broker, agents, MCP, templates, steward sessions, rounds, and OpenSpec.
+- Preserve current runtime identifiers and compatibility paths.
+
+Out of scope:
+
+- Renaming MCP server identity, MCP tool names, MCP resources, or MCP protocol fields.
+- Renaming Kubernetes resource names, labels used for selectors, kind cluster names, namespaces, services, deployments, or container images.
+- Renaming `.scion-ops` session directories or persisted state paths.
+- Renaming branch names, template names, kind names, Scion Hub primitives, broker identifiers, agent identifiers, or steward-session protocol fields.
+- Migrating package/module names, environment variable names, or CLI command names unless they are strictly display-only aliases.
+
+## Success Criteria
+
+- Operators opening the web UI see Holly Ops Drive as the app name and can recognize HHD as its short name.
+- User-facing coordinator/bot copy refers to Holly without changing underlying coordinator identifiers or stored agent records.
+- Existing MCP clients, Kubernetes workflows, `.scion-ops` session state, kind control-plane resources, and Scion runtime terminology remain compatible.
+- Tests or focused review cover representative UI/documentation copy and guard against accidental renames of compatibility-sensitive identifiers.

--- a/openspec/changes/holly-ops-branding/specs/web-app-hub/spec.md
+++ b/openspec/changes/holly-ops-branding/specs/web-app-hub/spec.md
@@ -1,0 +1,97 @@
+# Delta: Web App Hub
+
+## MODIFIED Requirements
+
+### Requirement: Operator Overview
+
+The system SHALL provide a web overview that summarizes Scion runtime readiness from existing Hub, Runtime Broker, MCP, Kubernetes runtime state, and the deployed Holly Ops Drive control-plane component.
+
+#### Scenario: Operator opens Holly Ops Drive
+
+- GIVEN an operator opens the web UI
+- WHEN the overview renders
+- THEN the browser-visible app identity is Holly Ops Drive
+- AND constrained app identity may use HHD as the short name
+- AND the overview still identifies real backing sources with their Scion runtime names, including Hub, broker, MCP, Kubernetes, agents, and steward-session state.
+
+#### Scenario: Runtime source is displayed
+
+- GIVEN the app renders Hub, Runtime Broker, MCP, Kubernetes, OpenSpec, template, agent, round, or steward-session details
+- WHEN those details name real Scion primitives or compatibility surfaces
+- THEN the app preserves the Scion runtime terminology
+- AND it does not relabel those primitives as Holly Ops entities.
+
+### Requirement: Round Detail Timeline
+
+The system SHALL provide a round detail view that combines messages, notifications, agent status, runner output, coordinator output, and final outcome for a selected round while using Holly as the operator-facing coordinator display name.
+
+#### Scenario: Coordinator output is displayed
+
+- GIVEN a selected round includes coordinator output, coordinator status, or coordinator-derived terminal state
+- WHEN the round detail view renders user-facing headings, labels, or summaries for that actor
+- THEN the actor is displayed as Holly
+- AND the underlying source role, structured field names, diagnostics, and runtime identifiers remain available without migration.
+
+#### Scenario: Agent and steward terminology is displayed
+
+- GIVEN a selected round includes Scion agents, steward sessions, templates, MCP events, branch evidence, or OpenSpec validation state
+- WHEN the round detail view renders those diagnostics
+- THEN it preserves those real runtime terms
+- AND it does not rename agents, steward sessions, templates, MCP events, branch identifiers, or OpenSpec fields to Holly-specific runtime identifiers.
+
+### Requirement: Source Of Truth Preservation
+
+The system SHALL derive displayed operational state from existing Scion Hub, MCP, and Kubernetes sources, and SHALL keep browser-visible branding separate from source-of-truth identifiers and compatibility contracts.
+
+#### Scenario: Branding is applied to display copy only
+
+- GIVEN source data contains MCP tool names, MCP resource URIs, Kubernetes resource names, `.scion-ops` paths, kind names, template names, branch names, environment variable names, or structured Scion fields
+- WHEN the web app normalizes and renders the data
+- THEN it may apply Holly Ops Drive, HHD, or Holly labels only in display copy
+- AND it preserves source identifiers and structured values in JSON, diagnostics, logs, and compatibility-sensitive surfaces.
+
+#### Scenario: Existing clients continue to work
+
+- GIVEN existing MCP clients, kind workflows, Kubernetes manifests, OpenSpec tooling, branch workflows, or `.scion-ops` session readers depend on current identifiers
+- WHEN the Holly Ops branding change is implemented
+- THEN those identifiers remain unchanged
+- AND no migration is required for existing session state or local control-plane resources.
+
+## ADDED Requirements
+
+### Requirement: Holly Ops Display Identity
+
+The system SHALL present the user-facing product experience as Holly Ops and the browser UI as Holly Ops Drive.
+
+#### Scenario: Primary app identity renders
+
+- GIVEN an operator opens any primary web app view
+- WHEN the page chrome and browser metadata render
+- THEN the visible app name is Holly Ops Drive
+- AND the broader product name is Holly Ops where product-level copy is needed
+- AND the app does not present the primary browser surface as `scion-ops hub`.
+
+#### Scenario: Short name is needed
+
+- GIVEN a compact navigation item, status label, browser context, or documentation table needs a short web UI name
+- WHEN a short name is used
+- THEN the short name is HHD
+- AND the first prominent identity in operator-facing documentation or app chrome still makes clear that HHD means Holly Ops Drive.
+
+### Requirement: Holly Coordinator Display
+
+The system SHALL display the operator-facing bot/coordinator persona as Holly without changing runtime coordinator identifiers.
+
+#### Scenario: Operator-facing bot copy renders
+
+- GIVEN the UI or documentation describes the bot or coordinator that conducts actions for an operator
+- WHEN that copy is display-only
+- THEN it calls the persona Holly
+- AND it does not require renaming stored coordinator role values, agent identifiers, MCP fields, or log-derived source names.
+
+#### Scenario: Diagnostic source identity is needed
+
+- GIVEN an operator inspects raw diagnostics, structured JSON, MCP payloads, logs, or source field names
+- WHEN those diagnostics contain `coordinator` or other existing runtime identifiers
+- THEN the app preserves those identifiers for traceability
+- AND any Holly display label does not obscure the underlying source identity.

--- a/openspec/changes/holly-ops-branding/tasks.md
+++ b/openspec/changes/holly-ops-branding/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [ ] 1.1 Inventory user-facing web UI, server log, and operator documentation strings that currently name the product experience as scion-ops or the browser surface as the scion-ops hub.
+- [ ] 1.2 Update display copy so the product experience is Holly Ops and the web UI is Holly Ops Drive, using HHD only as short display copy where space is constrained.
+- [ ] 1.3 Update operator-facing coordinator/bot copy to call the action-taking coordinator Holly while preserving underlying `coordinator` role and source identifiers.
+- [ ] 1.4 Keep Scion runtime terminology intact where it refers to real primitives, including Hub, broker, agents, MCP, templates, steward sessions, rounds, and OpenSpec.
+- [ ] 1.5 Confirm MCP server identity, MCP tool names, MCP resource URIs, Kubernetes resource names, `.scion-ops` paths, kind names, template names, branch names, and environment variable names remain compatible.
+- [ ] 1.6 Add or update focused tests or snapshots for Holly Ops Drive/HHD visible copy and Holly coordinator display behavior.
+- [ ] 1.7 Run relevant web app and documentation checks after implementation.
+- [ ] 1.8 Run OpenSpec validation for this change.


### PR DESCRIPTION
Created by scion-ops after successful spec steward validation.

- Session: `20260510t191636z-1566`
- Change: `holly-ops-branding`
- Head: `round-20260510t191636z-1566-spec-integration` (`e5919e9a466a`)
- Base: `main` (`2d7a02d1b546`)
- Steward validation: passed
- OpenSpec review: `accept`