### PR TITLE
OpenSpec: use-nicegui

### DIFF
--- a/openspec/changes/use-nicegui/design.md
+++ b/openspec/changes/use-nicegui/design.md
@@ -1,0 +1,102 @@
+# Design: Use NiceGUI
+
+## Overview
+
+The web UI should be rebuilt as a NiceGUI application that presents scion-ops state as an operator console. The implementation should keep the server-side Python boundary and source adapters, but the visible UI should be rethought around operator tasks rather than mirroring the current structure.
+
+The default experience should answer three questions quickly:
+
+- Is the control plane usable right now?
+- Which rounds need attention?
+- Where is the next useful context if something is blocked, stale, or failed?
+
+Deep diagnostics remain available, but they should be one level down from the default overview through tabs, drawers, expandable rows, detail panes, or drill-in views.
+
+## NiceGUI Application Shape
+
+The replacement should use NiceGUI for page composition, navigation, interactive controls, and live UI updates. It should remain Python-native and avoid adding a separate frontend build system unless NiceGUI itself requires generated assets.
+
+Expected application shape:
+
+- A small app entry point that can run locally for development and inside the existing kind control-plane web app container.
+- Server-side adapter functions that continue to produce browser-friendly snapshots, round details, inbox groups, runtime checks, and live update events.
+- NiceGUI pages or route handlers for overview, rounds, selected round detail, inbox, runtime, and troubleshooting diagnostics.
+- Reusable UI components for status badges, source health rows, live freshness indicators, round summaries, branch evidence, validation summaries, and diagnostic payload containers.
+
+The implementation may reorganize modules and templates freely, but JSON-producing adapter behavior should remain independently testable from NiceGUI widgets.
+
+## Contract Preservation
+
+Existing browser-facing contracts are compatibility boundaries. The NiceGUI migration should preserve:
+
+- health and readiness endpoints used by Kubernetes probes and smoke checks;
+- snapshot endpoints used by tests or external scripts;
+- round detail and event endpoints used for selected-round inspection;
+- live update endpoint semantics, cursor behavior, stale/fallback state, and source-specific errors;
+- structured JSON fields for source identifiers, timestamps, statuses, branch fields, validation fields, blockers, warnings, final-review verdicts, and runtime readiness.
+
+NiceGUI may consume these contracts internally, but it should not make automation depend on scraping rendered HTML. If a contract needs to grow, additions should be backward-compatible fields.
+
+## Runtime And Deployment Compatibility
+
+The NiceGUI app should fit the existing deployment model:
+
+- Local execution should work from the repository with the same Python dependency tooling used by the current web app.
+- The kind deployment should keep a web app Deployment, Service, labels, probes, read-only ServiceAccount/RBAC, mounted workspace, and Hub dev-auth Secret convention.
+- Environment variables such as `SCION_OPS_ROOT`, Hub endpoint values, MCP URL, grove id values, token file paths, and optional GitHub token wiring should keep their existing meanings.
+- The service should remain reachable through the documented kind host port path without requiring `kubectl port-forward`.
+- Kubernetes readiness and smoke checks should continue to verify the HTTP endpoint and a JSON snapshot or readiness response without starting model-backed work.
+
+NiceGUI startup, static assets, and websocket or polling behavior should be configured so probes and JSON endpoints remain reliable even when live UI clients disconnect or reconnect.
+
+## Operator Information Architecture
+
+The fresh UI should prioritize operational scanning:
+
+- **Overview:** compact readiness summary, live freshness state, active/blocked/recent round counts, and the highest-priority source or round needing attention.
+- **Rounds:** dense comparison of active and recent rounds with status, phase, decision flow, validation state, final review, branch evidence, latest update, and blocker summary.
+- **Round Detail:** selected-round context with summary first, followed by timeline, agents, decision flow, final review, validation, branches, artifacts, and runner output.
+- **Inbox:** operator-relevant messages and notifications grouped by round when possible, with source and timestamp visible.
+- **Runtime:** Hub, broker, MCP, Kubernetes, web app deployment, service, pod, PVC, and live update path readiness.
+- **Troubleshooting:** one-level-down diagnostic panels exposing raw JSON, source errors, logs, validation payloads, cursor state, and fallback evidence.
+
+The overview should not become a landing page or marketing hero. It should be an operational first screen with compact status, clear severity, and direct drill-ins.
+
+## Laws Of UX Constraints
+
+The interface should explicitly apply Laws of UX principles:
+
+- **Hick's Law:** show the smallest useful set of top-level navigation and actions; keep troubleshooting options grouped below the affected item.
+- **Miller's Law:** chunk readiness, rounds, inbox, runtime, and diagnostics into small scannable groups rather than long undifferentiated lists.
+- **Fitts's Law:** keep primary navigation, refresh or reconnect controls, and affected-item drill-ins close to their related context and large enough for reliable selection.
+- **Jakob's Law:** use familiar operations-console patterns such as status badges, tables, tabs, accordions, detail panes, and timestamped timelines.
+- **Law of Proximity and Common Region:** visually group each source error with the source and data it affects, not in a detached global error pile.
+- **Tesler's Law:** keep unavoidable complexity in the troubleshooting layer while presenting a concise default state.
+- **Doherty Threshold:** keep interactions responsive; show loading, reconnecting, stale, and fallback feedback quickly when source calls are slow.
+
+These constraints should guide layout and interaction decisions, not appear as explanatory text inside the app.
+
+## Visual And Interaction Direction
+
+Use a restrained operations-console style: neutral surfaces, compact spacing, stable dimensions, readable system typography, monospace treatment for code-like values, and semantic accents for state. Color must not be the only status signal; labels, icons, and source-specific text should also communicate state.
+
+Avoid decorative gradients, oversized hero sections, nested cards, ornamental illustrations, broad marketing copy, or one-note color themes. Repeated items may use simple panels or table rows, but page sections should remain efficient and scan-friendly.
+
+Responsive behavior should preserve the primary monitoring workflow on narrow screens. Tables may collapse into row summaries, detail panes may stack, and secondary diagnostic fields may move into expanders, but round identifiers, state, freshness, and blockers should remain visible.
+
+## Read-Only Safety
+
+The NiceGUI app should remain read-only across all visible and background paths. Loading pages, opening diagnostics, live subscriptions, reconnects, fallback polling, health checks, and smoke tests must not mutate Hub runtime records, Kubernetes resources, git refs, OpenSpec files, or round state.
+
+Any future write operations would require a separate OpenSpec change and should not be implied by button placement, placeholder actions, or disabled controls in this migration.
+
+## Verification Strategy
+
+Implementation should include no-spend checks for:
+
+- NiceGUI app startup and route rendering with representative healthy, empty, stale, blocked, degraded, and unavailable data.
+- JSON and health endpoint compatibility before and after the frontend replacement.
+- Read-only behavior during page load, live update subscription, reconnect, fallback polling, and diagnostic drill-in.
+- Kind manifest and lifecycle compatibility, including probes and service reachability.
+- Responsive rendering at desktop and narrow widths without blank screens, overlapping controls, or unreadable statuses.
+- Laws of UX constraints through focused layout or snapshot checks that prove concise defaults and one-level-down diagnostics.

