### PR TITLE
Tighten live web app promotion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.scion-ops
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+**/.vite
+**/coverage
+**/dist
+**/node_modules

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,6 +64,10 @@ tasks:
     cmds:
       - bash scripts/build-images.sh --only mcp {{.CLI_ARGS}}
 
+  build:web-app:
+    cmds:
+      - bash scripts/build-images.sh --only web-app {{.CLI_ARGS}}
+
   build:harness:
     cmds:
       - bash scripts/build-images.sh --only {{.CLI_ARGS}}
@@ -170,7 +174,7 @@ tasks:
   update:web-app:
     desc: Reload the web app image and restart its deployment.
     cmds:
-      - task kind:load-images -- localhost/scion-ops-mcp:latest
+      - task kind:load-images -- localhost/scion-ops-web-app:latest
       - kubectl --context '{{.KIND_CONTEXT}}' -n '{{.SCION_K8S_NAMESPACE}}' rollout restart deploy/scion-ops-web-app
       - task: kind:web-app:status
 
@@ -213,9 +217,19 @@ tasks:
       - task: storage:status
 
   web:hub:
-    desc: Run the read-only browser hub for scion-ops runtime state.
+    desc: Run the canonical React/Vite operator console adapter locally.
     cmds:
-      - uv run scripts/web_app_hub.py {{.CLI_ARGS}}
+      - |
+        set -- {{.CLI_ARGS}}
+        cd new-ui-evaluation
+        if [ ! -d node_modules ]; then
+          npm ci
+        fi
+        npm run build
+        exec python3 adapter.py \
+          --host "${SCION_OPS_WEB_HOST:-127.0.0.1}" \
+          --port "${SCION_OPS_WEB_PORT:-8091}" \
+          "$@"
 
   destroy:
     cmds:

--- a/docs/kind-control-plane.md
+++ b/docs/kind-control-plane.md
@@ -87,9 +87,8 @@ Open the React/Vite operator console in a browser at the configured web app URL
 (default `http://192.168.122.103:8808`). The web app is served by the
 `scion-ops-web-app` Deployment and Service. It uses `/api/snapshot` for the
 initial live read-only snapshot and `/api/events` for SSE updates. Fixture
-fallback is explicit: use `NEW_UI_EVALUATION_MODE=fixture` or request the UI
-with `?fixture=1`/`?mode=fixture`; fixture data is not the default kind runtime
-path.
+fallback is explicit: start the adapter with `SCION_OPS_WEB_APP_MODE=fixture`
+or `--mode fixture`; fixture data is not the default kind runtime path.
 
 The MCP pod reads Hub through the in-cluster `scion-hub` Service and uses the
 `scion-hub-dev-auth` Secret restored by `task bootstrap`.
@@ -152,6 +151,7 @@ task build:base
 task update:hub
 task build:mcp
 task update:mcp
+task build:web-app
 task update:web-app
 task build:harness -- codex
 task load:image -- localhost/scion-codex:latest

--- a/docs/new-ui-evaluation.md
+++ b/docs/new-ui-evaluation.md
@@ -43,6 +43,10 @@ python adapter.py --host 127.0.0.1 --port 8091
 
 Open `http://127.0.0.1:8091`.
 
+From the repository root, `task web:hub` performs the same local build and
+adapter startup path. Use `SCION_OPS_WEB_HOST` and `SCION_OPS_WEB_PORT` to
+override the local bind address or port.
+
 Use explicit fixture fallback for local fixture-only development or tests:
 
 ```bash
@@ -63,6 +67,8 @@ Open the Vite URL, normally `http://127.0.0.1:5174`.
 - `GET /api/snapshot` returns a versioned `scion-ops-web-app.live.v1` snapshot containing `sourceMode`, `fixtureBacked`, `generatedAt`, a content cursor, source health, connection metadata, overview, rounds, round details, inbox, `runtime.liveService`, diagnostics, and raw payload references. Hub and MCP source health is based on read-only operational API/probe results, not local file or module existence.
 - `GET /api/events` returns `text/event-stream` frames using `scion-ops-web-app.event.v1`. Events include type, stable id, entity id when applicable, source, timestamp, version/cursor, payload, source status, stale flag, and error metadata. After the initial connection frame, the stream polls read-only sources and emits typed incremental events such as `round_updated`, `timeline_entry`, `inbox_item`, `runtime_health`, `diagnostic`, `source_status`, `stale`, and `fallback` when those source slices change.
 - Reconnect uses the `cursor` query parameter when available. The server keeps a bounded in-memory cursor history and replays missed typed incremental events from a known cursor; if replay is unavailable, `/api/events` emits an explicit `snapshot_ready` recovery event containing the current read-only snapshot.
+- Fixture mode is process-level. Query parameters do not switch the live kind
+  deployment into fixture-backed mode.
 
 ## Endpoints
 

--- a/image-build/web-app/Dockerfile
+++ b/image-build/web-app/Dockerfile
@@ -26,10 +26,10 @@ RUN chown -R 1000:1000 /app/web-app
 
 USER 1000:1000
 
-EXPOSE 8080
+EXPOSE 8787
 
 HEALTHCHECK --interval=10s --timeout=3s \
-  CMD /opt/scion-ops-mcp/venv/bin/python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz', timeout=2)"
+  CMD /opt/scion-ops-mcp/venv/bin/python -c "import urllib.request; urllib.request.urlopen('http://localhost:8787/healthz', timeout=2)"
 
 ENTRYPOINT ["/opt/scion-ops-mcp/venv/bin/python", "/app/web-app/adapter.py"]
-CMD ["--host", "0.0.0.0", "--port", "8080"]
+CMD ["--host", "0.0.0.0", "--port", "8787"]

--- a/new-ui-evaluation/adapter.py
+++ b/new-ui-evaluation/adapter.py
@@ -39,6 +39,7 @@ EVENT_SCHEMA_VERSION = "scion-ops-web-app.event.v1"
 FIXTURE_SCHEMA_VERSION = "scion-ops-web-app.fixture.v1"
 READ_ONLY_COMMAND_TIMEOUT_SECONDS = 2
 SNAPSHOT_HISTORY_LIMIT = 8
+DEFAULT_SERVICE_PORT = 8091
 ROUND_ID_RE = re.compile(r"(?:round-)?(?P<id>\d{8}t\d{6}z-[a-z0-9]+)", re.IGNORECASE)
 
 Mode = Literal["live", "fixture"]