--- a/openspec/changes/use-nicegui/proposal.md
+++ b/openspec/changes/use-nicegui/proposal.md
@@ -1,0 +1,40 @@
+# Proposal: Use NiceGUI
+
+## Summary
+
+Replace the existing web UI frontend with a NiceGUI-based operator console for scion-ops. The new frontend should start from a fresh interface structure while preserving the current read-only operational model, browser-facing JSON and health contracts, deployment compatibility, and automatic update behavior.
+
+## Motivation
+
+The web UI has grown around a script-oriented HTTP server and accumulated view structure. Operators need a concise, action- and context-related console that makes the current state obvious by default, while keeping deeper troubleshooting one level down. NiceGUI provides a Python-native UI layer that fits the existing Python operational tooling and can produce a more deliberate interface without inventing a separate JavaScript application stack.
+
+The replacement should apply Laws of UX principles from https://lawsofux.com/ as design constraints: reduce cognitive load, favor recognition over recall, group related state, keep common actions and context close to the information they affect, and avoid visual or interaction patterns that slow repeated monitoring.
+
+## Scope
+
+In scope:
+
+- Rebuild the browser UI as a NiceGUI frontend served by the web app control-plane component.
+- Start the frontend information architecture from a fresh operator-console design rather than preserving current page layout.
+- Preserve existing read-only behavior and avoid round-starting, retrying, aborting, deleting, git-writing, OpenSpec-writing, or Kubernetes-mutating controls.
+- Preserve the existing browser-facing JSON snapshot, round detail, live update, and health contracts used by tests, smoke checks, and automation.
+- Preserve runtime and deployment compatibility with the current host-side script path and kind control-plane deployment shape.
+- Provide a concise operator overview by default, with in-depth troubleshooting and raw diagnostic detail one interaction level down.
+- Include Laws of UX design constraints for layout, hierarchy, interaction feedback, progressive disclosure, and accessibility.
+
+Out of scope:
+
+- Adding write operations or workflow orchestration controls to the web UI.
+- Changing Hub, MCP, Kubernetes, OpenSpec, or live-update source-of-truth contracts.
+- Removing or renaming existing JSON or health endpoints that external checks rely on.
+- Introducing a separate JavaScript single-page application build pipeline.
+- Production authentication, authorization, or user-specific personalization.
+
+## Success Criteria
+
+- Operators can open the NiceGUI app and immediately see control-plane readiness, live update freshness, active or blocked round context, and next relevant inspection targets.
+- Detailed source errors, raw payloads, validation output, branch evidence, and runner diagnostics are available one level below the overview or affected round, without crowding the default screen.
+- Existing JSON and health endpoints remain compatible with current no-spend tests and kind smoke checks.
+- The NiceGUI app runs in the existing local and kind deployment paths with the same source-of-truth, auth, workspace, and service conventions.
+- The interface remains read-only during page load, live updates, reconnect, fallback polling, and troubleshooting inspection.
+- Visual and interaction design demonstrably considers Laws of UX principles and avoids decorative, marketing-style, or high-cognitive-load presentation.