@@ -224,8 +225,9 @@ def source_state(
 class LiveSourceAggregator:
     """Builds versioned snapshots from local read-only operational sources."""
 
-    def __init__(self, project_root: Path = PROJECT_ROOT):
+    def __init__(self, project_root: Path = PROJECT_ROOT, *, service_port: int = DEFAULT_SERVICE_PORT):
         self.project_root = project_root
+        self.service_port = service_port
         self.sessions_root = project_root / ".scion-ops" / "sessions"
         self.openspec_root = project_root / "openspec"
         self._scion_ops_module: Any | None = None
@@ -264,7 +266,7 @@ class LiveSourceAggregator:
                 "sources": source_health,
                 "liveService": {
                     "name": "scion-ops-web-app",
-                    "port": 8091,
+                    "port": self.service_port,
                     "healthPath": "/healthz",
                     "fixtureOnly": False,
                     "liveReadsAllowed": True,
@@ -983,8 +985,10 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         if head_only:
             return
         for event in batch["events"]:
-            self._write_sse_event(event)
-        self.wfile.flush()
+            if not self._write_sse_event(event):
+                return
+        if not self._flush():
+            return
         if query.get("once", ["0"])[0] == "1":
             self.close_connection = True
             return
@@ -1006,17 +1010,36 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
             )
             try:
                 for event in events:
-                    self._write_sse_event(event)
-                self._write_sse_event(heartbeat)
-                self.wfile.flush()
+                    if not self._write_sse_event(event):
+                        return
+                if not self._write_sse_event(heartbeat):
+                    return
+                if not self._flush():
+                    return
             except (BrokenPipeError, ConnectionResetError):
                 return
         self.close_connection = True
 
-    def _write_sse_event(self, event: dict[str, Any]) -> None:
+    def _write_sse_event(self, event: dict[str, Any]) -> bool:
         data = json.dumps(event, sort_keys=True, default=str)
         frame = f"id: {event.get('cursor') or event.get('id') or ''}\nevent: {event.get('type') or 'message'}\ndata: {data}\n\n"
-        self.wfile.write(frame.encode("utf-8"))
+        return self._write_bytes(frame.encode("utf-8"))
+
+    def _write_bytes(self, body: bytes) -> bool:
+        try:
+            self.wfile.write(body)
+            return True
+        except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
+            return False
+
+    def _flush(self) -> bool:
+        try:
+            self.wfile.flush()
+            return True
+        except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
+            return False
 
     def _static(self, request_path: str, head_only: bool = False) -> None:
         relative = request_path.lstrip("/") or "index.html"
@@ -1040,7 +1063,7 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         if not head_only:
-            self.wfile.write(body)
+            self._write_bytes(body)
 
     def _json(self, payload: Any, status: HTTPStatus = HTTPStatus.OK, head_only: bool = False) -> None:
         body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
@@ -1051,7 +1074,7 @@ class OperatorConsoleHandler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         if not head_only:
-            self.wfile.write(body)
+            self._write_bytes(body)
 
     def _reject_mutation(self) -> None:
         self._json(READ_ONLY_MESSAGE, status=HTTPStatus.METHOD_NOT_ALLOWED)
@@ -1063,10 +1086,11 @@ def build_server(host: str, port: int, static_root: Path, fixture_path: Path, *,
     if mode == "fixture":
         load_fixtures(fixture_path)
     server = ThreadingHTTPServer((host, port), OperatorConsoleHandler)
+    service_port = server.server_port if port == 0 else port
     server.mode = mode  # type: ignore[attr-defined]
     server.static_root = static_root  # type: ignore[attr-defined]
     server.fixture_path = fixture_path  # type: ignore[attr-defined]
-    server.aggregator = LiveSourceAggregator(project_root)  # type: ignore[attr-defined]
+    server.aggregator = LiveSourceAggregator(project_root, service_port=service_port)  # type: ignore[attr-defined]
     server.snapshot_history = {}  # type: ignore[attr-defined]
     server.snapshot_history_lock = threading.Lock()  # type: ignore[attr-defined]
     return server
@@ -1075,7 +1099,7 @@ def build_server(host: str, port: int, static_root: Path, fixture_path: Path, *,
 def main() -> None:
     parser = argparse.ArgumentParser(description="Serve the read-only scion-ops web app operator console.")
     parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", default=8091, type=int)
+    parser.add_argument("--port", default=DEFAULT_SERVICE_PORT, type=int)
     parser.add_argument("--static-root", default=str(DEFAULT_STATIC_ROOT))
     parser.add_argument("--fixture-path", default=str(FIXTURE_PATH))
     parser.add_argument("--mode", choices=["live", "fixture"], default=os.environ.get("SCION_OPS_WEB_APP_MODE", "live"))

--- a/new-ui-evaluation/src/App.tsx
+++ b/new-ui-evaluation/src/App.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle, CheckCircle2, CircleDot, Database, GitBranch, Inbox, RefreshCcw, Server, ShieldCheck, Wifi, WifiOff } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { applyLiveEvent, fixtureModeRequested, loadOperatorData, markOperatorDataStale, openLiveEventStream } from "./api";
+import { applyLiveEvent, loadOperatorData, markOperatorDataStale, openLiveEventStream } from "./api";
 import type { DiagnosticsPayload, InboxMessage, LiveConnection, LiveEvent, OperatorData, RoundDetail, RoundSummary, SourceHealth, Status } from "./types";
 
 type View = "overview" | "rounds" | "detail" | "inbox" | "runtime" | "diagnostics";
@@ -36,7 +36,6 @@ const statusClass: Record<string, string> = {
 };
 
 export function App() {
-  const fixtureMode = useMemo(() => fixtureModeRequested(), []);
   const [data, setData] = useState<OperatorData | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [view, setView] = useState<View>("overview");
@@ -49,7 +48,7 @@ export function App() {
   async function refresh() {
     setLoadError(null);
     try {
-      const operatorData = await loadOperatorData({ fixtureMode });
+      const operatorData = await loadOperatorData();
       setData(operatorData);
       setSelectedRoundId((current) => (operatorData.rounds.some((round) => round.id === current) ? current : operatorData.rounds[0]?.id ?? ""));
     } catch (error) {

--- a/new-ui-evaluation/src/__tests__/fixtures.test.tsx
+++ b/new-ui-evaluation/src/__tests__/fixtures.test.tsx
@@ -136,16 +136,6 @@ describe("live UI contract", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/snapshot", expect.objectContaining({ method: "GET" }));
   });
 
-  it("uses fixture fallback only when explicitly requested", async () => {
-    const fixtureSnapshot = { ...liveSnapshot, sourceMode: "fixture", fixtureBacked: true };
-    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(fixtureSnapshot)));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await loadOperatorData({ fixtureMode: true });
-
-    expect(fetchMock).toHaveBeenCalledWith("/api/fixtures", expect.objectContaining({ method: "GET" }));
-  });
-
   it("renders live connection and source staleness from snapshot", async () => {
     const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(liveSnapshot)));
     vi.stubGlobal("fetch", fetchMock);

--- a/new-ui-evaluation/src/api.ts
+++ b/new-ui-evaluation/src/api.ts
@@ -24,14 +24,8 @@ async function getJson<T>(path: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-export function fixtureModeRequested(search = window.location.search): boolean {
-  const params = new URLSearchParams(search);
-  return params.get("fixture") === "1" || params.get("mode") === "fixture";
-}
-
-export async function loadOperatorData(options: { fixtureMode?: boolean } = {}): Promise<OperatorData> {
-  const path = options.fixtureMode ? "/api/fixtures" : "/api/snapshot";
-  const snapshot = await getJson<Omit<OperatorData, "loadedAt">>(path);
+export async function loadOperatorData(): Promise<OperatorData> {
+  const snapshot = await getJson<Omit<OperatorData, "loadedAt">>("/api/snapshot");
   return {
     ...snapshot,
     loadedAt: new Date().toISOString()

--- a/new-ui-evaluation/tests/test_adapter.py
+++ b/new-ui-evaluation/tests/test_adapter.py
@@ -153,6 +153,7 @@ class AdapterTests(unittest.TestCase):
             self.assertEqual(status, 200)
             self.assertEqual(snapshot["schemaVersion"], LIVE_SCHEMA_VERSION)
             self.assertEqual(snapshot["sourceMode"], "live")
+            self.assertEqual(snapshot["runtime"]["liveService"]["port"], server.server_port)
             self.assertEqual(snapshot["runtime"]["liveService"]["streamPath"], "/api/events")
 
             status, overview = request_json(f"{base_url}/api/overview")


### PR DESCRIPTION
## Summary
- load the promoted `localhost/scion-ops-web-app:latest` image in `task update:web-app` and add a direct `build:web-app` task
- align the web app image default port, exposed port, and Docker healthcheck with the live service on 8787
- report the actual adapter listen port in `runtime.liveService.port`
- switch local `task web:hub` to the canonical React/Vite adapter path instead of the legacy NiceGUI script
- remove browser URL-driven fixture switching so fixture mode remains an explicit process-level adapter mode
- suppress noisy adapter write tracebacks when clients disconnect mid-response or mid-SSE frame
- add a root `.dockerignore` so web-app image builds do not send `node_modules`, dist output, git metadata, or session state as Docker context
- fix stale fixture-mode docs and document local canonical adapter startup

## Verification
- `python3 -m py_compile new-ui-evaluation/adapter.py scripts/kind-control-plane-smoke.py`
- `PYTHONPATH=new-ui-evaluation python3 -m unittest new-ui-evaluation/tests/test_adapter.py`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `docker build --no-cache --tag localhost/scion-ops-web-app:latest --file image-build/web-app/Dockerfile .`
- `task build:web-app`
- `SCION_OPS_WEB_PORT=19091 task web:hub` plus `/healthz` and `/api/snapshot` checks
- standalone `localhost/scion-ops-web-app:latest` container: `/healthz` 200, `/api/snapshot` reports port 8787, Docker health healthy