--- a/openspec/changes/use-nicegui/specs/web-app-hub/spec.md
+++ b/openspec/changes/use-nicegui/specs/web-app-hub/spec.md
@@ -1,0 +1,219 @@
+# Delta: Web App Hub
+
+## MODIFIED Requirements
+
+### Requirement: Operator Overview
+
+The system SHALL provide a NiceGUI operator overview that summarizes scion-ops readiness from existing Hub, Runtime Broker, MCP, Kubernetes runtime state, the deployed web app control-plane component, and live update freshness.
+
+#### Scenario: Operator opens the NiceGUI overview
+
+- GIVEN Hub is reachable and authenticated
+- AND at least one Runtime Broker provider is registered for the active grove
+- AND MCP is reachable
+- AND required Kubernetes deployments and services for Hub, broker, MCP, and the web app are available
+- AND the live update path is fresh or connected
+- WHEN an operator opens the NiceGUI overview
+- THEN the app shows the control plane as ready
+- AND shows contributing Hub, broker, MCP, web app, Kubernetes, and live update checks as healthy
+- AND shows active, blocked, and recent round context without requiring the operator to open a diagnostic view.
+
+#### Scenario: Overview prioritizes concise operator context
+
+- GIVEN one or more rounds, sources, or live update paths are blocked, failed, stale, degraded, or unavailable
+- WHEN an operator opens the NiceGUI overview
+- THEN the app identifies the highest-priority affected source or round
+- AND shows concise status, last update time, and next inspection target
+- AND keeps raw payloads, long logs, and low-level troubleshooting details out of the default overview.
+
+#### Scenario: Overview exposes troubleshooting one level down
+
+- GIVEN overview data includes source errors, validation failures, branch mismatches, stale cursor state, or runner diagnostics
+- WHEN an operator drills into the affected check, round, or diagnostic control
+- THEN the NiceGUI app shows the relevant detailed troubleshooting information one interaction level below the overview
+- AND preserves healthy source details that are still available.
+
+### Requirement: Source Of Truth Preservation
+
+The system SHALL derive NiceGUI-displayed operational state from existing scion-ops Hub, MCP, Kubernetes, and normalized helper sources, while keeping browser-visible JSON contracts aligned with current MCP and web app tool result contracts.
+
+#### Scenario: NiceGUI renders source-backed state
+
+- GIVEN MCP, Hub, Kubernetes, or normalized helper output exposes structured readiness, round, event, artifact, validation, final-review, blocker, warning, or branch fields
+- WHEN the NiceGUI app renders overview, rounds, round detail, inbox, runtime, or troubleshooting views
+- THEN the displayed values are derived from those structured source fields
+- AND message text, notification text, task summaries, agent names, or slugs are used only as fallback sources when structured fields are unavailable
+- AND fallback-derived values are not allowed to override structured MCP or Hub fields.
+
+#### Scenario: Browser JSON contract remains compatible
+
+- GIVEN existing tests, smoke checks, or external scripts request browser-facing JSON snapshot, round detail, round event, live update, or health endpoints
+- WHEN the web app frontend has been replaced with NiceGUI
+- THEN those endpoints remain available with backward-compatible field names and semantics
+- AND source identifiers, timestamps, statuses, branch fields, validation fields, blockers, warnings, final-review verdicts, cursor values, live update state, and source-specific errors remain explicit JSON fields
+- AND automation does not need to scrape NiceGUI-rendered HTML to recover operational state.
+
+#### Scenario: Backing source fails under NiceGUI
+
+- GIVEN one backing source is unavailable
+- WHEN the NiceGUI app renders or updates a view that also depends on other sources
+- THEN it shows a source-specific error for the unavailable dependency
+- AND continues showing data from sources that responded successfully
+- AND does not clear previously visible data unless the source-of-truth response explicitly indicates the data is gone.
+
+### Requirement: Read Only Initial Interface
+
+The system SHALL keep the NiceGUI web app read-only and SHALL NOT expose round-starting, aborting, retrying, deleting, archiving, git-writing, OpenSpec-writing, or Kubernetes-mutating operations.
+
+#### Scenario: Operator uses NiceGUI views
+
+- GIVEN an operator opens overview, rounds, round detail, inbox, runtime, or troubleshooting views
+- WHEN the app loads, refreshes data, expands diagnostics, follows drill-ins, or receives live updates
+- THEN it does not start rounds
+- AND it does not abort, retry, delete, archive, or mutate rounds
+- AND it does not modify Kubernetes resources, Hub runtime records, git refs, or OpenSpec files.
+
+#### Scenario: Automatic update recovery remains read-only
+
+- GIVEN the NiceGUI app subscribes, reconnects, resumes from a cursor, or falls back to polling
+- WHEN the automatic update path recovers from stale or disconnected state
+- THEN recovery performs only read operations against Hub, MCP, Kubernetes, git, and OpenSpec status sources
+- AND no state-changing operation is exposed as an implied or hidden side effect.
+
+### Requirement: Kind Kustomize Installation
+
+The system SHALL run the NiceGUI web app in the local kind control-plane install while preserving the existing web app Deployment, Service, probe, workspace, auth, and read-only runtime conventions.
+
+#### Scenario: Control-plane kustomization is rendered for NiceGUI
+
+- GIVEN an operator runs the control-plane kustomize apply path
+- WHEN kustomize renders `deploy/kind/control-plane`
+- THEN the rendered resources include a web app Deployment that starts the NiceGUI application
+- AND include a web app Service with the existing stable service identity and port compatibility
+- AND include any read-only ServiceAccount, RBAC, ConfigMap, Secret mount, workspace mount, probes, and environment configuration required for NiceGUI to inspect Hub, MCP, and Kubernetes readiness.
+
+#### Scenario: NiceGUI uses in-cluster Scion configuration
+
+- GIVEN the NiceGUI app runs inside the kind control plane
+- WHEN it loads runtime configuration
+- THEN it uses the in-cluster Hub endpoint
+- AND it uses the in-cluster MCP service URL and path
+- AND it uses the active grove id from the mounted scion-ops checkout when available
+- AND it reads Hub dev auth from the same mounted Secret convention used by MCP and the previous web app.
+
+#### Scenario: NiceGUI remains reachable through existing local workflow
+
+- GIVEN the kind control plane has been created with the configured host port mappings
+- WHEN the NiceGUI web app Service is ready
+- THEN an operator can open the configured web app URL from the host without running `kubectl port-forward`
+- AND existing smoke checks can reach health or JSON snapshot endpoints without starting model-backed rounds.
+
+## ADDED Requirements
+
+### Requirement: NiceGUI Frontend
+
+The system SHALL replace the web UI frontend with a NiceGUI application that starts from a fresh operator-console interface while preserving the existing server-side source contracts.
+
+#### Scenario: NiceGUI application starts
+
+- GIVEN the web app process is started locally or inside the kind deployment
+- WHEN the HTTP server becomes ready
+- THEN it serves a NiceGUI-rendered operator interface
+- AND exposes health, snapshot, round detail, round events, and live update endpoints required by existing tests and smoke checks
+- AND does not require a separate JavaScript single-page application build pipeline.
+
+#### Scenario: Fresh interface structure is used
+
+- GIVEN the prior web UI page structure exists as historical context
+- WHEN the NiceGUI frontend is implemented
+- THEN the visible interface is organized around operator overview, rounds, round detail, inbox, runtime, and troubleshooting tasks
+- AND implementation is not required to preserve prior HTML structure, CSS classes, or page layout
+- AND externally consumed JSON and health contracts remain compatible.
+
+#### Scenario: NiceGUI components preserve operator state during updates
+
+- GIVEN an operator has selected a round, expanded a diagnostic section, or is viewing a filtered list
+- WHEN live update, reconnect, or fallback polling data arrives
+- THEN NiceGUI updates affected status, timeline, inbox, runtime, and freshness components without forcing a full page reload
+- AND preserves selected context where the backing source still supports it
+- AND avoids duplicate visible timeline or inbox entries for replayed update events.
+
+### Requirement: Progressive Troubleshooting
+
+The system SHALL present concise action- and context-related information by default, with in-depth troubleshooting information available one level down.
+
+#### Scenario: Default screens stay concise
+
+- GIVEN an operator opens overview, rounds, inbox, or runtime
+- WHEN the screen renders
+- THEN it shows operational state, severity, affected source or round, timestamp, and short blocker or outcome summaries first
+- AND avoids showing raw JSON, long logs, full validation output, or exhaustive source payloads by default
+- AND provides an obvious drill-in to the relevant details when deeper inspection is available.
+
+#### Scenario: Detailed diagnostics are one level down
+
+- GIVEN detailed diagnostics exist for a source, round, validation result, branch check, runner output, live cursor, or fallback state
+- WHEN the operator opens the related detail pane, tab, expander, drawer, or troubleshooting view
+- THEN the app shows the in-depth diagnostic information next to the context it explains
+- AND preserves timestamps, source labels, error categories, structured fields, and raw payloads when available.
+
+#### Scenario: Default view points to the next useful inspection
+
+- GIVEN a source or round is blocked, failed, stale, degraded, unavailable, or changes-requested
+- WHEN the operator views its concise summary
+- THEN the app identifies the likely next inspection target, such as runtime source, final review, validation, branch evidence, timeline, or runner output
+- AND the drill-in opens that context without requiring the operator to search through unrelated diagnostics.
+
+### Requirement: Laws Of UX Design Constraints
+
+The system SHALL apply Laws of UX principles to the NiceGUI frontend so repeated operational monitoring remains fast, understandable, and low-friction.
+
+#### Scenario: Information is chunked and grouped
+
+- GIVEN overview, rounds, round detail, inbox, runtime, or troubleshooting views contain multiple sources of operational state
+- WHEN the NiceGUI app renders them
+- THEN related state is grouped by source, round, timeline, validation, branch, or runtime dependency
+- AND the app avoids long undifferentiated lists of mixed status, log, and payload data
+- AND the layout supports recognition of state rather than requiring recall of hidden meanings.
+
+#### Scenario: Choices and actions are kept close to context
+
+- GIVEN an operator can navigate, refresh, reconnect, filter, expand, or drill into a status item
+- WHEN those controls are rendered
+- THEN the available choices are limited to the relevant context
+- AND controls are placed near the state they affect
+- AND interaction targets are large and stable enough for reliable selection on desktop and narrow screens.
+
+#### Scenario: Feedback is timely and explicit
+
+- GIVEN a source call, live update subscription, reconnect, fallback poll, or diagnostic load is in progress or delayed
+- WHEN the NiceGUI app waits for fresh data
+- THEN it shows loading, connected, reconnecting, stale, fallback, or failed feedback promptly
+- AND does not imply that an underlying round, source, validation, or final review succeeded merely because the UI request completed.
+
+### Requirement: NiceGUI Responsive Operator Layout
+
+The system SHALL keep the NiceGUI frontend usable and readable at typical desktop and narrow mobile widths.
+
+#### Scenario: Desktop viewport supports dense scanning
+
+- GIVEN the browser viewport is desktop width
+- WHEN an operator opens overview, rounds, round detail, inbox, runtime, or troubleshooting views
+- THEN the app uses available width for efficient scanning
+- AND status, timestamps, branch evidence, validation state, final-review outcome, blockers, and live freshness remain visible without excessive whitespace or decorative framing.
+
+#### Scenario: Narrow viewport preserves primary workflow
+
+- GIVEN the browser viewport is narrow
+- WHEN an operator opens overview, rounds, round detail, inbox, runtime, or troubleshooting views
+- THEN navigation, status labels, tables or row summaries, metadata, diagnostic controls, and action buttons do not overlap
+- AND essential round identifiers, source names, state, freshness, and blocker summaries remain visible
+- AND secondary columns or raw diagnostic details may wrap, collapse, or move behind one-level-down controls.
+
+#### Scenario: Keyboard and accessibility basics are preserved
+
+- GIVEN an operator navigates the NiceGUI app with a keyboard or assistive technology
+- WHEN focus moves through navigation, refresh, reconnect, filters, expanders, tabs, detail controls, and clickable round rows
+- THEN focused elements have visible focus treatment
+- AND statuses are communicated by labels, icons, or text in addition to color
+- AND text and semantic accents have sufficient contrast for an internal operations console.

--- a/openspec/changes/use-nicegui/tasks.md
+++ b/openspec/changes/use-nicegui/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [ ] 1.1 Inventory the current web app public HTTP, JSON, health, live update, deployment, and test contracts that must remain compatible.
+- [ ] 1.2 Add NiceGUI runtime dependencies and an application entry point that can run locally and inside the kind web app deployment.
+- [ ] 1.3 Separate browser-facing data adapters from rendered UI code so JSON and health endpoints remain independently testable.
+- [ ] 1.4 Build the NiceGUI overview with concise readiness, live freshness, active or blocked round context, and direct drill-ins.
+- [ ] 1.5 Build the NiceGUI rounds and round detail experience with dense comparison, structured branch evidence, validation state, final review, timeline, agents, and blockers.
+- [ ] 1.6 Build inbox, runtime, and one-level-down troubleshooting views for source errors, raw payloads, validation output, runner diagnostics, cursor state, and fallback evidence.
+- [ ] 1.7 Preserve read-only behavior for page load, live updates, reconnect, fallback polling, diagnostics, health checks, and smoke tests.
+- [ ] 1.8 Preserve existing JSON, health, snapshot, round detail, and live update contracts, adding only backward-compatible fields where needed.
+- [ ] 1.9 Update kind manifests, probes, service wiring, lifecycle tasks, and documentation for the NiceGUI web app while preserving existing runtime configuration conventions.
+- [ ] 1.10 Add focused no-spend tests or fixtures for NiceGUI rendering, contract compatibility, degraded source handling, responsive layout, and Laws of UX constraints.
+- [ ] 1.11 Run the repo validation and web app smoke/static checks required by the implementation branch.


### PR DESCRIPTION
Created by scion-ops after successful spec steward validation.

- Session: `20260510t193207z-32ef`
- Change: `use-nicegui`
- Head: `round-20260510t193207z-32ef-spec-integration` (`1affd3871898`)
- Base: `main` (`2d7a02d1b546`)
- Steward validation: passed
- OpenSpec review: `accept`